### PR TITLE
fix(deploy): cap access app destinations

### DIFF
--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -45,13 +45,13 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
-destinations are
-`/dashboard`, `/playground`, `/admin`, `/account`, `/routes`, `/console`,
-`/v1/session`, `/v1/me`, `/v1/usage`, `/v1/admin/*`, and matching `/api/*`
-aliases; override them with `CLAWROUTER_ACCESS_PATHS` only if the API contract
-changes. Do not add `/` on the shared API hostname: Cloudflare Access path
-inheritance would protect the public `/v1/*` API too. Root reaches Access by
-redirecting to `/dashboard`.
+destinations are `/dashboard`, `/v1/session`, `/v1/me`, `/v1/usage`, and
+`/v1/admin/*`. This stays within Cloudflare's per-application destination
+limit while still protecting the console entrypoint and the Access-backed user
+and admin APIs. Override them with `CLAWROUTER_ACCESS_PATHS` only if the API
+contract changes. Do not add `/` on the shared API hostname: Cloudflare Access
+path inheritance would protect the public `/v1/*` API too. Root reaches Access
+by redirecting to `/dashboard`.
 Set `CLAWROUTER_ACCESS_IDP_IDS` to one identity provider to enable automatic
 redirect to that provider; otherwise Access shows its normal login selector.
 When `-- --set-github-vars` is used, managed admin variables are deleted from
@@ -197,10 +197,11 @@ the `cf-access-jwt-assertion` signature against the team certs endpoint before
 it trusts the email or role.
 
 The browser console is fail-closed in the Worker. `/` redirects to
-`/dashboard`; `/dashboard`, `/playground`, `/admin`, `/account`, `/routes`, and
-`/console` only render after a verified Cloudflare Access session. Public and
-client-facing surfaces stay under the API paths such as `/v1`, `/v1/health`,
-`/v1/providers`, `/v1/routes`, and proxy endpoints.
+`/dashboard`; the default Access app protects `/dashboard`, and the Worker
+still refuses `/playground`, `/admin`, `/account`, `/routes`, and `/console`
+without a verified Access JWT. Public and client-facing surfaces stay under
+the API paths such as `/v1`, `/v1/health`, `/v1/providers`, `/v1/routes`, and
+proxy endpoints.
 
 After Access is configured, an unauthenticated request to `/` should be handled
 by the Worker with a redirect to `/dashboard`, and `/dashboard` should be

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -340,19 +340,10 @@ function destinationUris(app) {
 function defaultAccessPaths() {
   return [
     "/dashboard",
-    "/playground",
-    "/admin",
-    "/account",
-    "/routes",
-    "/console",
     "/v1/session",
     "/v1/me",
     "/v1/usage",
     "/v1/admin/*",
-    "/api/session",
-    "/api/me",
-    "/api/usage",
-    "/api/admin/*",
   ];
 }
 


### PR DESCRIPTION
## Summary
- reduce default Cloudflare Access destinations to the five paths required for root console login and Access-backed API auth
- document the Cloudflare destination limit tradeoff

## Verification
- env CLOUDFLARE_ACCOUNT_ID=91b59577e757131d68d55a471fe32aca CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai CLAWROUTER_ACCESS_ADMIN_EMAILS=vincentkoc@ieee.org node scripts/provision-access.mjs --dry-run
- git diff --check
- node --check scripts/provision-access.mjs
- cargo test -p clawrouter-edge root_redirect_points_to_dashboard

## Context
The live provision workflow now has a valid Cloudflare token, but Cloudflare rejects the previous one-app destination list with `too many destinations for one app`.