### PR TITLE
test(deploy): assert console access gate in smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
 `/dashboard` path, while public `/v1` catalog and proxy routes stay normal. A
 ClawRouter `access_session_required` JSON body on `/dashboard` means the Access
-app is not in front of the console path yet.
+app is not in front of the console path yet, and `pnpm cf:smoke` treats that as
+a failed deployment smoke.
 
 ## Edge Proxy
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -149,8 +149,10 @@ pnpm cf:deploy
 
 ## Smoke
 
-The deployed smoke checks health, provider snapshot size, key inspection when a
-smoke key is present, and that every provider has an executable smoke target:
+The deployed smoke checks health, root-to-dashboard redirect behavior, that the
+dashboard and session paths are gated before the Worker can return console HTML
+or fallback JSON, provider snapshot size, key inspection when a smoke key is
+present, and that every provider has an executable smoke target:
 
 ```sh
 export CLAWROUTER_BASE_URL=https://...

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -9,8 +9,8 @@ const baseUrl = required(process.env.CLAWROUTER_BASE_URL, "CLAWROUTER_BASE_URL")
 const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 
 await expectOk(`${baseUrl}/v1/health`, "health");
-await expectHtml(`${baseUrl}/`, "root console");
-await expectHtml(`${baseUrl}/dashboard`, "dashboard console");
+await expectRedirect(`${baseUrl}/`, "root redirect", "/dashboard");
+await expectAccessGate(`${baseUrl}/dashboard`, "dashboard access gate");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");
 if (!Array.isArray(providers.providers) || providers.providers.length < 20) {
   throw new Error("provider snapshot is unexpectedly small");
@@ -19,10 +19,7 @@ const routes = await expectOk(`${baseUrl}/v1/routes`, "route catalog");
 expectRouteCatalog(routes, "route catalog");
 const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alias");
 expectRouteCatalog(aliasedRoutes, "route catalog alias");
-const session = await expectOk(`${baseUrl}/v1/session`, "session");
-if (typeof session.authenticated !== "boolean" || typeof session.role !== "string") {
-  throw new Error("session response is missing authenticated/role fields");
-}
+await expectAccessGate(`${baseUrl}/v1/session`, "session access gate");
 const plan = buildProviderSmokePlan(providers);
 if (plan.targetCount !== plan.providerCount) {
   throw new Error(`provider smoke plan is incomplete: ${plan.targetCount}/${plan.providerCount}`);
@@ -57,19 +54,45 @@ async function expectOk(url, name) {
   return response.json();
 }
 
-async function expectHtml(url, name) {
-  const response = await fetch(url, { headers: { accept: "text/html" } });
-  if (!response.ok) {
-    throw new Error(`${name} failed with ${response.status}`);
+async function expectRedirect(url, name, location) {
+  const response = await fetch(url, { redirect: "manual" });
+  if (response.status < 300 || response.status >= 400) {
+    throw new Error(`${name} returned ${response.status}, expected redirect`);
   }
+  const actual = response.headers.get("location") ?? "";
+  if (actual !== location) {
+    throw new Error(`${name} redirected to ${actual || "<missing>"}, expected ${location}`);
+  }
+}
+
+async function expectAccessGate(url, name) {
+  const response = await fetch(url, {
+    headers: { accept: "text/html,application/json" },
+    redirect: "manual",
+  });
   const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.includes("text/html")) {
-    throw new Error(`${name} returned ${contentType || "no content-type"}, expected text/html`);
-  }
   const body = await response.text();
-  if (!body.includes("ClawRouter")) {
-    throw new Error(`${name} did not return the ClawRouter console`);
+  if (contentType.includes("application/json")) {
+    let json = null;
+    try {
+      json = JSON.parse(body);
+    } catch {}
+    if (json?.error?.code === "access_session_required") {
+      throw new Error(
+        `${name} reached ClawRouter's fallback 401; Cloudflare Access is not protecting the console path`,
+      );
+    }
   }
+  if (response.ok && contentType.includes("text/html") && body.includes("ClawRouter")) {
+    throw new Error(`${name} returned the ClawRouter console without Cloudflare Access`);
+  }
+  if (response.status >= 300 && response.status < 400) {
+    return;
+  }
+  if ((response.status === 401 || response.status === 403) && !body.includes("ClawRouter")) {
+    return;
+  }
+  throw new Error(`${name} returned ${response.status}, expected Cloudflare Access challenge`);
 }
 
 function expectRouteCatalog(catalog, name) {


### PR DESCRIPTION
Summary
- update deployed smoke to expect / -> /dashboard redirect instead of public console HTML
- make smoke fail when /dashboard or /v1/session reaches ClawRouter fallback instead of Cloudflare Access
- document that cf:smoke now proves the console/session gate is in front

Verification
- node --check scripts/smoke-deployed.mjs
- git diff --check
- CLOUDFLARE_ACCOUNT_ID=91b59577e757131d68d55a471fe32aca CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai pnpm cf:access -- --dry-run
- CLAWROUTER_BASE_URL=https://clawrouter.openclaw.ai pnpm cf:smoke fails as expected: dashboard access gate reached ClawRouter fallback 401
- local harness simulating Cloudflare Access redirects for /dashboard and /v1/session passes pnpm cf:smoke
- .agents/skills/autoreview/scripts/autoreview --mode local: clean

Deployment Status
- not deployed yet; merge then deploy main after checks pass

Remaining Risk
- live console remains blocked on provisioning a Cloudflare Access app with a token/session that can manage Zero Trust Access apps and policies