### PR TITLE
fix(deploy): require KV write preflight for deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -53,7 +53,7 @@ on:
         default: ""
         type: string
       skip_kv_write_preflight:
-        description: "Skip the preflight POLICY_KV write probe for deploy-only tokens"
+        description: "Deprecated: ignored for real deploys because Wrangler requires KV write permission for KV bindings"
         required: false
         default: false
         type: boolean
@@ -84,6 +84,7 @@ jobs:
       CLAWROUTER_SMOKE_KEY: ${{ secrets.CLAWROUTER_SMOKE_KEY }}
       CLAWROUTER_SMOKE_OPENAI: ${{ inputs.smoke_openai && '1' || '0' }}
       CLAWROUTER_SMOKE_LIVE_PROVIDERS: ${{ inputs.live_providers }}
+      CLAWROUTER_PREFLIGHT_DEPLOY: "1"
       CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE: ${{ inputs.skip_kv_write_preflight && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ deployment smoke.
 
 The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
 `provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
-Zero Trust Access apps and policies. Keep `access_domain` set to the console
-hostname; `worker_url` is only the post-deploy smoke-test target.
+Zero Trust Access apps and policies. Real deploys also require KV write
+permission because Wrangler validates the Worker `POLICY_KV` binding while
+publishing. Keep `access_domain` set to the console hostname; `worker_url` is
+only the post-deploy smoke-test target.
 
 ## Edge Proxy
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -155,6 +155,10 @@ pnpm cf:preflight
 pnpm cf:config
 ```
 
+`CLOUDFLARE_API_TOKEN` must be able to write `POLICY_KV`. This is not just a
+preflight nicety: Wrangler rejects deploys for Workers with KV bindings when
+the token cannot write the bound namespace.
+
 Deploy:
 
 ```sh

--- a/scripts/deploy-preflight.mjs
+++ b/scripts/deploy-preflight.mjs
@@ -83,6 +83,11 @@ async function checkCloudflarePermissions() {
 
   await checkCloudflareWorkerRead({ token, accountId, workerName });
   if (process.env.CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE === "1") {
+    if (process.env.CLAWROUTER_PREFLIGHT_DEPLOY === "1") {
+      errors.push(
+        "CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE cannot be used for deploy: Wrangler requires KV write permission for Workers with KV bindings",
+      );
+    }
     console.log("cloudflare kv token: skipped write probe");
     return;
   }


### PR DESCRIPTION
## Summary
- mark deploy preflight as a real deploy context
- fail early when the deprecated KV write skip is used for deploys
- document that Wrangler deploy requires KV write permission for POLICY_KV bindings

## Verification
- node --check scripts/deploy-preflight.mjs
- env CLOUDFLARE_API_TOKEN=x CLOUDFLARE_ACCOUNT_ID=x CLAWROUTER_ADMIN_TOKEN_SHA256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa CLAWROUTER_POLICY_KV_ID=x CLAWROUTER_PREFLIGHT_DEPLOY=1 CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE=1 node scripts/deploy-preflight.mjs
- git diff --check origin/main...HEAD
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

## Deployment
- not deployed; workflow guardrail only

## Remaining risk
- GitHub deploy still needs a Cloudflare token with KV write permission before the deploy workflow can publish this Worker.