### PR TITLE
fix(deploy): skip route management in CI deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -86,6 +86,7 @@ jobs:
       CLAWROUTER_SMOKE_LIVE_PROVIDERS: ${{ inputs.live_providers }}
       CLAWROUTER_PREFLIGHT_DEPLOY: "1"
       CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE: ${{ inputs.skip_kv_write_preflight && '1' || '0' }}
+      CLAWROUTER_OMIT_ROUTES: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -159,6 +159,10 @@ pnpm cf:config
 preflight nicety: Wrangler rejects deploys for Workers with KV bindings when
 the token cannot write the bound namespace.
 
+GitHub deploys render Wrangler config with `CLAWROUTER_OMIT_ROUTES=1` so normal
+script updates do not require zone-level Worker route permissions after the
+custom domain route has already been provisioned.
+
 Deploy:
 
 ```sh

--- a/scripts/render-wrangler-config.mjs
+++ b/scripts/render-wrangler-config.mjs
@@ -10,6 +10,7 @@ const kvId = process.env.CLAWROUTER_POLICY_KV_ID;
 const kvPreviewId = process.env.CLAWROUTER_POLICY_KV_PREVIEW_ID ?? kvId;
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
 const strict = process.env.CLAWROUTER_STRICT_CONFIG !== "0";
+const omitRoutes = process.env.CLAWROUTER_OMIT_ROUTES === "1";
 const workerVars = [
   "CLAWROUTER_ACCESS_TEAM_DOMAIN",
   "CLAWROUTER_ACCESS_AUD",
@@ -25,6 +26,11 @@ if (strict && !kvId) {
 let config = readFileSync(source, "utf8");
 config = config.replace(/^name = .+$/m, `name = "${workerName}"`);
 config = config.replace(/queue = ".+"/, `queue = "${queueName}"`);
+if (omitRoutes) {
+  config = removeTomlArrayBlocks(config, "routes");
+  config = ensureTopLevelSetting(config, "workers_dev", "false");
+  config = ensureTopLevelSetting(config, "preview_urls", "false");
+}
 
 if (kvId) {
   config = `${config.trimEnd()}
@@ -53,3 +59,29 @@ ${renderedVars.join("\n")}
 mkdirSync(dirname(target), { recursive: true });
 writeFileSync(target, config);
 console.log(`rendered ${target}`);
+
+function removeTomlArrayBlocks(input, name) {
+  const header = `[[${name}]]`;
+  const lines = input.split("\n");
+  const output = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== header) {
+      output.push(lines[index]);
+      continue;
+    }
+    index += 1;
+    while (index < lines.length && !lines[index].trimStart().startsWith("[")) {
+      index += 1;
+    }
+    index -= 1;
+  }
+  return output.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+
+function ensureTopLevelSetting(input, key, value) {
+  const pattern = new RegExp(`^${key}\\s*=`, "m");
+  if (pattern.test(input)) {
+    return input;
+  }
+  return input.replace(/^name = .+$/m, (line) => `${line}\n${key} = ${value}`);
+}


### PR DESCRIPTION
## Summary
- allow rendered Wrangler configs to omit route blocks for steady-state deploys
- make the deploy workflow omit route management so it does not require zone-level Worker route permissions
- keep workers.dev and preview URLs explicitly disabled when routes are omitted

## Verification
- node --check scripts/render-wrangler-config.mjs
- env CLAWROUTER_OMIT_ROUTES=1 CLOUDFLARE_ACCOUNT_ID=91b59577e757131d68d55a471fe32aca CLAWROUTER_POLICY_KV_ID=fd500e918fc84431a2d5aef3dfd28214 node scripts/render-wrangler-config.mjs wrangler.toml /tmp/clawrouter-wrangler-no-routes.toml
- git diff --check
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

## Deployment
- not deployed by this PR yet; intended to unblock the Deploy Cloudflare workflow with the current token.

## Remaining risk
- route creation or custom-domain changes still require an operator token with zone Worker route permissions.