### PR TITLE
ci(deploy): add access provisioning dispatch path

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -17,6 +17,41 @@ on:
         required: false
         default: ""
         type: string
+      provision_access:
+        description: "Provision/update the Cloudflare Access console app before deploy"
+        required: false
+        default: false
+        type: boolean
+      access_domain:
+        description: "Hostname for the Cloudflare Access console app"
+        required: false
+        default: "clawrouter.openclaw.ai"
+        type: string
+      access_allowed_emails:
+        description: "Comma-separated emails allowed through Cloudflare Access"
+        required: false
+        default: ""
+        type: string
+      access_allowed_domains:
+        description: "Comma-separated email domains allowed through Cloudflare Access"
+        required: false
+        default: "openclaw.ai"
+        type: string
+      access_admin_emails:
+        description: "Comma-separated emails treated as ClawRouter admins"
+        required: false
+        default: ""
+        type: string
+      access_admin_domains:
+        description: "Comma-separated email domains treated as ClawRouter admins"
+        required: false
+        default: ""
+        type: string
+      access_idp_ids:
+        description: "Optional comma-separated Cloudflare Access identity provider ids"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   deploy:
@@ -34,6 +69,9 @@ jobs:
       CLAWROUTER_ACCESS_ADMIN_EMAILS: ${{ vars.CLAWROUTER_ACCESS_ADMIN_EMAILS }}
       CLAWROUTER_ACCESS_ADMIN_DOMAINS: ${{ vars.CLAWROUTER_ACCESS_ADMIN_DOMAINS }}
       CLAWROUTER_ACCESS_DEFAULT_TENANT: ${{ vars.CLAWROUTER_ACCESS_DEFAULT_TENANT }}
+      CLAWROUTER_ACCESS_ALLOWED_EMAILS: ${{ inputs.access_allowed_emails }}
+      CLAWROUTER_ACCESS_ALLOWED_DOMAINS: ${{ inputs.access_allowed_domains }}
+      CLAWROUTER_ACCESS_IDP_IDS: ${{ inputs.access_idp_ids }}
       CLAWROUTER_BASE_URL: ${{ inputs.worker_url }}
       CLAWROUTER_SMOKE_KEY: ${{ secrets.CLAWROUTER_SMOKE_KEY }}
       CLAWROUTER_SMOKE_OPENAI: ${{ inputs.smoke_openai && '1' || '0' }}
@@ -54,6 +92,13 @@ jobs:
       - run: cargo test --workspace
       - run: pnpm --dir admin check
       - run: pnpm --dir admin build
+      - if: ${{ inputs.provision_access }}
+        env:
+          CLAWROUTER_ACCESS_DOMAIN: ${{ inputs.access_domain }}
+          CLAWROUTER_BASE_URL: ""
+          CLAWROUTER_ACCESS_ADMIN_EMAILS: ${{ inputs.access_admin_emails || vars.CLAWROUTER_ACCESS_ADMIN_EMAILS }}
+          CLAWROUTER_ACCESS_ADMIN_DOMAINS: ${{ inputs.access_admin_domains || vars.CLAWROUTER_ACCESS_ADMIN_DOMAINS }}
+        run: pnpm cf:access -- --write-github-env
       - run: pnpm cf:config
       - run: pnpm exec wrangler deploy --config .wrangler.generated.toml
       - if: ${{ inputs.worker_url != '' }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ ClawRouter `access_session_required` JSON body on `/dashboard` means the Access
 app is not in front of the console path yet, and `pnpm cf:smoke` treats that as
 a failed deployment smoke.
 
+The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
+`provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
+Zero Trust Access apps and policies. Keep `access_domain` set to the console
+hostname; `worker_url` is only the post-deploy smoke-test target.
+
 ## Edge Proxy
 
 The Worker currently exposes:

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -38,7 +38,9 @@ policy, and prints the
 `CLAWROUTER_ACCESS_TEAM_DOMAIN` and `CLAWROUTER_ACCESS_AUD` values that the
 Worker uses to verify Access JWTs. Add `-- --dry-run` to inspect the plan
 without calling Cloudflare, or `-- --set-github-vars` to write the non-secret
-GitHub Actions variables after provisioning.
+GitHub Actions variables after provisioning. In GitHub Actions,
+`-- --write-github-env` writes those same values into `GITHUB_ENV` so the
+current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_ALLOWED_*` controls who can pass Cloudflare Access;
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
@@ -80,6 +82,15 @@ CLAWROUTER_ACCESS_ADMIN_EMAILS        # comma-separated admin emails
 CLAWROUTER_ACCESS_ADMIN_DOMAINS       # optional comma-separated admin domains
 CLAWROUTER_ACCESS_DEFAULT_TENANT      # optional, defaults to default
 ```
+
+The `Deploy Cloudflare` workflow can provision Access and deploy in one run
+when `CLOUDFLARE_API_TOKEN` has Zero Trust Access application/policy
+permissions. Dispatch it with `provision_access=true`, set the allowlist inputs
+such as `access_allowed_domains=openclaw.ai`, set `access_domain` if the console
+host is not `clawrouter.openclaw.ai`, and optionally set `access_admin_emails`
+or `access_admin_domains`. The workflow runs
+`pnpm cf:access -- --write-github-env` before rendering the Wrangler config, so
+the newly created Access audience tag is included in the deployed Worker.
 
 Check the deploy surface without printing secret values:
 

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -39,6 +41,7 @@ const autoRedirect =
   (requestedAutoRedirect !== "0" && allowedIdps.length === 1);
 const repo = process.env.CLAWROUTER_GITHUB_REPO?.trim() || "openclaw/clawrouter";
 const setGitHubVars = Boolean(args["set-github-vars"]);
+const writeGitHubEnv = Boolean(args["write-github-env"]);
 const keepExtraPolicies = process.env.CLAWROUTER_ACCESS_KEEP_EXTRA_POLICIES === "1";
 
 const humanInclude = buildHumanPolicyInclude({
@@ -175,6 +178,16 @@ if (setGitHubVars) {
   syncGitHubVariable(repo, "CLAWROUTER_ACCESS_DEFAULT_TENANT", defaultTenant);
   syncGitHubVariable(repo, "CLAWROUTER_ACCESS_ADMIN_EMAILS", adminEmails.join(","));
   syncGitHubVariable(repo, "CLAWROUTER_ACCESS_ADMIN_DOMAINS", adminDomains.join(","));
+}
+
+if (writeGitHubEnv) {
+  writeGitHubEnvironment({
+    CLAWROUTER_ACCESS_TEAM_DOMAIN: teamDomain,
+    CLAWROUTER_ACCESS_AUD: aud,
+    CLAWROUTER_ACCESS_DEFAULT_TENANT: defaultTenant,
+    CLAWROUTER_ACCESS_ADMIN_EMAILS: adminEmails.join(","),
+    CLAWROUTER_ACCESS_ADMIN_DOMAINS: adminDomains.join(","),
+  });
 }
 
 printPlan({
@@ -436,4 +449,27 @@ function syncGitHubVariable(repoName, name, value) {
     }
     throw new Error(output);
   }
+}
+
+function writeGitHubEnvironment(values) {
+  const file = process.env.GITHUB_ENV;
+  if (!file) {
+    throw new Error("--write-github-env requires GITHUB_ENV");
+  }
+  const lines = [];
+  for (const [name, value] of Object.entries(values)) {
+    const delimiter = uniqueGitHubEnvDelimiter(value || "");
+    lines.push(`${name}<<${delimiter}`);
+    lines.push(value || "");
+    lines.push(delimiter);
+  }
+  appendFileSync(file, `${lines.join("\n")}\n`);
+}
+
+function uniqueGitHubEnvDelimiter(value) {
+  let delimiter = "";
+  do {
+    delimiter = `CLAWROUTER_ENV_${randomUUID().replaceAll("-", "_")}`;
+  } while (value.includes(delimiter));
+  return delimiter;
 }


### PR DESCRIPTION
Summary
- add manual deploy inputs to provision the Cloudflare Access console app before deploy
- write provisioned Access team/audience/admin vars into GITHUB_ENV so the same job deploys a Worker that can verify Access JWTs
- document the GitHub Actions path for the remaining Zero Trust token unblock

Verification
- node --check scripts/provision-access.mjs
- ruby YAML.load_file(.github/workflows/deploy-cloudflare.yml)
- actionlint .github/workflows/deploy-cloudflare.yml
- git diff --check
- CLOUDFLARE_ACCOUNT_ID=91b59577e757131d68d55a471fe32aca CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai pnpm cf:access -- --dry-run
- CLAWROUTER_BASE_URL=https://wrong-smoke.example CLAWROUTER_ACCESS_DOMAIN=clawrouter.openclaw.ai ... pnpm cf:access -- --dry-run confirms access_domain does not follow worker_url
- GITHUB_ENV delimiter regression check for newline/delimiter injection
- .agents/skills/autoreview/scripts/autoreview --mode local: clean

Deployment Status
- not deployed yet; merge then deploy main after checks pass

Remaining Risk
- live Access app provisioning still requires a CLOUDFLARE_API_TOKEN/session with Zero Trust Access app/policy permissions