### PR TITLE
fix(console): bootstrap entitlements from session

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ pnpm cf:access
 Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
 `/dashboard` path, while public `/v1` catalog and proxy routes stay normal.
-The Access app must also protect `/v1/entitlements` and `/v1/playground/*` so
-browser catalog and playground calls carry a verified Access session. A
-ClawRouter `access_session_required` JSON body on `/dashboard`,
-`/v1/entitlements`, or `/v1/playground/*` means the Access app is not in front of
-that console path yet, and `pnpm cf:smoke` treats that as a failed deployment
-smoke.
+The Access app must also protect `/v1/session` and `/v1/playground/*` so the
+browser console can bootstrap identity, entitlements, and playground calls from
+a verified Access session. A ClawRouter `access_session_required` JSON body on
+`/dashboard`, `/v1/session`, or `/v1/playground/*` means the Access app is not
+in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
+deployment smoke.
 
 The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
 `provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
@@ -82,6 +82,7 @@ The Worker currently exposes:
 
 - `GET /v1/health`
 - `GET /v1/providers`
+- `GET /v1/session`
 - `GET /v1/entitlements`
 - `GET /v1/key/inspect`
 - `POST /v1/chat/completions`

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -86,6 +86,8 @@ interface SessionResponse {
   email?: string | null;
   subject?: string | null;
   tenantId?: string | null;
+  entitlements?: { providers: ProviderAccess[] } | null;
+  entitlementsError?: string | null;
 }
 
 interface ProviderReadiness {
@@ -296,14 +298,22 @@ function App() {
       setSession(sessionData);
       setProviders(providerData.providers);
       setRoutes(routeData);
-      let refreshWarnings: string[] = [];
-      const entitlementResult = await settled(() => request<EntitlementsResponse>(gatewayOrigin, "/v1/entitlements"));
-      if (entitlementResult.ok) {
-        setEntitlements(entitlementResult.value);
-        setProviderReadiness(readinessMap(entitlementResult.value.providers.map((item) => item.readiness)));
+      let refreshWarnings = sessionData.entitlementsError ? [`entitlements unavailable: ${sessionData.entitlementsError}`] : [];
+      const sessionEntitlements = sessionData.entitlements
+        ? { session: sessionData, providers: sessionData.entitlements.providers }
+        : null;
+      if (sessionEntitlements) {
+        setEntitlements(sessionEntitlements);
+        setProviderReadiness(readinessMap(sessionEntitlements.providers.map((item) => item.readiness)));
       } else {
-        setEntitlements(null);
-        refreshWarnings = [...refreshWarnings, `entitlements unavailable: ${entitlementResult.error}`];
+        const entitlementResult = await settled(() => request<EntitlementsResponse>(gatewayOrigin, "/v1/entitlements"));
+        if (entitlementResult.ok) {
+          setEntitlements(entitlementResult.value);
+          setProviderReadiness(readinessMap(entitlementResult.value.providers.map((item) => item.readiness)));
+        } else {
+          setEntitlements(null);
+          refreshWarnings = [...refreshWarnings, `entitlements unavailable: ${entitlementResult.error}`];
+        }
       }
       if (sessionData.role === "admin") {
         const [keyData, userData, readinessData] = await Promise.all([

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -770,6 +770,23 @@ struct EntitlementsResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct SessionProfileResponse {
+    #[serde(flatten)]
+    session: AccessSession,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entitlements: Option<SessionEntitlements>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entitlements_error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionEntitlements {
+    providers: Vec<EntitlementProviderRow>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct EntitlementProviderRow {
     provider: String,
     display_name: String,
@@ -889,7 +906,16 @@ struct KeyPolicyEntry {
 
 async fn session_profile(headers: &Headers, env: &Env) -> Result<Response> {
     if let Some(session) = verified_access_session(headers, env).await? {
-        return Response::from_json(&session);
+        let (entitlements, entitlements_error) =
+            match access_entitlement_rows_for_session(&session, env).await {
+                Ok(providers) => (Some(SessionEntitlements { providers }), None),
+                Err(error) => (None, Some(provider_runtime_error_summary(&error))),
+            };
+        return Response::from_json(&SessionProfileResponse {
+            session,
+            entitlements,
+            entitlements_error,
+        });
     }
     Response::from_json(&serde_json::json!({
         "authenticated": false,
@@ -909,20 +935,26 @@ async fn access_entitlements(headers: &Headers, env: &Env) -> Result<Response> {
             401,
         );
     };
+    let providers = access_entitlement_rows_for_session(&session, env).await?;
+    Response::from_json(&EntitlementsResponse { session, providers })
+}
+
+async fn access_entitlement_rows_for_session(
+    session: &AccessSession,
+    env: &Env,
+) -> Result<Vec<EntitlementProviderRow>> {
     let kv = match env.kv("POLICY_KV") {
         Ok(kv) => kv,
         Err(_) => {
-            return json_error(
-                "policy_store_unavailable",
-                "POLICY_KV binding is required for Access entitlements",
-                503,
-            );
+            return Err(Error::RustError(
+                "POLICY_KV binding is required for Access entitlements".to_string(),
+            ));
         }
     };
     let snapshot = provider_snapshot()?;
     let entries = list_key_policy_records(&kv).await?;
     let grants = list_oauth_grants(&kv).await?;
-    let providers = snapshot
+    Ok(snapshot
         .providers
         .iter()
         .map(|provider| {
@@ -945,8 +977,14 @@ async fn access_entitlements(headers: &Headers, env: &Env) -> Result<Response> {
                 readiness,
             }
         })
-        .collect();
-    Response::from_json(&EntitlementsResponse { session, providers })
+        .collect())
+}
+
+fn provider_runtime_error_summary(error: &Error) -> String {
+    match error {
+        Error::RustError(message) => message.clone(),
+        _ => "entitlements unavailable".to_string(),
+    }
 }
 
 async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -24,6 +24,8 @@ const CORS_ALLOW_METHODS: &str = "GET,POST,PUT,OPTIONS";
 const CORS_ALLOW_HEADERS: &str = "authorization,content-type,x-request-id";
 const CORS_MAX_AGE: &str = "600";
 const ROOT_REDIRECT_PATH: &str = "/dashboard";
+const POLICY_KV_ENTITLEMENTS_REQUIRED: &str =
+    "POLICY_KV binding is required for Access entitlements";
 type HmacSha256 = Hmac<Sha256>;
 const MISSING_ADMIN_HTML: &str = r##"<!doctype html>
 <html lang="en">
@@ -935,7 +937,13 @@ async fn access_entitlements(headers: &Headers, env: &Env) -> Result<Response> {
             401,
         );
     };
-    let providers = access_entitlement_rows_for_session(&session, env).await?;
+    let providers = match access_entitlement_rows_for_session(&session, env).await {
+        Ok(providers) => providers,
+        Err(Error::RustError(message)) if message == POLICY_KV_ENTITLEMENTS_REQUIRED => {
+            return json_error("policy_store_unavailable", &message, 503);
+        }
+        Err(error) => return Err(error),
+    };
     Response::from_json(&EntitlementsResponse { session, providers })
 }
 
@@ -947,7 +955,7 @@ async fn access_entitlement_rows_for_session(
         Ok(kv) => kv,
         Err(_) => {
             return Err(Error::RustError(
-                "POLICY_KV binding is required for Access entitlements".to_string(),
+                POLICY_KV_ENTITLEMENTS_REQUIRED.to_string(),
             ));
         }
     };

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -224,10 +224,12 @@ admin rights.
 }
 ```
 
-`GET /v1/session` reports the verified Access session. `GET /v1/entitlements`
-materializes the current user's provider access and readiness. The admin UI can
-call admin routes through the same-origin Access session; the admin bearer token
-is only a fallback for automation or emergency access.
+`GET /v1/session` reports the verified Access session and carries the console
+bootstrap entitlements/readiness payload when `POLICY_KV` is available.
+`GET /v1/entitlements` remains available for deployments that also protect that
+compatibility route. The admin UI can call admin routes through the same-origin
+Access session; the admin bearer token is only a fallback for automation or
+emergency access.
 
 Admins can inspect materialized Access users and update tenant/status in the
 console or API:

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -20,7 +20,6 @@ expectRouteCatalog(routes, "route catalog");
 const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alias");
 expectRouteCatalog(aliasedRoutes, "route catalog alias");
 await expectAccessGate(`${baseUrl}/v1/session`, "session access gate");
-await expectAccessGate(`${baseUrl}/v1/entitlements`, "entitlements access gate");
 await expectAccessGate(`${baseUrl}/v1/playground/v1/chat/completions`, "playground access gate");
 const plan = buildProviderSmokePlan(providers);
 if (plan.targetCount !== plan.providerCount) {


### PR DESCRIPTION
Summary
- include entitlement/readiness rows in the protected `/v1/session` boot payload
- make the admin console prefer session-provided entitlements and keep `/v1/entitlements` as a fallback compatibility route
- preserve the structured `policy_store_unavailable` response on `/v1/entitlements`
- update deployed smoke/docs so `/v1/session` is the required Access gate

Verification
- cargo test -p clawrouter-edge
- cargo test --workspace
- node scripts/provider-smoke-plan.mjs --strict
- admin: tsc -p tsconfig.json --noEmit
- admin: vite build
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Deployment
- pending merge; local deploy can proceed with Wrangler OAuth after CI

Remaining risk
- GitHub Cloudflare token still lacks Zero Trust Access app/policy permissions, so workflow Access provisioning remains blocked until that secret is rotated
