### PR TITLE
fix(edge): provision path-scoped Access console

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ It checks Wrangler auth, required GitHub Actions secret names, local deploy env,
 provider binding coverage, and the all-provider smoke plan without printing
 secret values.
 
+The browser console is meant to sit behind Cloudflare Access. Provision that
+edge gate with:
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=... \
+CLOUDFLARE_API_TOKEN=... \
+CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai \
+CLAWROUTER_ACCESS_ADMIN_EMAILS=you@example.com \
+pnpm cf:access
+```
+
+Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
+`CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
+`/dashboard` path, while public `/v1` catalog and proxy routes stay normal. A
+ClawRouter `access_session_required` JSON body on `/dashboard` means the Access
+app is not in front of the console path yet.
+
 ## Edge Proxy
 
 The Worker currently exposes:

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -20,6 +20,7 @@ const CORS_ALLOW_ORIGIN: &str = "*";
 const CORS_ALLOW_METHODS: &str = "GET,POST,PUT,OPTIONS";
 const CORS_ALLOW_HEADERS: &str = "authorization,content-type,x-request-id";
 const CORS_MAX_AGE: &str = "600";
+const ROOT_REDIRECT_PATH: &str = "/dashboard";
 type HmacSha256 = Hmac<Sha256>;
 const INTERFACE_HTML: &str = r##"<!doctype html>
 <html lang="en">
@@ -760,7 +761,7 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return cors_preflight();
     }
     if req.method() == Method::Get && request_path == "/" {
-        return protected_interface_shell(req.headers(), &env).await;
+        return redirect_to(ROOT_REDIRECT_PATH);
     }
     if req.method() == Method::Get && url.path() == "/v1" {
         return service_index().and_then(with_cors);
@@ -901,6 +902,15 @@ async fn protected_interface_shell(headers: &Headers, env: &Env) -> Result<Respo
 
 fn interface_shell() -> Result<Response> {
     let mut response = Response::from_html(INTERFACE_HTML)?;
+    response
+        .headers_mut()
+        .set("cache-control", "no-store, max-age=0")?;
+    Ok(response)
+}
+
+fn redirect_to(location: &str) -> Result<Response> {
+    let mut response = Response::empty()?.with_status(302);
+    response.headers_mut().set("location", location)?;
     response
         .headers_mut()
         .set("cache-control", "no-store, max-age=0")?;
@@ -4547,6 +4557,11 @@ mod tests {
         assert!(interface_path("/account"));
         assert!(interface_path("/routes"));
         assert!(!interface_path("/v1/admin/keys"));
+    }
+
+    #[test]
+    fn root_redirect_points_to_dashboard() {
+        assert_eq!(ROOT_REDIRECT_PATH, "/dashboard");
     }
 
     #[test]

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -21,6 +21,43 @@ Authenticate Wrangler first, then create the runtime resources:
 pnpm cf:provision
 ```
 
+Protect the browser console with Cloudflare Access before treating the custom
+domain as ready:
+
+```sh
+export CLOUDFLARE_ACCOUNT_ID=...
+export CLOUDFLARE_API_TOKEN=... # must be able to manage Zero Trust Access apps/policies
+export CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai
+export CLAWROUTER_ACCESS_ADMIN_EMAILS=you@example.com
+pnpm cf:access
+```
+
+`pnpm cf:access` creates or updates a self-hosted Access application for the
+console and session/admin paths on `clawrouter.openclaw.ai`, installs an allow
+policy, and prints the
+`CLAWROUTER_ACCESS_TEAM_DOMAIN` and `CLAWROUTER_ACCESS_AUD` values that the
+Worker uses to verify Access JWTs. Add `-- --dry-run` to inspect the plan
+without calling Cloudflare, or `-- --set-github-vars` to write the non-secret
+GitHub Actions variables after provisioning.
+`CLAWROUTER_ACCESS_ALLOWED_*` controls who can pass Cloudflare Access;
+`CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
+`CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
+(`non_identity`) policy for automation. The default path-scoped Access
+destinations are
+`/dashboard`, `/playground`, `/admin`, `/account`, `/routes`, `/console`,
+`/v1/session`, `/v1/me`, `/v1/usage`, `/v1/admin/*`, and matching `/api/*`
+aliases; override them with `CLAWROUTER_ACCESS_PATHS` only if the API contract
+changes.
+Set `CLAWROUTER_ACCESS_IDP_IDS` to one identity provider to enable automatic
+redirect to that provider; otherwise Access shows its normal login selector.
+When `-- --set-github-vars` is used, managed admin variables are deleted from
+GitHub if the corresponding local admin list is empty.
+
+For safety, provisioning refuses to report success when the target Access
+application already has extra policies, because a stale broad policy could keep
+granting access. Remove the extra policies first, or set
+`CLAWROUTER_ACCESS_KEEP_EXTRA_POLICIES=1` when those policies are intentional.
+
 Set these GitHub Actions secrets for workflow deploys:
 
 ```text
@@ -137,17 +174,25 @@ proxy smoke key with access to every selected provider.
 
 ## Cloudflare Access Console
 
-Protect the Worker route with a Cloudflare Access application, then set
+Protect the Worker route with a Cloudflare Access application. Use
+`pnpm cf:access` for the standard `clawrouter.openclaw.ai` route, then set
 `CLAWROUTER_ACCESS_TEAM_DOMAIN` to the team domain and `CLAWROUTER_ACCESS_AUD`
-to the Access application audience tag. ClawRouter verifies the
-`cf-access-jwt-assertion` signature against the team certs endpoint before it
-trusts the email or role.
+to the Access application audience tag before deploying. ClawRouter verifies
+the `cf-access-jwt-assertion` signature against the team certs endpoint before
+it trusts the email or role.
 
-The browser console is fail-closed in the Worker. `/`, `/dashboard`,
-`/playground`, `/admin`, `/account`, `/routes`, and `/console` only render after
-a verified Cloudflare Access session. Public and client-facing surfaces stay
-under the API paths such as `/v1`, `/v1/health`, `/v1/providers`, `/v1/routes`,
-and proxy endpoints.
+The browser console is fail-closed in the Worker. `/` redirects to
+`/dashboard`; `/dashboard`, `/playground`, `/admin`, `/account`, `/routes`, and
+`/console` only render after a verified Cloudflare Access session. Public and
+client-facing surfaces stay under the API paths such as `/v1`, `/v1/health`,
+`/v1/providers`, `/v1/routes`, and proxy endpoints.
+
+After Access is configured, an unauthenticated request to `/` should be handled
+by the Worker with a redirect to `/dashboard`, and `/dashboard` should be
+handled by Cloudflare Access before it reaches the Worker. A raw `401` JSON
+response with `access_session_required` on `/dashboard` means the Access
+application is not protecting the console path or the Worker was deployed
+without the Access team/AUD vars.
 
 Access users are `user` by default. Admins are resolved from
 `access/users/<email>` in `POLICY_KV`, then from `CLAWROUTER_ACCESS_ADMIN_EMAILS`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cf:doctor": "node scripts/deploy-doctor.mjs",
     "cf:config": "node scripts/render-wrangler-config.mjs",
     "cf:provision": "node scripts/provision-cloudflare.mjs",
+    "cf:access": "node scripts/provision-access.mjs",
     "cf:deploy": "pnpm cf:config && wrangler deploy --config .wrangler.generated.toml",
     "cf:key:put": "node scripts/key-put.mjs",
     "cf:key:revoke": "node scripts/key-revoke.mjs",

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -1,0 +1,436 @@
+import { spawnSync } from "node:child_process";
+
+const args = parseArgs(process.argv.slice(2));
+
+const accountId = requiredEnv("CLOUDFLARE_ACCOUNT_ID");
+const token = process.env.CLOUDFLARE_API_TOKEN?.trim();
+const dryRun = Boolean(args["dry-run"]);
+const host =
+  process.env.CLAWROUTER_ACCESS_DOMAIN?.trim() ||
+  hostFromBaseUrl(process.env.CLAWROUTER_BASE_URL) ||
+  "clawrouter.openclaw.ai";
+const appDomains = accessDestinations(host);
+const appName = process.env.CLAWROUTER_ACCESS_APP_NAME?.trim() || "ClawRouter Console";
+const policyName =
+  process.env.CLAWROUTER_ACCESS_POLICY_NAME?.trim() || "ClawRouter Console Users";
+const servicePolicyName =
+  process.env.CLAWROUTER_ACCESS_SERVICE_POLICY_NAME?.trim() ||
+  "ClawRouter Console Service Tokens";
+const sessionDuration =
+  process.env.CLAWROUTER_ACCESS_SESSION_DURATION?.trim() || "24h";
+const adminEmails = csv(process.env.CLAWROUTER_ACCESS_ADMIN_EMAILS);
+const adminDomains = csv(process.env.CLAWROUTER_ACCESS_ADMIN_DOMAINS);
+const accessAllowedEmails = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_EMAILS);
+const accessAllowedDomains = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_DOMAINS);
+const allowedEmails = accessAllowedEmails.length > 0 ? accessAllowedEmails : adminEmails;
+const allowedDomains = accessAllowedDomains.length > 0 ? accessAllowedDomains : adminDomains;
+const serviceTokenIds = csv(process.env.CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS);
+const allowedIdps = csv(process.env.CLAWROUTER_ACCESS_IDP_IDS);
+const defaultTenant =
+  process.env.CLAWROUTER_ACCESS_DEFAULT_TENANT?.trim() || "default";
+const requestedAutoRedirect = process.env.CLAWROUTER_ACCESS_AUTO_REDIRECT?.trim();
+if (requestedAutoRedirect === "1" && allowedIdps.length !== 1) {
+  throw new Error(
+    "CLAWROUTER_ACCESS_AUTO_REDIRECT=1 requires exactly one CLAWROUTER_ACCESS_IDP_IDS value",
+  );
+}
+const autoRedirect =
+  requestedAutoRedirect === "1" ||
+  (requestedAutoRedirect !== "0" && allowedIdps.length === 1);
+const repo = process.env.CLAWROUTER_GITHUB_REPO?.trim() || "openclaw/clawrouter";
+const setGitHubVars = Boolean(args["set-github-vars"]);
+const keepExtraPolicies = process.env.CLAWROUTER_ACCESS_KEEP_EXTRA_POLICIES === "1";
+
+const humanInclude = buildHumanPolicyInclude({
+  allowedEmails,
+  allowedDomains,
+  allowEveryone: process.env.CLAWROUTER_ACCESS_ALLOW_EVERYONE === "1",
+});
+const serviceInclude = serviceTokenIds.map((tokenId) => ({
+  service_token: { token_id: tokenId },
+}));
+
+if (humanInclude.length === 0 && serviceInclude.length === 0) {
+  throw new Error(
+    [
+      "refusing to create an Access policy with no include rules",
+      "set CLAWROUTER_ACCESS_ALLOWED_EMAILS, CLAWROUTER_ACCESS_ALLOWED_DOMAINS,",
+      "CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS, or CLAWROUTER_ACCESS_ALLOW_EVERYONE=1",
+    ].join(" "),
+  );
+}
+
+if (!dryRun && !token) {
+  throw new Error("CLOUDFLARE_API_TOKEN is required unless --dry-run is set");
+}
+
+const appPayload = {
+  name: appName,
+  type: "self_hosted",
+  domain: appDomains[0],
+  destinations: appDomains.map((uri) => ({ type: "public", uri })),
+  session_duration: sessionDuration,
+  app_launcher_visible: false,
+  auto_redirect_to_identity: autoRedirect,
+};
+if (allowedIdps.length > 0) {
+  appPayload.allowed_idps = allowedIdps;
+}
+
+const policyPayloads = [
+  {
+    name: policyName,
+    decision: "allow",
+    precedence: 1,
+    include: humanInclude,
+  },
+  {
+    name: servicePolicyName,
+    decision: "non_identity",
+    precedence: 2,
+    include: serviceInclude,
+  },
+];
+
+if (dryRun) {
+  printPlan({
+    app: appPayload,
+    policies: policyPayloads,
+    teamDomain: process.env.CLAWROUTER_ACCESS_TEAM_DOMAIN?.trim() || null,
+    aud: process.env.CLAWROUTER_ACCESS_AUD?.trim() || null,
+    created: false,
+    updated: false,
+  });
+  process.exit(0);
+}
+
+const organization = await getAccessOrganization();
+const teamDomain =
+  process.env.CLAWROUTER_ACCESS_TEAM_DOMAIN?.trim() ||
+  accessTeamDomain(organization);
+
+if (!teamDomain) {
+  throw new Error(
+    "could not resolve Cloudflare Access team domain; set CLAWROUTER_ACCESS_TEAM_DOMAIN",
+  );
+}
+
+let created = false;
+let updated = false;
+let app = await findAccessApplication(appName, host, appDomains);
+let policies = [];
+if (app) {
+  policies = await listAccessPolicies(app.id);
+  guardExtraPolicies(policies, policyPayloads);
+  app = await request(
+    "PUT",
+    `/accounts/${accountId}/access/apps/${app.id}`,
+    { ...appPayload, id: app.id },
+  );
+  updated = true;
+} else {
+  app = await request("POST", `/accounts/${accountId}/access/apps`, appPayload);
+  created = true;
+}
+
+for (const policyPayload of policyPayloads) {
+  const existingPolicy = policies.find((policy) => policy.name === policyPayload.name);
+  if (policyPayload.include.length === 0) {
+    if (existingPolicy) {
+      await request(
+        "DELETE",
+        `/accounts/${accountId}/access/apps/${app.id}/policies/${existingPolicy.id}`,
+      );
+      updated = true;
+    }
+    continue;
+  }
+  if (existingPolicy) {
+    await request(
+      "PUT",
+      `/accounts/${accountId}/access/apps/${app.id}/policies/${existingPolicy.id}`,
+      { ...policyPayload, id: existingPolicy.id },
+    );
+    updated = true;
+  } else {
+    await request(
+      "POST",
+      `/accounts/${accountId}/access/apps/${app.id}/policies`,
+      policyPayload,
+    );
+    created = true;
+  }
+}
+
+const aud = accessAudience(app);
+if (!aud) {
+  throw new Error(
+    "Cloudflare created the Access application but did not return an audience tag",
+  );
+}
+
+if (setGitHubVars) {
+  syncGitHubVariable(repo, "CLAWROUTER_ACCESS_TEAM_DOMAIN", teamDomain);
+  syncGitHubVariable(repo, "CLAWROUTER_ACCESS_AUD", aud);
+  syncGitHubVariable(repo, "CLAWROUTER_ACCESS_DEFAULT_TENANT", defaultTenant);
+  syncGitHubVariable(repo, "CLAWROUTER_ACCESS_ADMIN_EMAILS", adminEmails.join(","));
+  syncGitHubVariable(repo, "CLAWROUTER_ACCESS_ADMIN_DOMAINS", adminDomains.join(","));
+}
+
+printPlan({
+  app: { ...appPayload, id: app.id },
+  policies: policyPayloads,
+  teamDomain,
+  aud,
+  created,
+  updated,
+});
+
+async function getAccessOrganization() {
+  try {
+    return await request("GET", `/accounts/${accountId}/access/organizations`);
+  } catch (error) {
+    if (process.env.CLAWROUTER_ACCESS_TEAM_DOMAIN) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function findAccessApplication(targetName, targetHost, targetDomains) {
+  const apps = asArray(await request("GET", `/accounts/${accountId}/access/apps?per_page=100`));
+  return (
+    apps.find((app) => app.name === targetName) ||
+    apps.find((app) => destinationUris(app).some((uri) => targetDomains.includes(uri))) ||
+    apps.find((app) => targetDomains.includes(app.domain)) ||
+    apps.find((app) => app.domain === targetHost) ||
+    null
+  );
+}
+
+async function listAccessPolicies(appId) {
+  return asArray(
+    await request("GET", `/accounts/${accountId}/access/apps/${appId}/policies?per_page=100`),
+  );
+}
+
+function guardExtraPolicies(policies, managedPolicies) {
+  const managedPolicyNames = new Set(managedPolicies.map((policy) => policy.name));
+  const extraPolicies = policies.filter((policy) => !managedPolicyNames.has(policy.name));
+  if (extraPolicies.length === 0 || keepExtraPolicies) {
+    return;
+  }
+  throw new Error(
+    [
+      "Access application has unmanaged policies:",
+      extraPolicies.map((policy) => `${policy.name}(${policy.decision || "unknown"})`).join(", "),
+      "Set CLAWROUTER_ACCESS_KEEP_EXTRA_POLICIES=1 to keep them intentionally,",
+      "or remove them before rerunning so provisioning converges to the requested allowlist.",
+    ].join(" "),
+  );
+}
+
+async function request(method, path, body) {
+  const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`Cloudflare API returned non-JSON ${response.status}: ${text}`);
+  }
+  if (!response.ok || json.success === false) {
+    const details = asArray(json.errors)
+      .map((error) => `${error.code ?? "error"} ${error.message ?? ""}`.trim())
+      .filter(Boolean)
+      .join("; ");
+    const hint =
+      response.status === 403 && path.includes("/access/")
+        ? " Provide a Cloudflare API token or session with Zero Trust Access application and policy permissions."
+        : "";
+    throw new Error(
+      `Cloudflare API ${method} ${path} failed (${response.status})${details ? `: ${details}` : ""}.${hint}`,
+    );
+  }
+  return json.result;
+}
+
+function buildHumanPolicyInclude({
+  allowedEmails: emails,
+  allowedDomains: domains,
+  allowEveryone,
+}) {
+  const rules = [];
+  for (const email of emails) {
+    rules.push({ email: { email } });
+  }
+  for (const domainValue of domains) {
+    rules.push({ email_domain: { domain: domainValue } });
+  }
+  if (allowEveryone) {
+    rules.push({ everyone: {} });
+  }
+  return rules;
+}
+
+function accessTeamDomain(organization) {
+  const org = Array.isArray(organization) ? organization[0] : organization;
+  const raw =
+    org?.auth_domain ||
+    org?.team_domain ||
+    org?.login_domain ||
+    org?.name ||
+    "";
+  const value = String(raw).trim().replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  if (!value) {
+    return "";
+  }
+  return value.includes(".") ? value : `${value}.cloudflareaccess.com`;
+}
+
+function accessAudience(app) {
+  return app?.aud || app?.aud_tag || app?.audience_tag || "";
+}
+
+function hostFromBaseUrl(value) {
+  if (!value) {
+    return "";
+  }
+  try {
+    return new URL(value).host;
+  } catch {
+    return "";
+  }
+}
+
+function accessDestinations(targetHost) {
+  return (csv(process.env.CLAWROUTER_ACCESS_PATHS).length > 0
+    ? csv(process.env.CLAWROUTER_ACCESS_PATHS)
+    : defaultAccessPaths()
+  ).map((path) => `${targetHost}${normalizeAccessPath(path)}`);
+}
+
+function destinationUris(app) {
+  const destinations = asArray(app?.destinations)
+    .map((destination) => destination?.uri)
+    .filter(Boolean);
+  return destinations.length > 0 ? destinations : asArray(app?.self_hosted_domains);
+}
+
+function defaultAccessPaths() {
+  return [
+    "/dashboard",
+    "/playground",
+    "/admin",
+    "/account",
+    "/routes",
+    "/console",
+    "/v1/session",
+    "/v1/me",
+    "/v1/usage",
+    "/v1/admin/*",
+    "/api/session",
+    "/api/me",
+    "/api/usage",
+    "/api/admin/*",
+  ];
+}
+
+function normalizeAccessPath(value) {
+  const path = value.trim();
+  if (!path || path === "/") {
+    throw new Error("do not protect bare / with Cloudflare Access; root redirects to /dashboard");
+  }
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function csv(value) {
+  return (value || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (Array.isArray(value?.result)) {
+    return value.result;
+  }
+  return [];
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (const arg of argv) {
+    if (arg === "--") {
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      parsed[arg.slice(2)] = true;
+    }
+  }
+  return parsed;
+}
+
+function printPlan({ app, policies, teamDomain, aud, created, updated }) {
+  console.log("Cloudflare Access plan:");
+  console.log(`host=${host}`);
+  console.log(`destinations=${app.destinations.map((destination) => destination.uri).join(",")}`);
+  console.log(`app=${app.name}${app.id ? ` (${app.id})` : ""}`);
+  for (const policy of policies.filter((entry) => entry.include.length > 0)) {
+    console.log(`policy=${policy.name} decision=${policy.decision}`);
+  }
+  console.log(`created=${created}`);
+  console.log(`updated=${updated}`);
+  console.log(`teamDomain=${teamDomain || "<pending>"}`);
+  console.log(`aud=${aud || "<pending>"}`);
+  console.log("");
+  console.log("Deploy vars:");
+  console.log(`CLAWROUTER_ACCESS_TEAM_DOMAIN=${teamDomain || "<team>.cloudflareaccess.com"}`);
+  console.log(`CLAWROUTER_ACCESS_AUD=${aud || "<access app audience tag>"}`);
+  console.log(`CLAWROUTER_ACCESS_DEFAULT_TENANT=${defaultTenant}`);
+  if (adminEmails.length > 0) {
+    console.log(`CLAWROUTER_ACCESS_ADMIN_EMAILS=${adminEmails.join(",")}`);
+  }
+  if (adminDomains.length > 0) {
+    console.log(`CLAWROUTER_ACCESS_ADMIN_DOMAINS=${adminDomains.join(",")}`);
+  }
+  console.log("");
+  console.log("Expected live root check after redeploy:");
+  console.log(`curl -sS -D - -o /dev/null https://${host}/`);
+}
+
+function syncGitHubVariable(repoName, name, value) {
+  const cli = process.env.CLAWROUTER_GITHUB_CLI || "ghx";
+  const command = value
+    ? ["variable", "set", name, "--repo", repoName, "--body", value]
+    : ["variable", "delete", name, "--repo", repoName];
+  const result = spawnSync(cli, command, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const output = result.stderr || result.stdout || `${cli} ${command.join(" ")} failed`;
+    if (!value && /not found|not exist|could not resolve/i.test(output)) {
+      return;
+    }
+    throw new Error(output);
+  }
+}

--- a/scripts/provision-cloudflare.mjs
+++ b/scripts/provision-cloudflare.mjs
@@ -26,6 +26,9 @@ console.log("Set these as GitHub Actions secrets before workflow deploy:");
 console.log("CLOUDFLARE_API_TOKEN=<redacted>");
 console.log("CLOUDFLARE_ACCOUNT_ID=<account id>");
 console.log(`CLAWROUTER_POLICY_KV_ID=${parsed.id}`);
+console.log("");
+console.log("Then provision the Cloudflare Access gate for the browser console:");
+console.log("pnpm cf:access");
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {


### PR DESCRIPTION
Summary:
- redirect `/` to `/dashboard` so root routes into the Access-protected console path
- add `pnpm cf:access` to provision path-scoped Cloudflare Access destinations for console/session/admin routes without blocking public `/v1` provider/proxy APIs
- document Access allow/admin role vars, service-token policy handling, and the expected live root/dashboard checks

Verification:
- `node --check scripts/provision-access.mjs`
- `CLOUDFLARE_ACCOUNT_ID=... CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai CLAWROUTER_ACCESS_ADMIN_EMAILS=admin@example.com pnpm cf:access -- --dry-run`
- `cargo fmt --check`
- `cargo test -p clawrouter-edge`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Deployment status:
- not deployed yet: current Wrangler OAuth token still gets `403 Authentication error` on Cloudflare Access app listing; needs a Zero Trust-capable Cloudflare token/session before `pnpm cf:access` can create/update the Access app.