### PR TITLE
docs(deploy): clarify root access redirect

### DIFF
--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -49,7 +49,9 @@ destinations are
 `/dashboard`, `/playground`, `/admin`, `/account`, `/routes`, `/console`,
 `/v1/session`, `/v1/me`, `/v1/usage`, `/v1/admin/*`, and matching `/api/*`
 aliases; override them with `CLAWROUTER_ACCESS_PATHS` only if the API contract
-changes.
+changes. Do not add `/` on the shared API hostname: Cloudflare Access path
+inheritance would protect the public `/v1/*` API too. Root reaches Access by
+redirecting to `/dashboard`.
 Set `CLAWROUTER_ACCESS_IDP_IDS` to one identity provider to enable automatic
 redirect to that provider; otherwise Access shows its normal login selector.
 When `-- --set-github-vars` is used, managed admin variables are deleted from


### PR DESCRIPTION
## Summary
- document why the shared API hostname must not add `/` to Cloudflare Access paths
- clarify that root reaches Access by redirecting to the protected dashboard path

## Verification
- `node --check scripts/provision-access.mjs`
- `node --check scripts/smoke-deployed.mjs`
- `git diff --check`
- `CLOUDFLARE_ACCOUNT_ID=... CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai pnpm cf:access -- --dry-run`
- `CLAWROUTER_BASE_URL=https://clawrouter.openclaw.ai pnpm cf:smoke` (expected fail: Cloudflare Access app is not yet protecting `/dashboard`)
- repo-local autoreview helper: clean, no accepted/actionable findings
