### PR TITLE
fix(edge): expose console aliases in deploy smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,7 @@ jobs:
       - run: pnpm install --frozen-lockfile=false
       - run: pnpm provider:smoke-plan
       - run: CLAWROUTER_STRICT_CONFIG=0 pnpm cf:config
-      - run: pnpm exec wrangler deploy --dry-run --config .wrangler.generated.toml
+      - run: pnpm exec wrangler deploy --dry-run --outdir /tmp/clawrouter-worker-dry-run --config .wrangler.generated.toml
+        timeout-minutes: 5
+        env:
+          WRANGLER_SEND_METRICS: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - run: pnpm install --frozen-lockfile=false
       - run: pnpm provider:smoke-plan
       - run: CLAWROUTER_STRICT_CONFIG=0 pnpm cf:config
-      - run: pnpm exec wrangler deploy --dry-run --outdir /tmp/clawrouter-worker-dry-run --config .wrangler.generated.toml
-        timeout-minutes: 5
+      - run: timeout 300s pnpm exec wrangler deploy --dry-run --outdir /tmp/clawrouter-worker-dry-run --config .wrangler.generated.toml
+        timeout-minutes: 6
         env:
           WRANGLER_SEND_METRICS: "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - run: pnpm install --frozen-lockfile=false
       - run: pnpm provider:smoke-plan
       - run: CLAWROUTER_STRICT_CONFIG=0 pnpm cf:config
-      - run: timeout 300s pnpm exec wrangler deploy --dry-run --outdir /tmp/clawrouter-worker-dry-run --config .wrangler.generated.toml
-        timeout-minutes: 6
+      - run: timeout 900s pnpm exec wrangler deploy --dry-run --outdir /tmp/clawrouter-worker-dry-run --config .wrangler.generated.toml
+        timeout-minutes: 16
         env:
           WRANGLER_SEND_METRICS: "false"

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -360,8 +360,13 @@ const INTERFACE_HTML: &str = r#"<!doctype html>
 #[event(fetch)]
 async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     let url = req.url()?;
-    if req.method() == Method::Options && cors_enabled_path(url.path()) {
+    let request_path = url.path().to_string();
+    let api_path = canonical_api_path(&request_path);
+    if req.method() == Method::Options && cors_enabled_path(&api_path) {
         return cors_preflight();
+    }
+    if req.method() == Method::Get && request_path == "/" && accepts_html(req.headers())? {
+        return interface_shell();
     }
     if req.method() == Method::Get && matches!(url.path(), "/" | "/v1") {
         return service_index().and_then(with_cors);
@@ -383,21 +388,21 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return Response::from_json(&snapshot).and_then(with_cors);
     }
 
-    if req.method() == Method::Get && url.path() == "/v1/routes" {
+    if req.method() == Method::Get && api_path == "/v1/routes" {
         let snapshot = provider_snapshot()?;
         return Response::from_json(&route_catalog(&snapshot)).and_then(with_cors);
     }
 
-    if req.method() == Method::Get && url.path() == "/v1/me" {
+    if req.method() == Method::Get && api_path == "/v1/me" {
         return user_profile(req.headers(), &env).await.and_then(with_cors);
     }
 
-    if req.method() == Method::Get && url.path() == "/v1/usage" {
+    if req.method() == Method::Get && api_path == "/v1/usage" {
         return user_usage(req.headers(), &env).await.and_then(with_cors);
     }
 
-    if url.path().starts_with("/v1/admin/") {
-        return admin_api(req, env, url.path()).await.and_then(with_cors);
+    if api_path.starts_with("/v1/admin/") {
+        return admin_api(req, env, &api_path).await.and_then(with_cors);
     }
 
     if url.path() == "/v1/key/inspect" {
@@ -429,6 +434,7 @@ fn service_index() -> Result<Response> {
         "service": "clawrouter-edge",
         "runtime": "rust-wasm",
         "interface": {
+            "root": "/",
             "dashboard": "/dashboard",
             "admin": "/admin",
             "account": "/account"
@@ -444,6 +450,12 @@ fn service_index() -> Result<Response> {
             "adminUsers": "/v1/admin/users",
             "adminUsage": "/v1/admin/usage",
             "adminKeys": "/v1/admin/keys",
+            "apiAliases": {
+                "routes": ["/api/route", "/api/routes"],
+                "me": "/api/me",
+                "usage": "/api/usage",
+                "admin": "/api/admin/*"
+            },
             "openaiCompatible": [
                 "/v1/chat/completions",
                 "/v1/responses",
@@ -459,6 +471,23 @@ fn interface_path(path: &str) -> bool {
         path,
         "/dashboard" | "/admin" | "/account" | "/console" | "/routes"
     )
+}
+
+fn accepts_html(headers: &Headers) -> Result<bool> {
+    let accept = headers.get("accept")?.unwrap_or_default();
+    Ok(accept
+        .split(',')
+        .any(|value| value.trim().starts_with("text/html")))
+}
+
+fn canonical_api_path(path: &str) -> String {
+    match path {
+        "/api/route" | "/api/routes" => "/v1/routes".to_string(),
+        "/api/me" => "/v1/me".to_string(),
+        "/api/usage" => "/v1/usage".to_string(),
+        _ if path.starts_with("/api/admin/") => format!("/v1{}", path.trim_start_matches("/api")),
+        _ => path.to_string(),
+    }
 }
 
 fn interface_shell() -> Result<Response> {
@@ -3499,6 +3528,19 @@ mod tests {
         assert!(interface_path("/account"));
         assert!(interface_path("/routes"));
         assert!(!interface_path("/v1/admin/keys"));
+    }
+
+    #[test]
+    fn api_aliases_map_to_canonical_v1_routes() {
+        assert_eq!(canonical_api_path("/api/route"), "/v1/routes");
+        assert_eq!(canonical_api_path("/api/routes"), "/v1/routes");
+        assert_eq!(canonical_api_path("/api/me"), "/v1/me");
+        assert_eq!(canonical_api_path("/api/usage"), "/v1/usage");
+        assert_eq!(
+            canonical_api_path("/api/admin/overview"),
+            "/v1/admin/overview"
+        );
+        assert_eq!(canonical_api_path("/v1/providers"), "/v1/providers");
     }
 
     #[test]

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -9,10 +9,16 @@ const baseUrl = required(process.env.CLAWROUTER_BASE_URL, "CLAWROUTER_BASE_URL")
 const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 
 await expectOk(`${baseUrl}/v1/health`, "health");
+await expectHtml(`${baseUrl}/`, "root console");
+await expectHtml(`${baseUrl}/dashboard`, "dashboard console");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");
 if (!Array.isArray(providers.providers) || providers.providers.length < 20) {
   throw new Error("provider snapshot is unexpectedly small");
 }
+const routes = await expectOk(`${baseUrl}/v1/routes`, "route catalog");
+expectRouteCatalog(routes, "route catalog");
+const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alias");
+expectRouteCatalog(aliasedRoutes, "route catalog alias");
 const plan = buildProviderSmokePlan(providers);
 if (plan.targetCount !== plan.providerCount) {
   throw new Error(`provider smoke plan is incomplete: ${plan.targetCount}/${plan.providerCount}`);
@@ -45,6 +51,33 @@ async function expectOk(url, name) {
     throw new Error(`${name} failed with ${response.status}`);
   }
   return response.json();
+}
+
+async function expectHtml(url, name) {
+  const response = await fetch(url, { headers: { accept: "text/html" } });
+  if (!response.ok) {
+    throw new Error(`${name} failed with ${response.status}`);
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) {
+    throw new Error(`${name} returned ${contentType || "no content-type"}, expected text/html`);
+  }
+  const body = await response.text();
+  if (!body.includes("ClawRouter")) {
+    throw new Error(`${name} did not return the ClawRouter console`);
+  }
+}
+
+function expectRouteCatalog(catalog, name) {
+  if (!Array.isArray(catalog.openaiCompatible) || catalog.openaiCompatible.length === 0) {
+    throw new Error(`${name} is missing OpenAI-compatible routes`);
+  }
+  if (!Array.isArray(catalog.manifestProxy) || catalog.manifestProxy.length === 0) {
+    throw new Error(`${name} is missing manifest proxy routes`);
+  }
+  if (!catalog.manifestProxy.some((route) => route.route === "/v1/proxy/tavily/search")) {
+    throw new Error(`${name} is missing the Tavily manifest route`);
+  }
 }
 
 function required(value, name) {


### PR DESCRIPTION
Summary:
- Serve the embedded console from `/` when a browser requests HTML.
- Add `/api/route`, `/api/routes`, `/api/me`, `/api/usage`, and `/api/admin/*` aliases over the canonical `/v1/*` backend.
- Extend deployed smoke coverage so a deploy must prove the console and route catalog are live.

Verification:
- `cargo fmt --check`
- `git diff --check`
- `node --check scripts/smoke-deployed.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `CLAWROUTER_BASE_URL=https://clawrouter.openclaw.ai node scripts/smoke-deployed.mjs` fails on current production because `/` returns JSON instead of the console, confirming the deployed worker is older/mismatched.

Deployment status:
- Current production does not include the interface backend from main: `/admin`, `/dashboard`, `/v1/routes`, `/v1/me`, and `/v1/usage` still return 404.
- GitHub deploy workflow cannot deploy until `CLOUDFLARE_API_TOKEN` exists as a repo secret.

Remaining risk:
- Local Rust tests could not complete on the Mac because the filesystem ran out of space during dependency compilation. CI should provide the Rust proof for this branch.
