### PR TITLE
fix(deploy): expose KV preflight skip

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -52,6 +52,11 @@ on:
         required: false
         default: ""
         type: string
+      skip_kv_write_preflight:
+        description: "Skip the preflight POLICY_KV write probe for deploy-only tokens"
+        required: false
+        default: false
+        type: boolean
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -79,6 +84,7 @@ jobs:
       CLAWROUTER_SMOKE_KEY: ${{ secrets.CLAWROUTER_SMOKE_KEY }}
       CLAWROUTER_SMOKE_OPENAI: ${{ inputs.smoke_openai && '1' || '0' }}
       CLAWROUTER_SMOKE_LIVE_PROVIDERS: ${{ inputs.live_providers }}
+      CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE: ${{ inputs.skip_kv_write_preflight && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Summary
- expose the existing `CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE` deploy preflight escape hatch as a workflow_dispatch input
- keeps the default strict behavior, but allows deploy-only Cloudflare tokens to proceed when KV data writes are handled outside Actions

Verification
- ruby YAML parse for .github/workflows/deploy-cloudflare.yml

Deployment
- needed to rerun the Cloudflare deploy workflow after the current GitHub token failed the POLICY_KV write probe
