### PR TITLE
fix(smoke): use live provider model overrides

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -84,6 +84,7 @@ jobs:
       CLAWROUTER_SMOKE_KEY: ${{ secrets.CLAWROUTER_SMOKE_KEY }}
       CLAWROUTER_SMOKE_OPENAI: ${{ inputs.smoke_openai && '1' || '0' }}
       CLAWROUTER_SMOKE_LIVE_PROVIDERS: ${{ inputs.live_providers }}
+      CLAWROUTER_SMOKE_MODEL_AZURE_OPENAI: ${{ vars.CLAWROUTER_SMOKE_MODEL_AZURE_OPENAI }}
       CLAWROUTER_PREFLIGHT_DEPLOY: "1"
       CLAWROUTER_PREFLIGHT_SKIP_KV_WRITE: ${{ inputs.skip_kv_write_preflight && '1' || '0' }}
       CLAWROUTER_OMIT_ROUTES: "1"

--- a/providers/fireworks.provider.yaml
+++ b/providers/fireworks.provider.yaml
@@ -38,10 +38,9 @@ endpoints:
 models:
   entries:
     - id: fireworks/default
-      upstream: fireworks
+      upstream: accounts/fireworks/models/gpt-oss-120b
       capabilities: [llm.chat]
       pricingRef: fireworks-default
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]
-

--- a/providers/together.provider.yaml
+++ b/providers/together.provider.yaml
@@ -38,7 +38,7 @@ endpoints:
 models:
   entries:
     - id: together/default
-      upstream: meta-llama/Llama-3.3-70B-Instruct-Turbo
+      upstream: Qwen/Qwen2.5-7B-Instruct-Turbo
       capabilities: [llm.chat]
       pricingRef: together-default
 billing:

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -125,7 +125,7 @@ export function summarizePlan(plan) {
 
 function smokeTarget(provider, env) {
   if (supportsOpenAiCompatibleProxy(provider)) {
-    const model = smokeModel(provider);
+    const model = smokeModel(provider, env);
     if (model) {
       return {
         kind: "openai_chat",
@@ -164,7 +164,11 @@ function smokeTarget(provider, env) {
   };
 }
 
-function smokeModel(provider) {
+function smokeModel(provider, env) {
+  const override = providerSmokeModelOverride(provider, env);
+  if (override) {
+    return override;
+  }
   const direct = provider.models.find((model) => {
     return model.capabilities.includes("llm.chat") && !model.upstream.includes("${");
   });
@@ -176,6 +180,33 @@ function smokeModel(provider) {
     return `${prefix}smoke-model`;
   }
   return provider.models.find((model) => !model.upstream.includes("${"))?.id ?? null;
+}
+
+function providerSmokeModelOverride(provider, env) {
+  const providerName = envName(provider.id);
+  const override =
+    env[`CLAWROUTER_SMOKE_MODEL_${providerName}`] ||
+    env[`${providerName}_SMOKE_MODEL`] ||
+    null;
+  if (!override) {
+    return null;
+  }
+  const catalogModel = provider.models.find((model) => model.id === override);
+  if (catalogModel) {
+    if (!catalogModel.capabilities.includes("llm.chat")) {
+      throw new Error(`smoke model override for ${provider.id} must support llm.chat`);
+    }
+    return override;
+  }
+  const matchesPrefix = (provider.routing.modelPrefixes ?? []).some((prefix) => {
+    return override.startsWith(prefix) && override.length > prefix.length;
+  });
+  if (!matchesPrefix) {
+    throw new Error(
+      `smoke model override for ${provider.id} must match a catalog id or provider model prefix`,
+    );
+  }
+  return override;
 }
 
 function smokeEndpoint(provider) {


### PR DESCRIPTION
## Summary
- add validated provider-specific smoke model overrides
- update Fireworks and Together default smoke models to live-tested upstreams
- expose the Azure OpenAI smoke deployment override in the deploy workflow

## Verification
- `cargo run -p clawrouter -- provider validate providers/*.provider.yaml`
- `CLAWROUTER_SMOKE_MODEL_AZURE_OPENAI=azure-openai/gpt-54-mini-live node scripts/provider-smoke-plan.mjs --strict`
- invalid cross-provider override rejected
- non-chat catalog override rejected
- live smokes passed for Anthropic, DeepSeek, Mistral, OpenRouter, Perplexity, Tavily
- live override smokes passed for Azure OpenAI, Fireworks, Together
- autoreview clean: no accepted/actionable findings reported

## Deployment
- Not deployed by this PR yet. Worker provider secrets were set directly from 1Password for the live environment.

## Risk
- Low. The override validator fails closed when a configured smoke model does not belong to the selected provider or names a non-chat catalog model.