### PR TITLE
fix(admin): tighten ClawRouter access console

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ pnpm cf:access
 
 Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
-`/dashboard` path, while public `/v1` catalog and proxy routes stay normal.
-The Access app must also protect `/v1/session` and `/v1/playground/*` so the
-browser console can bootstrap identity, entitlements, and playground calls from
-a verified Access session. A ClawRouter `access_session_required` JSON body on
-`/dashboard`, `/v1/session`, or `/v1/playground/*` means the Access app is not
+`/dashboard` path, and canonical console views live under `/dashboard/*`, while
+public `/v1` catalog and proxy routes stay normal. The Access app must also
+protect `/v1/session` and `/v1/playground/*` so the browser console can
+bootstrap identity, entitlements, and playground calls from a verified Access
+session. A ClawRouter `access_session_required` JSON body on `/dashboard`,
+`/dashboard/*`, `/v1/session`, or `/v1/playground/*` means the Access app is not
 in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
 deployment smoke.
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ pnpm cf:access
 
 Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
-`/dashboard` path, and canonical console views live under `/dashboard/*`, while
+`/dashboard` path, `/dashboard` redirects to `/dashboard/catalog`, and canonical console views live under `/dashboard/*`, while
 public `/v1` catalog and proxy routes stay normal. The Access app must also
 protect `/v1/session` and `/v1/playground/*` so the browser console can
 bootstrap identity, entitlements, and playground calls from a verified Access
-session. A ClawRouter `access_session_required` JSON body on `/dashboard`,
-`/dashboard/*`, `/v1/session`, or `/v1/playground/*` means the Access app is not
+session. A ClawRouter `access_session_required` JSON body on `/dashboard/*`,
+`/v1/session`, or `/v1/playground/*` means the Access app is not
 in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
 deployment smoke.
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -645,6 +645,7 @@ function App() {
   function setPolicyProviderGroup(providerIds: string[], checked: boolean) {
     const allProviderIds = providers.map((provider) => provider.id);
     setPolicyForm((current) => {
+      if (current.allProviders && checked) return current;
       const selected = current.allProviders ? allProviderIds : current.providers;
       return {
         ...current,

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -199,6 +199,16 @@ interface ServiceItem {
   brandIcon?: BrandIcon;
 }
 
+type OutcomeTone = "active" | "revoked" | "neutral";
+
+interface ServiceOutcome {
+  label: string;
+  detail: string;
+  tone: OutcomeTone;
+  playable: boolean;
+  blocked: boolean;
+}
+
 interface PolicyForm {
   kid: string;
   tokenRole: string;
@@ -757,44 +767,61 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
   const selectedPolicies = selected ? activePolicies.filter((policy) => policy.providers.includes(selected.provider)) : [];
   const kindCounts = new Map(kinds.map((item) => [item, item === "all" ? queryMatchedServices.length : queryMatchedServices.filter((service) => service.kind === item).length]));
   const servicePolicies = (service: ServiceItem) => activePolicies.filter((policy) => policy.providers.includes(service.provider));
+  const outcomes = allServices.map((service) => serviceOutcome(service, servicePolicies(service)));
+  const usableCount = outcomes.filter((outcome) => outcome.playable).length;
+  const grantedCount = allServices.filter((service) => servicePolicies(service).length || service.access?.allowed).length;
+  const blockedCount = outcomes.filter((outcome) => outcome.blocked).length;
 
   return (
     <div className="entityLayout">
       <section className="mainPane">
         <div className="catalogControls">
-          <div className="catalogMeta"><strong>{services.length} services</strong><span>{readyCount(allServices)} ready · {allowedCount(allServices)} accessible</span></div>
-          <label><span>search catalog</span><div className="inputWithIcon"><Search aria-hidden="true" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="provider, model, route, tool" /></div></label>
+          <div className="catalogMeta"><strong>{services.length} services</strong><span>{usableCount} usable · {grantedCount} granted · {blockedCount} blocked</span></div>
+          <label><span>search catalog</span><div className="inputWithIcon"><Search aria-hidden="true" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="service, provider, model, route" /></div></label>
           <div className="kindTabs" role="tablist" aria-label="service kind">
             {kinds.map((item) => <button key={item} type="button" className={kind === item ? "active" : ""} onClick={() => setKind(item)}>{kindLabel(item)}<span>{kindCounts.get(item) ?? 0}</span></button>)}
           </div>
         </div>
         <EntityTable
-          columns={["service", "kind", "readiness", "access", "route"]}
-          columnTemplate="minmax(210px, 1.5fr) 72px 128px 120px minmax(150px, 0.9fr)"
-          rows={services.map((service) => ({
-            id: service.id,
-            active: selected?.id === service.id,
-            onClick: () => onSelect(service),
-            cells: [
-              <EntityName brandIcon={service.brandIcon} icon={kindIcon(service.kind)} title={service.name} subtitle={service.provider} />,
-              kindLabel(service.kind),
-              <ReadinessStatus readiness={service.readiness} />,
-              <AccessStatus service={service} policies={servicePolicies(service)} />,
-              service.surfaces.join(", "),
-            ],
-          }))}
+          columns={["service", "status", "granted by", "coverage", "routes"]}
+          columnTemplate="minmax(220px, 1.45fr) 138px minmax(130px, 0.8fr) 120px minmax(150px, 0.9fr)"
+          rows={services.map((service) => {
+            const policiesForService = servicePolicies(service);
+            const outcome = serviceOutcome(service, policiesForService);
+            return {
+              id: service.id,
+              active: selected?.id === service.id,
+              onClick: () => onSelect(service),
+              cells: [
+                <EntityName brandIcon={service.brandIcon} icon={kindIcon(service.kind)} title={service.name} subtitle={`${service.provider} · ${kindLabel(service.kind)}`} />,
+                <OutcomeStatus outcome={outcome} />,
+                <PolicyChips policies={policiesForService} />,
+                service.models ? `${service.models} models` : `${service.surfaces.length} route${service.surfaces.length === 1 ? "" : "s"}`,
+                service.surfaces.join(", "),
+              ],
+            };
+          })}
         />
       </section>
       <aside className="inspector">
         {selected ? (
           <>
+            {(() => {
+              const outcome = serviceOutcome(selected, selectedPolicies);
+              const playBlocker = playgroundBlockedForService(selected, selectedPolicies);
+              return (
+                <>
             <InspectorHeader brandIcon={selected.brandIcon} icon={kindIcon(selected.kind)} title={selected.name} subtitle={`${kindLabel(selected.kind)} · ${selected.category}`} />
+            <div className="outcomeCallout">
+              <OutcomeStatus outcome={outcome} />
+              <p>{outcome.detail}</p>
+            </div>
             <dl className="facts">
               <dt>provider</dt><dd>{selected.provider}</dd>
-              <dt>route</dt><dd>{selected.route}</dd>
+              <dt>routes</dt><dd>{selected.route}</dd>
               <dt>surfaces</dt><dd>{selected.surfaces.join(", ")}</dd>
               <dt>models</dt><dd>{selected.models || "n/a"}</dd>
-              <dt>access</dt><dd>{selected.access ? (selected.access.allowed ? `allowed by ${selected.access.policies.join(", ") || "session"}` : "not granted") : "unknown"}</dd>
+              <dt>grant</dt><dd>{selectedPolicies.length ? selectedPolicies.map((policy) => policy.kid).join(", ") : selected.access?.allowed ? selected.access.policies.join(", ") || "session" : "none"}</dd>
               <dt>readiness</dt><dd>{readinessLabel(selected.readiness)}</dd>
               <dt>missing</dt><dd>{selected.readiness?.missingConfig.length ? selected.readiness.missingConfig.join(", ") : "none"}</dd>
               <dt>oauth grants</dt><dd>{selected.readiness?.oauthGrantRequired ? selected.readiness.oauthGrantCount : "n/a"}</dd>
@@ -813,9 +840,12 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
               {selectedPolicies.length ? selectedPolicies.map((policy) => <button key={policy.kid} type="button">{policy.kid}<span>{policy.tenantId ?? "default"}</span></button>) : <p>No policy grants this service yet.</p>}
             </div>
             <div className="inspectorActions">
-              <button type="button" disabled={Boolean(playgroundBlockedForService(selected))} onClick={() => onPlay(selected)} title={playgroundBlockedForService(selected) ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Try in playground</span></button>
-              <button type="button" className="buttonSecondary" onClick={() => onAdd(selected)}><Plus className="buttonIcon" aria-hidden="true" /><span>Add to policy</span></button>
+              <button type="button" disabled={Boolean(playBlocker)} onClick={() => onPlay(selected)} title={playBlocker ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Try in playground</span></button>
+              <button type="button" className="buttonSecondary" onClick={() => onAdd(selected)}><Plus className="buttonIcon" aria-hidden="true" /><span>Add to grant</span></button>
             </div>
+                </>
+              );
+            })()}
           </>
         ) : <p>Select a service.</p>}
       </aside>
@@ -942,14 +972,14 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
     <div className="entityLayout">
       <section className="mainPane">
         <EntityTable
-          columns={["policy", "audience", "role", "services", "monthly cap", "status"]}
+          columns={["grant", "tenant", "role", "services", "budget", "state"]}
           columnTemplate="minmax(220px, 1.4fr) 130px 120px 110px 130px 120px"
-          rows={keys.map((key) => ({ id: key.kid, active: selected?.kid === key.kid, onClick: () => onEdit(key), cells: [<EntityName icon={KeyRound} title={key.kid} subtitle={key.enabled ? "active policy" : "revoked"} />, key.tenantId ?? "default", key.tokenRole ?? "custom", String(key.providers.length), formatBudget(key.monthlyBudgetMicros), <Status label={key.enabled ? "active" : "revoked"} tone={key.enabled ? "active" : "revoked"} />] }))}
+          rows={keys.map((key) => ({ id: key.kid, active: selected?.kid === key.kid, onClick: () => onEdit(key), cells: [<EntityName icon={KeyRound} title={key.kid} subtitle={key.enabled ? "active grant" : "revoked grant"} />, key.tenantId ?? "default", key.tokenRole ?? "custom", String(key.providers.length), formatBudget(key.monthlyBudgetMicros), <Status label={key.enabled ? "active" : "revoked"} tone={key.enabled ? "active" : "revoked"} />] }))}
         />
       </section>
       <aside className="inspector wideInspector">
         <form onSubmit={onSave}>
-          <InspectorHeader icon={KeyRound} title="Access policy" subtitle={`${form.providers.length} services · ${form.tenantId || "default"}`} />
+          <InspectorHeader icon={KeyRound} title="Access grant" subtitle={`${form.tenantId || "default"} gets ${form.providers.length} services`} />
           {error ? <InlineError message={error} /> : null}
           {issuedKey ? (
             <div className="issuedKey">
@@ -957,15 +987,19 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
               <button type="button" className="buttonSecondary" onClick={copyIssuedKey}>Copy</button>
             </div>
           ) : null}
-          <div className="presetRow" aria-label="policy templates">{Object.keys(rolePresets).map((role) => <button key={role} type="button" className="buttonSecondary" onClick={() => onPreset(role as keyof typeof rolePresets)}>{role}</button>)}</div>
+          <div className="grantSummary">
+            <strong>{form.tenantId || "default"}</strong>
+            <span>{form.enabled ? "will have" : "would have"} access to {form.providers.length} selected services under the {form.tokenRole || "custom"} role.</span>
+          </div>
+          <div className="presetRow" aria-label="grant templates">{Object.keys(rolePresets).map((role) => <button key={role} type="button" className="buttonSecondary" onClick={() => onPreset(role as keyof typeof rolePresets)}>{role}</button>)}</div>
           <div className="formGrid compact">
-            <label><span>policy id</span><input value={form.kid} onChange={(event) => setForm({ ...form, kid: event.target.value })} /></label>
-            <label><span>audience tenant</span><input value={form.tenantId} onChange={(event) => setForm({ ...form, tenantId: event.target.value })} /></label>
+            <label><span>grant id</span><input value={form.kid} onChange={(event) => setForm({ ...form, kid: event.target.value })} /></label>
+            <label><span>tenant</span><input value={form.tenantId} onChange={(event) => setForm({ ...form, tenantId: event.target.value })} /></label>
             <label><span>role</span><input value={form.tokenRole} onChange={(event) => setForm({ ...form, tokenRole: event.target.value })} /></label>
             <label><span>status</span><select value={form.enabled ? "active" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "active" })}><option value="active">active</option><option value="disabled">disabled</option></select></label>
             <label className="full"><span>monthly budget</span><input inputMode="decimal" value={form.monthlyBudgetMicros} onChange={(event) => setForm({ ...form, monthlyBudgetMicros: event.target.value })} placeholder="unlimited" /></label>
           </div>
-          <div className="matrixHeader"><strong>service access</strong><span>{form.providers.length} selected · {visibleProviderCount} shown</span></div>
+          <div className="matrixHeader"><strong>Services in this grant</strong><span>{form.providers.length} selected · {visibleProviderCount} shown</span></div>
           <div className="inputWithIcon providerFilter"><Search aria-hidden="true" /><input value={providerQuery} onChange={(event) => setProviderQuery(event.target.value)} placeholder="filter services" /></div>
           <div className="serviceGroups">
             {providerGroups.length ? providerGroups.map((group) => {
@@ -984,7 +1018,7 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
               );
             }) : <p>No services match this filter.</p>}
           </div>
-          <div className="inspectorActions"><button type="submit" disabled={busy || !form.providers.length}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save policy</span></button>{selected ? <button type="button" className="buttonDanger" disabled={!selected.enabled || busy} onClick={() => onRevoke(selected.kid)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke selected</span></button> : null}</div>
+          <div className="inspectorActions"><button type="submit" disabled={busy || !form.providers.length}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected ? <button type="button" className="buttonDanger" disabled={!selected.enabled || busy} onClick={() => onRevoke(selected.kid)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke grant</span></button> : null}</div>
         </form>
       </aside>
     </div>
@@ -1006,10 +1040,17 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
 }) {
   const accessForUser = (user: AccessUser | undefined) => effectiveAccess(user, policies, services);
   const selectedAccess = accessForUser(selected);
+  const selectedOutcomes = selectedAccess.services.map((service) => ({ service, outcome: serviceOutcome(service, selectedAccess.policies.filter((policy) => policy.providers.includes(service.provider))) }));
+  const selectedUsable = selectedOutcomes.filter((item) => item.outcome.playable).length;
+  const selectedBlocked = selectedOutcomes.filter((item) => item.outcome.blocked).length;
   return (
     <div className="entityLayout">
       <section className="mainPane">
-        <EntityTable columns={["user", "role", "tenant", "access", "status"]} columnTemplate="minmax(260px, 1.5fr) 100px 140px 120px 120px" rows={users.map((user) => ({ id: user.email, active: selected?.email === user.email, onClick: () => onSelect(user), cells: [<EntityName icon={Users} title={user.email} subtitle="Cloudflare Access" />, user.role, user.tenantId, String(accessForUser(user).services.length), <Status label={user.enabled ? "enabled" : "disabled"} tone={user.enabled ? "active" : "revoked"} />] }))} />
+        <EntityTable columns={["identity", "role", "tenant", "grants", "usable", "status"]} columnTemplate="minmax(260px, 1.5fr) 90px 130px 96px 96px 116px" rows={users.map((user) => {
+          const access = accessForUser(user);
+          const usable = access.services.filter((service) => serviceOutcome(service, access.policies.filter((policy) => policy.providers.includes(service.provider))).playable).length;
+          return { id: user.email, active: selected?.email === user.email, onClick: () => onSelect(user), cells: [<EntityName icon={Users} title={user.email} subtitle="Cloudflare Access" />, user.role, user.tenantId, String(access.policies.length), `${usable}/${access.services.length}`, <Status label={user.enabled ? "enabled" : "disabled"} tone={user.enabled ? "active" : "revoked"} />] };
+        })} />
       </section>
       <aside className="inspector">
         <form onSubmit={onSave}>
@@ -1021,11 +1062,11 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
             <label><span>tenant</span><input value={form.tenantId} onChange={(event) => setForm({ ...form, tenantId: event.target.value })} /></label>
             <label><span>status</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
           </div>
-          <dl className="facts"><dt>effective services</dt><dd>{selectedAccess.services.length}</dd><dt>active policies</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
-          <div className="sectionTitle">Tenant policies</div>
-          <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{policy.providers.length} services</span></button>) : <p>No active policy grants this tenant access.</p>}</div>
+          <dl className="facts"><dt>usable services</dt><dd>{selectedUsable}/{selectedAccess.services.length}</dd><dt>blocked services</dt><dd>{selectedBlocked}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
+          <div className="sectionTitle">Tenant grants</div>
+          <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{policy.providers.length} services · {formatBudget(policy.monthlyBudgetMicros)}</span></button>) : <p>No active grant gives this tenant service access.</p>}</div>
           <div className="sectionTitle">Effective access</div>
-          <div className="miniList">{selectedAccess.services.length ? selectedAccess.services.slice(0, 8).map((service) => <button type="button" key={service.id}>{service.name}<span>{kindLabel(service.kind)}</span></button>) : <p>No services available for this user.</p>}</div>
+          <div className="miniList">{selectedOutcomes.length ? selectedOutcomes.slice(0, 8).map(({ service, outcome }) => <button type="button" key={service.id}>{service.name}<span>{outcome.label} · {kindLabel(service.kind)}</span></button>) : <p>No services available for this user.</p>}</div>
           <div className="inspectorActions"><button type="submit" disabled={busy}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save user</span></button></div>
         </form>
       </aside>
@@ -1120,9 +1161,13 @@ function InlineNote({ children }: { children: React.ReactNode }) {
   return <div className="inlineNote">{children}</div>;
 }
 
-function Status({ label, tone }: { label: string; tone: "active" | "revoked" | "neutral" }) {
+function Status({ label, tone }: { label: string; tone: OutcomeTone }) {
   const Icon = tone === "active" ? CheckCircle2 : tone === "revoked" ? CircleSlash2 : null;
   return <span className={`status ${tone}`}>{Icon ? <Icon aria-hidden="true" /> : null}{label}</span>;
+}
+
+function OutcomeStatus({ outcome }: { outcome: ServiceOutcome }) {
+  return <Status label={outcome.label} tone={outcome.tone} />;
 }
 
 function ReadinessStatus({ readiness }: { readiness?: ProviderReadiness }) {
@@ -1139,16 +1184,16 @@ function AccessStatus({ service, policies }: { service: ServiceItem; policies: K
 }
 
 function viewTitle(view: View) {
-  return ({ catalog: "Catalog", playground: "Playground", policies: "Policies", users: "Users", usage: "Usage" } as const)[view];
+  return ({ catalog: "Catalog", playground: "Playground", policies: "Access", users: "Users", usage: "Usage" } as const)[view];
 }
 
 function viewSubtitle(view: View) {
   return {
-    catalog: "Access catalog",
-    playground: "Policy-path test",
-    policies: "Provider allowlists",
-    users: "Tenant grants",
-    usage: "Budget coverage",
+    catalog: "Service access catalog",
+    playground: "Run through the same access path",
+    policies: "Grant services to tenants",
+    users: "Cloudflare Access identities",
+    usage: "Tenant budget ledger",
   }[view];
 }
 
@@ -1246,6 +1291,49 @@ function readyCount(services: ServiceItem[]) {
 
 function allowedCount(services: ServiceItem[]) {
   return services.filter((service) => service.access?.allowed).length;
+}
+
+function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): ServiceOutcome {
+  const grantedBySession = Boolean(service.access?.allowed);
+  const explicitlyDenied = service.access ? !service.access.allowed : false;
+  const granted = grantedBySession || policies.length > 0;
+  const policyNames = service.access?.policies.length ? service.access.policies : policies.map((policy) => policy.kid);
+  if (!granted) {
+    return {
+      label: explicitlyDenied ? "denied" : "not granted",
+      detail: explicitlyDenied ? "Current Cloudflare Access identity is denied by policy." : "No active grant currently includes this service.",
+      tone: "revoked",
+      playable: false,
+      blocked: true,
+    };
+  }
+  if (!service.readiness) {
+    return {
+      label: "unknown",
+      detail: `Granted by ${policyNames.join(", ") || "session"}, but runtime readiness has not loaded yet.`,
+      tone: "neutral",
+      playable: false,
+      blocked: true,
+    };
+  }
+  if (service.readiness.executable) {
+    return {
+      label: "usable",
+      detail: `Granted by ${policyNames.join(", ") || "session"} and executable in the gateway.`,
+      tone: "active",
+      playable: true,
+      blocked: false,
+    };
+  }
+  const missing = service.readiness.missingConfig.length ? `Missing ${service.readiness.missingConfig.join(", ")}.` : "";
+  const oauth = service.readiness.oauthGrantRequired ? "OAuth grant required before calls can run." : "";
+  return {
+    label: service.readiness.status === "missing_config" ? "missing config" : service.readiness.status === "grant_required" ? "needs OAuth" : readinessLabel(service.readiness),
+    detail: [service.readiness.reasons[0], missing, oauth].filter(Boolean).join(" "),
+    tone: "revoked",
+    playable: false,
+    blocked: true,
+  };
 }
 
 function readinessLabel(readiness: ProviderReadiness | undefined) {
@@ -1508,8 +1596,9 @@ function playgroundBlocker(form: PlaygroundForm, model: CatalogModel | undefined
   return null;
 }
 
-function playgroundBlockedForService(service: ServiceItem) {
-  if (service.access && !service.access.allowed) return "current Access identity is not granted this service";
+function playgroundBlockedForService(service: ServiceItem, policies: KeyPolicy[] = []) {
+  const outcome = serviceOutcome(service, policies);
+  if (!outcome.playable) return outcome.detail;
   if (service.readiness && !service.readiness.executable) return service.readiness.reasons[0] ?? `service is ${readinessLabel(service.readiness)}`;
   if (!service.models && service.surfaces.includes("provider")) return "no executable model or proxy route declared";
   return null;

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -224,6 +224,7 @@ interface PolicyForm {
   monthlyBudgetMicros: string;
   requestCostMicros: string;
   providers: string[];
+  allProviders: boolean;
 }
 
 interface AccessForm {
@@ -260,6 +261,7 @@ const defaultPolicy: PolicyForm = {
   monthlyBudgetMicros: "100",
   requestCostMicros: "1000",
   providers: ["openai", "tavily"],
+  allProviders: false,
 };
 
 const defaultAccess: AccessForm = {
@@ -292,6 +294,7 @@ function App() {
   const [providers, setProviders] = useState<ProviderRow[]>(allowDemo ? demo.providers : []);
   const [routes, setRoutes] = useState<RouteCatalog>(allowDemo ? demo.routes : emptyRoutes);
   const [keys, setKeys] = useState<KeyPolicy[]>(allowDemo ? demo.keys : []);
+  const [policyDataLoaded, setPolicyDataLoaded] = useState(allowDemo);
   const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
   const [adminOverview, setAdminOverview] = useState<AdminOverview | null>(allowDemo ? demo.overview : null);
   const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
@@ -377,6 +380,7 @@ function App() {
   async function refresh() {
     try {
       setStatus("loading");
+      setPolicyDataLoaded(false);
       const [sessionData, providerData, routeData] = await Promise.all([
         request<SessionResponse>(gatewayOrigin, "/v1/session"),
         request<ProviderResponse>(gatewayOrigin, "/v1/providers"),
@@ -409,6 +413,7 @@ function App() {
           request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
         ]);
         setKeys(keyData.keys);
+        setPolicyDataLoaded(true);
         setUsers(userData.users);
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
         const [overviewResult, tenantResult] = await Promise.all([
@@ -438,6 +443,7 @@ function App() {
           enabled: sessionData.authenticated,
         };
         setKeys([]);
+        setPolicyDataLoaded(false);
         setUsers([user]);
         setAdminOverview(null);
         setTenantSummaries([]);
@@ -455,6 +461,7 @@ function App() {
         setProviders(demo.providers);
         setRoutes(demo.routes);
         setKeys(demo.keys);
+        setPolicyDataLoaded(true);
         setUsers(demo.users);
         setAdminOverview(demo.overview);
         setTenantSummaries(demo.tenants);
@@ -480,12 +487,12 @@ function App() {
     try {
       setPolicyError("");
       setStatus("saving grant");
-      if (!policyForm.providers.length) throw new Error("select at least one service");
+      if (!policyForm.allProviders && !policyForm.providers.length) throw new Error("select at least one service");
       if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.kid)) throw new Error("grant id must use 4 or more letters, numbers, or underscores");
       const next: KeyPolicy = {
         kid: policyForm.kid,
         enabled: policyForm.enabled,
-        providers: policyForm.providers,
+        providers: policyForm.allProviders ? [] : policyForm.providers,
         tenantId: policyForm.tenantId || "default",
         tokenRole: policyForm.tokenRole || null,
         monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,
@@ -620,25 +627,33 @@ function App() {
       monthlyBudgetMicros: currencyInput(optionalNumber(preset.budget)),
       requestCostMicros: preset.request,
       providers: preset.providers.length ? preset.providers.filter((id) => available.has(id)) : providers.map((provider) => provider.id),
+      allProviders: false,
     }));
   }
 
   function togglePolicyProvider(providerId: string) {
+    const allProviderIds = providers.map((provider) => provider.id);
     setPolicyForm((current) => ({
       ...current,
-      providers: current.providers.includes(providerId)
-        ? current.providers.filter((id) => id !== providerId)
+      allProviders: false,
+      providers: (current.allProviders ? allProviderIds : current.providers).includes(providerId)
+        ? (current.allProviders ? allProviderIds : current.providers).filter((id) => id !== providerId)
         : [...current.providers, providerId].sort(),
     }));
   }
 
   function setPolicyProviderGroup(providerIds: string[], checked: boolean) {
-    setPolicyForm((current) => ({
-      ...current,
-      providers: checked
-        ? unique([...current.providers, ...providerIds]).sort()
-        : current.providers.filter((id) => !providerIds.includes(id)),
-    }));
+    const allProviderIds = providers.map((provider) => provider.id);
+    setPolicyForm((current) => {
+      const selected = current.allProviders ? allProviderIds : current.providers;
+      return {
+        ...current,
+        allProviders: false,
+        providers: checked
+          ? unique([...selected, ...providerIds]).sort()
+          : selected.filter((id) => !providerIds.includes(id)),
+      };
+    });
   }
 
   function applyDemoKeys(updater: (current: KeyPolicy[]) => KeyPolicy[]) {
@@ -708,7 +723,7 @@ function App() {
             allServices={services}
             selected={selectedService}
             policies={keys}
-            policyFallbackAuthoritative={session.role === "admin"}
+            policyFallbackAuthoritative={session.role === "admin" && policyDataLoaded}
             query={query}
             setQuery={setQuery}
             kind={kind}
@@ -726,7 +741,7 @@ function App() {
             onAdd={(service) => {
               setPolicyForm((current) => ({
                 ...current,
-                providers: current.providers.includes(service.provider) ? current.providers : [...current.providers, service.provider].sort(),
+                providers: current.allProviders || current.providers.includes(service.provider) ? current.providers : [...current.providers, service.provider].sort(),
               }));
               navigateTo("policies");
             }}
@@ -1017,6 +1032,8 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
   const [providerQuery, setProviderQuery] = useState("");
   const providerGroups = groupedProviders(providers, providerQuery);
   const visibleProviderCount = providerGroups.reduce((total, group) => total + group.providers.length, 0);
+  const formServiceLabel = form.allProviders ? "all services" : `${form.providers.length} selected service${form.providers.length === 1 ? "" : "s"}`;
+  const formSelectionLabel = form.allProviders ? `all services · ${visibleProviderCount} shown` : `${form.providers.length} selected · ${visibleProviderCount} shown`;
   const copyIssuedKey = () => {
     void navigator.clipboard?.writeText(issuedKey);
   };
@@ -1026,12 +1043,12 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
         <EntityTable
           columns={["grant", "tenant", "role", "services", "budget", "state"]}
           columnTemplate="minmax(220px, 1.4fr) 130px 120px 110px 130px 120px"
-          rows={keys.map((key) => ({ id: key.kid, active: selected?.kid === key.kid, onClick: () => onEdit(key), cells: [<EntityName icon={KeyRound} title={key.kid} subtitle={key.enabled ? "active grant" : "revoked grant"} />, key.tenantId ?? "default", key.tokenRole ?? "custom", String(key.providers.length), formatBudget(key.monthlyBudgetMicros), <Status label={key.enabled ? "active" : "revoked"} tone={key.enabled ? "active" : "revoked"} />] }))}
+          rows={keys.map((key) => ({ id: key.kid, active: selected?.kid === key.kid, onClick: () => onEdit(key), cells: [<EntityName icon={KeyRound} title={key.kid} subtitle={key.enabled ? "active grant" : "revoked grant"} />, key.tenantId ?? "default", key.tokenRole ?? "custom", key.providers.length ? String(key.providers.length) : "all", formatBudget(key.monthlyBudgetMicros), <Status label={key.enabled ? "active" : "revoked"} tone={key.enabled ? "active" : "revoked"} />] }))}
         />
       </section>
       <aside className="inspector wideInspector">
         <form onSubmit={onSave}>
-          <InspectorHeader icon={KeyRound} title="Access grant" subtitle={`${form.tenantId || "default"} gets ${form.providers.length} services`} />
+          <InspectorHeader icon={KeyRound} title="Access grant" subtitle={`${form.tenantId || "default"} gets ${formServiceLabel}`} />
           {error ? <InlineError message={error} /> : null}
           {issuedKey ? (
             <div className="issuedKey">
@@ -1041,7 +1058,7 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
           ) : null}
           <div className="grantSummary">
             <strong>{form.tenantId || "default"}</strong>
-            <span>{form.enabled ? "will have" : "would have"} access to {form.providers.length} selected services under the {form.tokenRole || "custom"} role.</span>
+            <span>{form.enabled ? "will have" : "would have"} access to {formServiceLabel} under the {form.tokenRole || "custom"} role.</span>
           </div>
           <div className="presetRow" aria-label="grant templates">{Object.keys(rolePresets).map((role) => <button key={role} type="button" className="buttonSecondary" onClick={() => onPreset(role as keyof typeof rolePresets)}>{role}</button>)}</div>
           <div className="formGrid compact">
@@ -1051,12 +1068,12 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
             <label><span>status</span><select value={form.enabled ? "active" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "active" })}><option value="active">active</option><option value="disabled">disabled</option></select></label>
             <label className="full"><span>monthly budget</span><input inputMode="decimal" value={form.monthlyBudgetMicros} onChange={(event) => setForm({ ...form, monthlyBudgetMicros: event.target.value })} placeholder="unlimited" /></label>
           </div>
-          <div className="matrixHeader"><strong>Services in this grant</strong><span>{form.providers.length} selected · {visibleProviderCount} shown</span></div>
+          <div className="matrixHeader"><strong>Services in this grant</strong><span>{formSelectionLabel}</span></div>
           <div className="inputWithIcon providerFilter"><Search aria-hidden="true" /><input value={providerQuery} onChange={(event) => setProviderQuery(event.target.value)} placeholder="filter services" /></div>
           <div className="serviceGroups">
             {providerGroups.length ? providerGroups.map((group) => {
               const groupIds = group.providers.map((provider) => provider.id);
-              const selectedCount = groupIds.filter((id) => form.providers.includes(id)).length;
+              const selectedCount = form.allProviders ? group.providers.length : groupIds.filter((id) => form.providers.includes(id)).length;
               return (
                 <section className="serviceGroup" key={group.kind}>
                   <div className="serviceGroupHeader">
@@ -1065,12 +1082,12 @@ function PoliciesScreen({ keys, selected, providers, form, setForm, issuedKey, e
                     <button type="button" className="buttonSecondary" onClick={() => onSetProviderGroup(groupIds, true)}>All</button>
                     <button type="button" className="buttonSecondary" onClick={() => onSetProviderGroup(groupIds, false)}>None</button>
                   </div>
-                  <div className="serviceMatrix">{group.providers.map((provider) => <label key={provider.id} title={provider.id}><input type="checkbox" checked={form.providers.includes(provider.id)} onChange={() => onToggleProvider(provider.id)} /><span>{provider.display_name}</span><small>{provider.id}</small></label>)}</div>
+                  <div className="serviceMatrix">{group.providers.map((provider) => <label key={provider.id} title={provider.id}><input type="checkbox" checked={form.allProviders || form.providers.includes(provider.id)} onChange={() => onToggleProvider(provider.id)} /><span>{provider.display_name}</span><small>{provider.id}</small></label>)}</div>
                 </section>
               );
             }) : <p>No services match this filter.</p>}
           </div>
-          <div className="inspectorActions"><button type="submit" disabled={busy || !form.providers.length}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected ? <button type="button" className="buttonDanger" disabled={!selected.enabled || busy} onClick={() => onRevoke(selected.kid)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke grant</span></button> : null}</div>
+          <div className="inspectorActions"><button type="submit" disabled={busy || (!form.allProviders && !form.providers.length)}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected ? <button type="button" className="buttonDanger" disabled={!selected.enabled || busy} onClick={() => onRevoke(selected.kid)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke grant</span></button> : null}</div>
         </form>
       </aside>
     </div>
@@ -1350,8 +1367,16 @@ function grantNamesForService(service: ServiceItem, policies: KeyPolicy[] = []) 
 
 function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = [], policyFallbackAuthoritative = false): ServiceOutcome {
   const grantedBySession = Boolean(service.access?.allowed);
-  const explicitlyDenied = service.access ? !service.access.allowed : false;
-  const granted = grantedBySession || policies.length > 0;
+  if (service.access && !service.access.allowed) {
+    return {
+      label: "denied",
+      detail: "Current Cloudflare Access identity is denied by policy.",
+      tone: "revoked",
+      playable: false,
+      blocked: true,
+    };
+  }
+  const granted = grantedBySession || (!service.access && policies.length > 0);
   const policyNames = service.access?.policies.length ? service.access.policies : policies.map((policy) => policy.kid);
   if (!granted) {
     if (!service.access && !policyFallbackAuthoritative) {
@@ -1364,8 +1389,8 @@ function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = [], policy
       };
     }
     return {
-      label: explicitlyDenied ? "denied" : "not granted",
-      detail: explicitlyDenied ? "Current Cloudflare Access identity is denied by policy." : "No active grant currently includes this service.",
+      label: "not granted",
+      detail: "No active grant currently includes this service.",
       tone: "revoked",
       playable: false,
       blocked: true,
@@ -1492,6 +1517,7 @@ function policyFormFromKey(key: KeyPolicy): PolicyForm {
     monthlyBudgetMicros: currencyInput(key.monthlyBudgetMicros),
     requestCostMicros: key.requestCostMicros?.toString() ?? "",
     providers: key.providers,
+    allProviders: key.providers.length === 0,
   };
 }
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1130,7 +1130,7 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
           </div>
           <dl className="facts"><dt>granted services</dt><dd>{selectedAccess.services.length}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
           <div className="sectionTitle">Tenant grants</div>
-          <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{policy.providers.length} services · {formatBudget(policy.monthlyBudgetMicros)}</span></button>) : <p>No active grant gives this tenant service access.</p>}</div>
+          <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{effectiveProviderCount(policy.providers, services)} services · {formatBudget(policy.monthlyBudgetMicros)}</span></button>) : <p>No active grant gives this tenant service access.</p>}</div>
           <div className="sectionTitle">Effective access</div>
           <div className="miniList">{selectedServices.length ? selectedServices.slice(0, 8).map(({ service, label }) => <button type="button" key={service.id}>{service.name}<span>{label} · {kindLabel(service.kind)}</span></button>) : <p>No services available for this user.</p>}</div>
           <div className="inspectorActions"><button type="submit" disabled={busy}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save user</span></button></div>

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -164,6 +164,7 @@ interface AdminTenantSummary {
   keys: number;
   activeKeys: number;
   providers: string[];
+  allProviders?: boolean;
   monthlyBudgetMicros: number;
   requestCostMicros: number;
 }
@@ -296,6 +297,7 @@ function App() {
   const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
   const [usageRows, setUsageRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
   const [usageLoaded, setUsageLoaded] = useState(allowDemo);
+  const [usageRefreshKey, setUsageRefreshKey] = useState(0);
   const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
   const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {});
   const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromKey(demo.keys[0]) : defaultPolicy);
@@ -357,7 +359,7 @@ function App() {
     if (view === "usage" && session.role === "admin" && !demoMode && !usageLoaded) {
       void refreshUsageLedger();
     }
-  }, [demoMode, session.role, usageLoaded, view]);
+  }, [demoMode, session.role, usageLoaded, usageRefreshKey, view]);
 
   useEffect(() => {
     if (models.length && !models.some((model) => model.id === playground.model)) {
@@ -427,6 +429,7 @@ function App() {
         }
         setUsageRows([]);
         setUsageLoaded(false);
+        if (view === "usage") setUsageRefreshKey((current) => current + 1);
       } else {
         const user = {
           email: sessionData.email ?? "access-user",
@@ -1154,7 +1157,7 @@ function UsageScreen({ keys, services, overview, tenants, usageRows, usageLoaded
         <InspectorHeader icon={BarChart3} title="Usage ledger" subtitle="tenant budgets and grant health" />
         <dl className="facts"><dt>active grants</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{totalBudgetLabel}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
         <div className="sectionTitle">Tenants</div>
-        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {effectiveProviderCount(tenant.providers, services)} services</span></button>) : <p>No tenant grants yet.</p>}</div>
+        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {effectiveProviderCount(tenant.providers, services, tenant.allProviders)} services</span></button>) : <p>No tenant grants yet.</p>}</div>
         <div className="sectionTitle">Needs configuration</div>
         <div className="miniList">{blockedServices.length ? blockedServices.slice(0, 8).map((service) => <button type="button" key={service.id}>{service.name}<span>{readinessLabel(service.readiness)}</span></button>) : <p>All visible services are executable.</p>}</div>
       </aside>
@@ -1445,9 +1448,8 @@ function formatMicros(value: number | null | undefined) {
   return `$${(value / 1_000_000).toFixed(2)}`;
 }
 
-function effectiveProviderCount(providerIds: string[], services: ServiceItem[]) {
-  if (providerIds.length) return String(providerIds.length);
-  return `all ${new Set(services.map((service) => service.provider)).size}`;
+function effectiveProviderCount(providerIds: string[], services: ServiceItem[], allProviders = providerIds.length === 0) {
+  return allProviders ? `all ${new Set(services.map((service) => service.provider)).size}` : String(providerIds.length);
 }
 
 function catalogModels(routes: RouteCatalog): CatalogModel[] {
@@ -1521,15 +1523,19 @@ function policyUsageFallback(policy: KeyPolicy): AdminUsageRow {
 function tenantSummaryFallback(keys: KeyPolicy[]): AdminTenantSummary[] {
   const groups = keys.reduce((acc, key) => {
     const tenantId = key.tenantId ?? "default";
-    const current = acc.get(tenantId) ?? { tenantId, keys: 0, activeKeys: 0, providers: new Set<string>(), monthlyBudgetMicros: 0, requestCostMicros: 0 };
+    const current = acc.get(tenantId) ?? { tenantId, keys: 0, activeKeys: 0, providers: new Set<string>(), allProviders: false, monthlyBudgetMicros: 0, requestCostMicros: 0 };
     current.keys += 1;
     if (key.enabled) current.activeKeys += 1;
-    key.providers.forEach((provider) => current.providers.add(provider));
+    if (key.providers.length) {
+      key.providers.forEach((provider) => current.providers.add(provider));
+    } else {
+      current.allProviders = true;
+    }
     current.monthlyBudgetMicros += key.monthlyBudgetMicros ?? 0;
     current.requestCostMicros += key.requestCostMicros ?? 0;
     acc.set(tenantId, current);
     return acc;
-  }, new Map<string, { tenantId: string; keys: number; activeKeys: number; providers: Set<string>; monthlyBudgetMicros: number; requestCostMicros: number }>());
+  }, new Map<string, { tenantId: string; keys: number; activeKeys: number; providers: Set<string>; allProviders: boolean; monthlyBudgetMicros: number; requestCostMicros: number }>());
   return Array.from(groups.values()).map((tenant) => ({ ...tenant, providers: Array.from(tenant.providers).sort() }));
 }
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1134,10 +1134,9 @@ function UsageScreen({ keys, services, overview, tenants, usageRows, usageLoaded
     ? null
     : activeBudgetValues.reduce<number>((total, value) => total + (value ?? 0), 0);
   const totalBudgetLabel = hasUnlimitedBudget ? "unlimited" : formatMicros(totalBudget);
-  const trackedRows = rows.filter((row) => row.budget.configured);
-  const totalSpent = !usageLoaded || trackedRows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
+  const totalSpent = !usageLoaded || rows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
     ? null
-    : trackedRows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
+    : rows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
   const routeTotal = services.reduce((total, service) => total + service.routeCount, 0);
   const providerTotal = overview?.providerCount ?? new Set(services.map((service) => service.provider)).size;
   return (

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -480,7 +480,7 @@ function App() {
         requestCostMicros: optionalNumber(policyForm.requestCostMicros) ?? null,
       };
       if (demoMode) {
-        setKeys((current) => [next, ...current.filter((key) => key.kid !== next.kid)]);
+        applyDemoKeys((current) => [next, ...current.filter((key) => key.kid !== next.kid)]);
         setSelectedPolicyId(next.kid);
         setStatus("saved grant");
         return;
@@ -535,7 +535,7 @@ function App() {
     try {
       setStatus(`revoking ${kid}`);
       if (demoMode) {
-        setKeys((current) => current.map((key) => (key.kid === kid ? { ...key, enabled: false } : key)));
+        applyDemoKeys((current) => current.map((key) => (key.kid === kid ? { ...key, enabled: false } : key)));
         setStatus(`revoked ${kid}`);
         return;
       }
@@ -614,6 +614,16 @@ function App() {
         ? unique([...current.providers, ...providerIds]).sort()
         : current.providers.filter((id) => !providerIds.includes(id)),
     }));
+  }
+
+  function applyDemoKeys(updater: (current: KeyPolicy[]) => KeyPolicy[]) {
+    setKeys((current) => {
+      const next = updater(current);
+      setAdminOverview(adminOverviewFromKeys(next, providers, routes));
+      setTenantSummaries(tenantSummaryFallback(next));
+      setUsageRows(next.map(policyUsageFallback));
+      return next;
+    });
   }
 
   function navigateTo(nextView: View) {
@@ -1054,8 +1064,7 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
 }) {
   const accessForUser = (user: AccessUser | undefined) => effectiveAccess(user, policies, services);
   const selectedAccess = accessForUser(selected);
-  const selectedServices = selectedAccess.services.map((service) => ({ service, label: userServiceGrantLabel(service) }));
-  const selectedBlocked = selectedServices.filter(({ service }) => !service.readiness?.executable).length;
+  const selectedServices = selectedAccess.services.map((service) => ({ service, label: "granted" }));
   return (
     <div className="entityLayout">
       <section className="mainPane">
@@ -1074,7 +1083,7 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
             <label><span>tenant</span><input value={form.tenantId} onChange={(event) => setForm({ ...form, tenantId: event.target.value })} /></label>
             <label><span>status</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
           </div>
-          <dl className="facts"><dt>granted services</dt><dd>{selectedAccess.services.length}</dd><dt>blocked/unknown</dt><dd>{selectedBlocked}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
+          <dl className="facts"><dt>granted services</dt><dd>{selectedAccess.services.length}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
           <div className="sectionTitle">Tenant grants</div>
           <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{policy.providers.length} services · {formatBudget(policy.monthlyBudgetMicros)}</span></button>) : <p>No active grant gives this tenant service access.</p>}</div>
           <div className="sectionTitle">Effective access</div>
@@ -1092,15 +1101,17 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
   const blockedServices = services.filter((service) => service.readiness && !service.readiness.executable);
   const rows = usageRows.length ? usageRows : keys.map(policyUsageFallback);
   const tenantRows = tenants.length ? tenants : tenantSummaryFallback(keys);
-  const totalBudget = overview?.monthlyBudgetMicros ?? activeKeys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
+  const totalBudget = overview?.monthlyBudgetMicros ?? keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
   const totalSpent = rows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
+  const routeTotal = overview ? overview.openaiCompatibleProviders + overview.manifestRoutes : services.reduce((total, service) => total + service.routeCount, 0);
+  const providerTotal = overview?.providerCount ?? services.length;
   return (
     <div className="entityLayout">
       <section className="mainPane">
         <div className="overviewStrip">
           <Metric label="active grants" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
           <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${new Set(activeKeys.flatMap((key) => key.providers)).size} granted services`} />
-          <Metric label="routes" value={String((overview?.openaiCompatibleProviders ?? 0) + (overview?.manifestRoutes ?? 0))} meta={`${overview?.providerCount ?? services.length} providers`} />
+          <Metric label="routes" value={String(routeTotal)} meta={`${providerTotal} providers`} />
           <Metric label="budget" value={formatMicros(totalBudget)} meta={`${formatMicros(totalSpent)} spent`} />
         </div>
         <EntityTable columns={["grant", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", String(row.providers.length), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
@@ -1341,11 +1352,6 @@ function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): Servi
   };
 }
 
-function userServiceGrantLabel(service: ServiceItem) {
-  if (!service.readiness) return "readiness unknown";
-  return service.readiness.executable ? "granted" : readinessLabel(service.readiness);
-}
-
 function readinessLabel(readiness: ProviderReadiness | undefined) {
   if (!readiness) return "unknown";
   return readiness.status.replace(/_/g, " ");
@@ -1485,6 +1491,20 @@ function tenantSummaryFallback(keys: KeyPolicy[]): AdminTenantSummary[] {
     return acc;
   }, new Map<string, { tenantId: string; keys: number; activeKeys: number; providers: Set<string>; monthlyBudgetMicros: number; requestCostMicros: number }>());
   return Array.from(groups.values()).map((tenant) => ({ ...tenant, providers: Array.from(tenant.providers).sort() }));
+}
+
+function adminOverviewFromKeys(keys: KeyPolicy[], providers: ProviderRow[], routes: RouteCatalog): AdminOverview {
+  const tenants = tenantSummaryFallback(keys);
+  return {
+    keysTotal: keys.length,
+    keysActive: keys.filter((key) => key.enabled).length,
+    tenantsTotal: tenants.length,
+    providerCount: providers.length,
+    openaiCompatibleProviders: routes.openaiCompatible.length,
+    manifestRoutes: routes.manifestProxy.length,
+    monthlyBudgetMicros: keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0),
+    requestCostMicros: keys.reduce((total, key) => total + (key.requestCostMicros ?? 0), 0),
+  };
 }
 
 function serviceItems(providers: ProviderRow[], routes: RouteCatalog, readinessByProvider: Record<string, ProviderReadiness> = {}, accessByProvider: Map<string, ProviderAccess> = new Map()): ServiceItem[] {
@@ -1744,16 +1764,7 @@ function demoData() {
   const readinessByProvider = readinessMap(entitlements.providers.map((item) => item.readiness));
   const usageRows = keys.map(policyUsageFallback);
   const tenants = tenantSummaryFallback(keys);
-  const overview: AdminOverview = {
-    keysTotal: keys.length,
-    keysActive: keys.filter((key) => key.enabled).length,
-    tenantsTotal: tenants.length,
-    providerCount: providers.length,
-    openaiCompatibleProviders: routes.openaiCompatible.length,
-    manifestRoutes: routes.manifestProxy.length,
-    monthlyBudgetMicros: keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0),
-    requestCostMicros: keys.reduce((total, key) => total + (key.requestCostMicros ?? 0), 0),
-  };
+  const overview = adminOverviewFromKeys(keys, providers, routes);
   return { session, providers, routes, keys, users, overview, tenants, usageRows, entitlements, services: serviceItems(providers, routes, readinessByProvider, accessByProvider), models };
 }
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1489,7 +1489,7 @@ function policyUsageFallback(policy: KeyPolicy): AdminUsageRow {
       configured: false,
       ledger: "untracked",
       limitMicros: policy.monthlyBudgetMicros,
-      spentMicros: 0,
+      spentMicros: null,
       remainingMicros: policy.monthlyBudgetMicros,
     },
   };

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -291,8 +291,8 @@ function App() {
   const [usageRows, setUsageRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
   const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
   const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {});
-  const [policyForm, setPolicyForm] = useState<PolicyForm>(defaultPolicy);
-  const [accessForm, setAccessForm] = useState<AccessForm>(defaultAccess);
+  const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromKey(demo.keys[0]) : defaultPolicy);
+  const [accessForm, setAccessForm] = useState<AccessForm>(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0]) : defaultAccess);
   const [query, setQuery] = useState("");
   const [kind, setKind] = useState("all");
   const [selectedServiceId, setSelectedServiceId] = useState(demo.services[0]?.id ?? "");
@@ -415,7 +415,7 @@ function App() {
         setTenantSummaries([]);
         setUsageRows([]);
         setSelectedUserEmail(user.email);
-        setAccessForm(user);
+        setAccessForm(accessFormFromUser(user));
       }
       setDemoMode(false);
       setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : "connected");
@@ -432,8 +432,12 @@ function App() {
         setUsageRows(demo.usageRows);
         setEntitlements(demo.entitlements);
         setProviderReadiness(readinessMap(demo.entitlements.providers.map((item) => item.readiness)));
+        setSelectedPolicyId(demo.keys[0]?.kid ?? "");
+        setPolicyForm(demo.keys[0] ? policyFormFromKey(demo.keys[0]) : defaultPolicy);
+        setSelectedUserEmail(demo.users[0]?.email ?? "");
+        setAccessForm(demo.users[0] ? accessFormFromUser(demo.users[0]) : defaultAccess);
         setDemoMode(true);
-        setStatus(`demo mode: ${message}`);
+        setStatus("local demo data loaded");
         return;
       }
       setDemoMode(false);
@@ -445,9 +449,9 @@ function App() {
     event.preventDefault();
     try {
       setPolicyError("");
-      setStatus("saving policy");
+      setStatus("saving grant");
       if (!policyForm.providers.length) throw new Error("select at least one service");
-      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.kid)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
+      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.kid)) throw new Error("grant id must use 4 or more letters, numbers, or underscores");
       const next: KeyPolicy = {
         kid: policyForm.kid,
         enabled: policyForm.enabled,
@@ -460,7 +464,7 @@ function App() {
       if (demoMode) {
         setKeys((current) => [next, ...current.filter((key) => key.kid !== next.kid)]);
         setSelectedPolicyId(next.kid);
-        setStatus("saved policy");
+        setStatus("saved grant");
         return;
       }
       const existingPolicy = keys.some((key) => key.kid === policyForm.kid);
@@ -473,7 +477,7 @@ function App() {
       });
       await refresh();
       setIssuedKey(generatedSecret ? `clawrouter-live-${policyForm.kid}-${generatedSecret}` : "");
-      setStatus("saved policy");
+      setStatus("saved grant");
     } catch (error) {
       const message = errorMessage(error);
       setPolicyError(message);
@@ -561,15 +565,7 @@ function App() {
   function editPolicy(key: KeyPolicy) {
     setIssuedKey("");
     setSelectedPolicyId(key.kid);
-    setPolicyForm({
-      kid: key.kid,
-      tokenRole: key.tokenRole ?? "",
-      tenantId: key.tenantId ?? "default",
-      enabled: key.enabled,
-      monthlyBudgetMicros: currencyInput(key.monthlyBudgetMicros),
-      requestCostMicros: key.requestCostMicros?.toString() ?? "",
-      providers: key.providers,
-    });
+    setPolicyForm(policyFormFromKey(key));
   }
 
   function applyPreset(role: keyof typeof rolePresets) {
@@ -735,7 +731,7 @@ function App() {
             }}
             onSelect={(user) => {
               setSelectedUserEmail(user.email);
-              setAccessForm(user);
+              setAccessForm(accessFormFromUser(user));
             }}
             onSave={saveUser}
             busy={busy}
@@ -835,9 +831,9 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
                 </div>
               </>
             ) : null}
-            <div className="sectionTitle">Granting policies</div>
+            <div className="sectionTitle">Granting access</div>
             <div className="miniList">
-              {selectedPolicies.length ? selectedPolicies.map((policy) => <button key={policy.kid} type="button">{policy.kid}<span>{policy.tenantId ?? "default"}</span></button>) : <p>No policy grants this service yet.</p>}
+              {selectedPolicies.length ? selectedPolicies.map((policy) => <button key={policy.kid} type="button">{policy.kid}<span>{policy.tenantId ?? "default"}</span></button>) : <p>No active grant includes this service yet.</p>}
             </div>
             <div className="inspectorActions">
               <button type="button" disabled={Boolean(playBlocker)} onClick={() => onPlay(selected)} title={playBlocker ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Try in playground</span></button>
@@ -854,7 +850,7 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
 }
 
 function PolicyChips({ policies }: { policies: KeyPolicy[] }) {
-  if (!policies.length) return <span className="emptyGrant">no policy</span>;
+  if (!policies.length) return <span className="emptyGrant">no grant</span>;
   const first = policies[0];
   return (
     <span className="grantChips">
@@ -1086,18 +1082,18 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
     <div className="entityLayout">
       <section className="mainPane">
         <div className="overviewStrip">
-          <Metric label="active policies" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
+          <Metric label="active grants" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
           <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${new Set(activeKeys.flatMap((key) => key.providers)).size} granted services`} />
           <Metric label="routes" value={String((overview?.openaiCompatibleProviders ?? 0) + (overview?.manifestRoutes ?? 0))} meta={`${overview?.providerCount ?? services.length} providers`} />
           <Metric label="budget" value={formatMicros(totalBudget)} meta={`${formatMicros(totalSpent)} spent`} />
         </div>
-        <EntityTable columns={["policy", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", String(row.providers.length), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
+        <EntityTable columns={["grant", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", String(row.providers.length), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
       </section>
       <aside className="inspector">
         <InspectorHeader icon={BarChart3} title="Usage ledger" subtitle="tenant budgets and grant health" />
-        <dl className="facts"><dt>active policies</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(totalBudget)}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
+        <dl className="facts"><dt>active grants</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(totalBudget)}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
         <div className="sectionTitle">Tenants</div>
-        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} policies · {tenant.providers.length} services</span></button>) : <p>No tenant policy coverage yet.</p>}</div>
+        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {tenant.providers.length} services</span></button>) : <p>No tenant grants yet.</p>}</div>
         <div className="sectionTitle">Needs configuration</div>
         <div className="miniList">{blockedServices.length ? blockedServices.slice(0, 8).map((service) => <button type="button" key={service.id}>{service.name}<span>{readinessLabel(service.readiness)}</span></button>) : <p>All visible services are executable.</p>}</div>
       </aside>
@@ -1413,6 +1409,27 @@ function groupedProviders(providers: ProviderRow[], query: string) {
   return Array.from(groups.entries())
     .map(([kind, groupProviders]) => ({ kind, providers: groupProviders.sort((a, b) => a.display_name.localeCompare(b.display_name)) }))
     .sort((a, b) => kindLabel(a.kind).localeCompare(kindLabel(b.kind)));
+}
+
+function policyFormFromKey(key: KeyPolicy): PolicyForm {
+  return {
+    kid: key.kid,
+    tokenRole: key.tokenRole ?? "",
+    tenantId: key.tenantId ?? "default",
+    enabled: key.enabled,
+    monthlyBudgetMicros: currencyInput(key.monthlyBudgetMicros),
+    requestCostMicros: key.requestCostMicros?.toString() ?? "",
+    providers: key.providers,
+  };
+}
+
+function accessFormFromUser(user: AccessUser): AccessForm {
+  return {
+    email: user.email,
+    role: user.role,
+    tenantId: user.tenantId,
+    enabled: user.enabled,
+  };
 }
 
 function effectiveAccess(user: AccessUser | undefined, policies: KeyPolicy[], services: ServiceItem[]) {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -708,6 +708,7 @@ function App() {
             allServices={services}
             selected={selectedService}
             policies={keys}
+            policyFallbackAuthoritative={session.role === "admin"}
             query={query}
             setQuery={setQuery}
             kind={kind}
@@ -798,11 +799,12 @@ function App() {
   );
 }
 
-function CatalogScreen({ services, allServices, selected, policies, query, setQuery, kind, setKind, kinds, onSelect, onPlay, onAdd }: {
+function CatalogScreen({ services, allServices, selected, policies, policyFallbackAuthoritative, query, setQuery, kind, setKind, kinds, onSelect, onPlay, onAdd }: {
   services: ServiceItem[];
   allServices: ServiceItem[];
   selected?: ServiceItem;
   policies: KeyPolicy[];
+  policyFallbackAuthoritative: boolean;
   query: string;
   setQuery: (value: string) => void;
   kind: string;
@@ -814,10 +816,10 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
 }) {
   const activePolicies = policies.filter((policy) => policy.enabled);
   const queryMatchedServices = allServices.filter((service) => matchesServiceQuery(service, query));
-  const selectedPolicies = selected ? activePolicies.filter((policy) => policy.providers.includes(selected.provider)) : [];
+  const selectedPolicies = selected ? activePolicies.filter((policy) => policyCoversProvider(policy, selected.provider)) : [];
   const kindCounts = new Map(kinds.map((item) => [item, item === "all" ? queryMatchedServices.length : queryMatchedServices.filter((service) => service.kind === item).length]));
-  const servicePolicies = (service: ServiceItem) => activePolicies.filter((policy) => policy.providers.includes(service.provider));
-  const outcomes = allServices.map((service) => serviceOutcome(service, servicePolicies(service)));
+  const servicePolicies = (service: ServiceItem) => activePolicies.filter((policy) => policyCoversProvider(policy, service.provider));
+  const outcomes = allServices.map((service) => serviceOutcome(service, servicePolicies(service), policyFallbackAuthoritative));
   const usableCount = outcomes.filter((outcome) => outcome.playable).length;
   const grantedCount = allServices.filter((service) => servicePolicies(service).length || service.access?.allowed).length;
   const blockedCount = outcomes.filter((outcome) => outcome.blocked).length;
@@ -837,7 +839,7 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
           columnTemplate="minmax(220px, 1.45fr) 138px minmax(130px, 0.8fr) 120px minmax(150px, 0.9fr)"
           rows={services.map((service) => {
             const policiesForService = servicePolicies(service);
-            const outcome = serviceOutcome(service, policiesForService);
+            const outcome = serviceOutcome(service, policiesForService, policyFallbackAuthoritative);
             return {
               id: service.id,
               active: selected?.id === service.id,
@@ -857,8 +859,8 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
         {selected ? (
           <>
             {(() => {
-              const outcome = serviceOutcome(selected, selectedPolicies);
-              const playBlocker = playgroundBlockedForService(selected, selectedPolicies);
+              const outcome = serviceOutcome(selected, selectedPolicies, policyFallbackAuthoritative);
+              const playBlocker = playgroundBlockedForService(selected, selectedPolicies, policyFallbackAuthoritative);
               return (
                 <>
             <InspectorHeader brandIcon={selected.brandIcon} icon={kindIcon(selected.kind)} title={selected.name} subtitle={`${kindLabel(selected.kind)} · ${selected.category}`} />
@@ -1346,12 +1348,21 @@ function grantNamesForService(service: ServiceItem, policies: KeyPolicy[] = []) 
   return unique([...policies.map((policy) => policy.kid), ...(service.access?.policies ?? [])]);
 }
 
-function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): ServiceOutcome {
+function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = [], policyFallbackAuthoritative = false): ServiceOutcome {
   const grantedBySession = Boolean(service.access?.allowed);
   const explicitlyDenied = service.access ? !service.access.allowed : false;
   const granted = grantedBySession || policies.length > 0;
   const policyNames = service.access?.policies.length ? service.access.policies : policies.map((policy) => policy.kid);
   if (!granted) {
+    if (!service.access && !policyFallbackAuthoritative) {
+      return {
+        label: "unknown",
+        detail: "Access entitlements are unavailable, so this identity's grant status cannot be determined.",
+        tone: "neutral",
+        playable: false,
+        blocked: false,
+      };
+    }
     return {
       label: explicitlyDenied ? "denied" : "not granted",
       detail: explicitlyDenied ? "Current Cloudflare Access identity is denied by policy." : "No active grant currently includes this service.",
@@ -1484,6 +1495,10 @@ function policyFormFromKey(key: KeyPolicy): PolicyForm {
   };
 }
 
+function policyCoversProvider(policy: KeyPolicy, providerId: string) {
+  return policy.providers.length === 0 || policy.providers.includes(providerId);
+}
+
 function accessFormFromUser(user: AccessUser): AccessForm {
   return {
     email: user.email,
@@ -1525,11 +1540,13 @@ function tenantSummaryFallback(keys: KeyPolicy[]): AdminTenantSummary[] {
     const tenantId = key.tenantId ?? "default";
     const current = acc.get(tenantId) ?? { tenantId, keys: 0, activeKeys: 0, providers: new Set<string>(), allProviders: false, monthlyBudgetMicros: 0, requestCostMicros: 0 };
     current.keys += 1;
-    if (key.enabled) current.activeKeys += 1;
-    if (key.providers.length) {
-      key.providers.forEach((provider) => current.providers.add(provider));
-    } else {
-      current.allProviders = true;
+    if (key.enabled) {
+      current.activeKeys += 1;
+      if (key.providers.length) {
+        key.providers.forEach((provider) => current.providers.add(provider));
+      } else {
+        current.allProviders = true;
+      }
     }
     current.monthlyBudgetMicros += key.monthlyBudgetMicros ?? 0;
     current.requestCostMicros += key.requestCostMicros ?? 0;
@@ -1696,8 +1713,8 @@ function playgroundBlocker(form: PlaygroundForm, model: CatalogModel | undefined
   return null;
 }
 
-function playgroundBlockedForService(service: ServiceItem, policies: KeyPolicy[] = []) {
-  const outcome = serviceOutcome(service, policies);
+function playgroundBlockedForService(service: ServiceItem, policies: KeyPolicy[] = [], policyFallbackAuthoritative = false) {
+  const outcome = serviceOutcome(service, policies, policyFallbackAuthoritative);
   if (!outcome.playable) return outcome.detail;
   if (service.readiness && !service.readiness.executable) return service.readiness.reasons[0] ?? `service is ${readinessLabel(service.readiness)}`;
   if (!service.models && service.surfaces.includes("provider")) return "no executable model or proxy route declared";
@@ -1795,7 +1812,7 @@ function demoData() {
   const entitlements: EntitlementsResponse = {
     session,
     providers: providers.map((item) => {
-      const policies = keys.filter((key) => key.enabled && (key.tenantId ?? "default") === session.tenantId && key.providers.includes(item.id)).map((key) => key.kid);
+      const policies = keys.filter((key) => key.enabled && (key.tenantId ?? "default") === session.tenantId && policyCoversProvider(key, item.id)).map((key) => key.kid);
       return {
         provider: item.id,
         displayName: item.display_name,

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -29,6 +29,11 @@ const pathViews: Record<string, View> = {
   "/catalog": "catalog",
   "/console": "catalog",
   "/dashboard": "catalog",
+  "/dashboard/access": "policies",
+  "/dashboard/catalog": "catalog",
+  "/dashboard/playground": "playground",
+  "/dashboard/usage": "usage",
+  "/dashboard/users": "users",
   "/policies": "policies",
   "/playground": "playground",
   "/routes": "catalog",
@@ -38,11 +43,11 @@ const pathViews: Record<string, View> = {
 };
 
 const viewPaths: Record<View, string> = {
-  catalog: "/catalog",
-  playground: "/playground",
-  policies: "/access",
-  users: "/users",
-  usage: "/usage",
+  catalog: "/dashboard/catalog",
+  playground: "/dashboard/playground",
+  policies: "/dashboard/access",
+  users: "/dashboard/users",
+  usage: "/dashboard/usage",
 };
 
 function initialViewFromPath(): View {
@@ -1101,6 +1106,10 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
   const blockedServices = services.filter((service) => service.readiness && !service.readiness.executable);
   const rows = usageRows.length ? usageRows : keys.map(policyUsageFallback);
   const tenantRows = tenants.length ? tenants : tenantSummaryFallback(keys);
+  const serviceProviderCount = new Set(services.map((service) => service.provider)).size;
+  const grantedServiceCount = activeKeys.some((key) => key.providers.length === 0)
+    ? serviceProviderCount
+    : new Set(activeKeys.flatMap((key) => key.providers)).size;
   const totalBudget = overview?.monthlyBudgetMicros ?? keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
   const trackedRows = rows.filter((row) => row.budget.configured);
   const totalSpent = trackedRows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
@@ -1113,17 +1122,17 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
       <section className="mainPane">
         <div className="overviewStrip">
           <Metric label="active grants" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
-          <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${new Set(activeKeys.flatMap((key) => key.providers)).size} granted services`} />
+          <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${grantedServiceCount} granted services`} />
           <Metric label="routes" value={String(routeTotal)} meta={`${providerTotal} providers`} />
           <Metric label="budget" value={formatMicros(totalBudget)} meta={`${formatMicros(totalSpent)} spent`} />
         </div>
-        <EntityTable columns={["grant", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", String(row.providers.length), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
+        <EntityTable columns={["grant", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", effectiveProviderCount(row.providers, services), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
       </section>
       <aside className="inspector">
         <InspectorHeader icon={BarChart3} title="Usage ledger" subtitle="tenant budgets and grant health" />
         <dl className="facts"><dt>active grants</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(totalBudget)}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
         <div className="sectionTitle">Tenants</div>
-        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {tenant.providers.length} services</span></button>) : <p>No tenant grants yet.</p>}</div>
+        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {effectiveProviderCount(tenant.providers, services)} services</span></button>) : <p>No tenant grants yet.</p>}</div>
         <div className="sectionTitle">Needs configuration</div>
         <div className="miniList">{blockedServices.length ? blockedServices.slice(0, 8).map((service) => <button type="button" key={service.id}>{service.name}<span>{readinessLabel(service.readiness)}</span></button>) : <p>All visible services are executable.</p>}</div>
       </aside>
@@ -1412,6 +1421,11 @@ function formatMicros(value: number | null | undefined) {
   if (value === undefined || value === null) return "unknown";
   if (!value) return "none";
   return `$${(value / 1_000_000).toFixed(2)}`;
+}
+
+function effectiveProviderCount(providerIds: string[], services: ServiceItem[]) {
+  if (providerIds.length) return String(providerIds.length);
+  return `all ${new Set(services.map((service) => service.provider)).size}`;
 }
 
 function catalogModels(routes: RouteCatalog): CatalogModel[] {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -24,12 +24,25 @@ type View = "catalog" | "playground" | "policies" | "users" | "usage";
 
 const pathViews: Record<string, View> = {
   "/": "catalog",
+  "/access": "policies",
   "/admin": "policies",
+  "/catalog": "catalog",
   "/console": "catalog",
   "/dashboard": "catalog",
+  "/policies": "policies",
   "/playground": "playground",
   "/routes": "catalog",
   "/account": "users",
+  "/usage": "usage",
+  "/users": "users",
+};
+
+const viewPaths: Record<View, string> = {
+  catalog: "/catalog",
+  playground: "/playground",
+  policies: "/access",
+  users: "/users",
+  usage: "/usage",
 };
 
 function initialViewFromPath(): View {
@@ -130,6 +143,46 @@ interface AccessUser {
   enabled: boolean;
 }
 
+interface AdminOverview {
+  keysTotal: number;
+  keysActive: number;
+  tenantsTotal: number;
+  providerCount: number;
+  openaiCompatibleProviders: number;
+  manifestRoutes: number;
+  monthlyBudgetMicros: number;
+  requestCostMicros: number;
+}
+
+interface AdminTenantSummary {
+  tenantId: string;
+  keys: number;
+  activeKeys: number;
+  providers: string[];
+  monthlyBudgetMicros: number;
+  requestCostMicros: number;
+}
+
+interface BudgetStatus {
+  configured: boolean;
+  ledger: string;
+  windowKey?: string | null;
+  limitMicros?: number | null;
+  spentMicros?: number | null;
+  remainingMicros?: number | null;
+}
+
+interface AdminUsageRow {
+  kid: string;
+  tenantId: string;
+  enabled: boolean;
+  providers: string[];
+  tokenRole?: string | null;
+  monthlyBudgetMicros?: number | null;
+  requestCostMicros?: number | null;
+  budget: BudgetStatus;
+}
+
 interface ServiceItem {
   id: string;
   name: string;
@@ -209,7 +262,7 @@ const rolePresets = {
 const navItems: Array<{ id: View; label: string; icon: IconComponent }> = [
   { id: "catalog", label: "Catalog", icon: Boxes },
   { id: "playground", label: "Playground", icon: FlaskConical },
-  { id: "policies", label: "Policies", icon: KeyRound },
+  { id: "policies", label: "Access", icon: KeyRound },
   { id: "users", label: "Users", icon: Users },
   { id: "usage", label: "Usage", icon: BarChart3 },
 ];
@@ -223,6 +276,9 @@ function App() {
   const [routes, setRoutes] = useState<RouteCatalog>(allowDemo ? demo.routes : emptyRoutes);
   const [keys, setKeys] = useState<KeyPolicy[]>(allowDemo ? demo.keys : []);
   const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
+  const [adminOverview, setAdminOverview] = useState<AdminOverview | null>(allowDemo ? demo.overview : null);
+  const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
+  const [usageRows, setUsageRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
   const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
   const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {});
   const [policyForm, setPolicyForm] = useState<PolicyForm>(defaultPolicy);
@@ -275,6 +331,12 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const onPopState = () => setView(initialViewFromPath());
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  useEffect(() => {
     if (models.length && !models.some((model) => model.id === playground.model)) {
       setPlayground((current) => ({ ...current, model: models[0].id }));
     }
@@ -316,13 +378,19 @@ function App() {
         }
       }
       if (sessionData.role === "admin") {
-        const [keyData, userData, readinessData] = await Promise.all([
+        const [keyData, userData, readinessData, overviewData, tenantData, usageData] = await Promise.all([
           request<{ keys: KeyPolicy[] }>(gatewayOrigin, "/v1/admin/keys"),
           request<{ users: AccessUser[] }>(gatewayOrigin, "/v1/admin/access-users"),
           request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
+          request<AdminOverview>(gatewayOrigin, "/v1/admin/overview"),
+          request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/users"),
+          request<{ keys: AdminUsageRow[] }>(gatewayOrigin, "/v1/admin/usage"),
         ]);
         setKeys(keyData.keys);
         setUsers(userData.users);
+        setAdminOverview(overviewData);
+        setTenantSummaries(tenantData.tenants);
+        setUsageRows(usageData.keys);
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
       } else {
         const user = {
@@ -333,6 +401,9 @@ function App() {
         };
         setKeys([]);
         setUsers([user]);
+        setAdminOverview(null);
+        setTenantSummaries([]);
+        setUsageRows([]);
         setSelectedUserEmail(user.email);
         setAccessForm(user);
       }
@@ -346,6 +417,9 @@ function App() {
         setRoutes(demo.routes);
         setKeys(demo.keys);
         setUsers(demo.users);
+        setAdminOverview(demo.overview);
+        setTenantSummaries(demo.tenants);
+        setUsageRows(demo.usageRows);
         setEntitlements(demo.entitlements);
         setProviderReadiness(readinessMap(demo.entitlements.providers.map((item) => item.readiness)));
         setDemoMode(true);
@@ -518,6 +592,14 @@ function App() {
     }));
   }
 
+  function navigateTo(nextView: View) {
+    setView(nextView);
+    const nextPath = viewPaths[nextView];
+    if (window.location.pathname !== nextPath) {
+      window.history.pushState(null, "", `${nextPath}${window.location.search}${window.location.hash}`);
+    }
+  }
+
   return (
     <main className="appShell">
       <aside className="sidebar">
@@ -532,7 +614,7 @@ function App() {
         </div>
         <nav className="navTabs" aria-label="console">
           {navItems.map(({ id, label, icon: Icon }) => (
-            <button key={id} className={view === id ? "active" : ""} type="button" onClick={() => setView(id)}>
+            <button key={id} className={view === id ? "active" : ""} type="button" onClick={() => navigateTo(id)}>
               <Icon className="navIcon" aria-hidden="true" />
               <span>{label}</span>
             </button>
@@ -578,14 +660,14 @@ function App() {
               setPlayground((current) => model
                 ? { ...current, mode: "model", model: model.id }
                 : proxyRoute ? { ...current, mode: "service", serviceRoute: routeKey(proxyRoute), serviceMethod: proxyRoute.methods[0] ?? "POST" } : current);
-              setView("playground");
+              navigateTo("playground");
             }}
             onAdd={(service) => {
               setPolicyForm((current) => ({
                 ...current,
                 providers: current.providers.includes(service.provider) ? current.providers : [...current.providers, service.provider].sort(),
               }));
-              setView("policies");
+              navigateTo("policies");
             }}
           />
         ) : null}
@@ -639,7 +721,7 @@ function App() {
             error={userError}
             onOpenPolicy={(policy) => {
               editPolicy(policy);
-              setView("policies");
+              navigateTo("policies");
             }}
             onSelect={(user) => {
               setSelectedUserEmail(user.email);
@@ -650,7 +732,7 @@ function App() {
           />
         ) : null}
 
-        {view === "usage" ? <UsageScreen keys={keys} services={services} /> : null}
+        {view === "usage" ? <UsageScreen keys={keys} services={services} overview={adminOverview} tenants={tenantSummaries} usageRows={usageRows} /> : null}
       </section>
     </main>
   );
@@ -951,24 +1033,39 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
   );
 }
 
-function UsageScreen({ keys, services }: { keys: KeyPolicy[]; services: ServiceItem[] }) {
+function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: KeyPolicy[]; services: ServiceItem[]; overview: AdminOverview | null; tenants: AdminTenantSummary[]; usageRows: AdminUsageRow[] }) {
   const activeKeys = keys.filter((key) => key.enabled);
   const readyServices = readyCount(services);
-  const missingServices = services.filter((service) => service.readiness?.status === "missing_config");
   const blockedServices = services.filter((service) => service.readiness && !service.readiness.executable);
+  const rows = usageRows.length ? usageRows : keys.map(policyUsageFallback);
+  const tenantRows = tenants.length ? tenants : tenantSummaryFallback(keys);
+  const totalBudget = overview?.monthlyBudgetMicros ?? activeKeys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
+  const totalSpent = rows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
   return (
     <div className="entityLayout">
       <section className="mainPane">
-        <EntityTable columns={["policy", "tenant", "budget", "request cost", "services"]} columnTemplate="minmax(240px, 1.5fr) 150px 140px 140px 120px" rows={keys.map((key) => ({ id: key.kid, cells: [<EntityName icon={KeyRound} title={key.kid} subtitle={key.tokenRole ?? "custom"} />, key.tenantId ?? "default", formatBudget(key.monthlyBudgetMicros), formatMicros(key.requestCostMicros), String(key.providers.length)] }))} />
+        <div className="overviewStrip">
+          <Metric label="active policies" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
+          <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${new Set(activeKeys.flatMap((key) => key.providers)).size} granted services`} />
+          <Metric label="routes" value={String((overview?.openaiCompatibleProviders ?? 0) + (overview?.manifestRoutes ?? 0))} meta={`${overview?.providerCount ?? services.length} providers`} />
+          <Metric label="budget" value={formatMicros(totalBudget)} meta={`${formatMicros(totalSpent)} spent`} />
+        </div>
+        <EntityTable columns={["policy", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", String(row.providers.length), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
       </section>
       <aside className="inspector">
-        <InspectorHeader icon={BarChart3} title="Budget ledger" subtitle="policy coverage, not request analytics yet" />
-        <dl className="facts"><dt>active policies</dt><dd>{activeKeys.length}</dd><dt>granted services</dt><dd>{new Set(activeKeys.flatMap((key) => key.providers)).size}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>missing config</dt><dd>{missingServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(activeKeys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0))}</dd></dl>
+        <InspectorHeader icon={BarChart3} title="Usage ledger" subtitle="tenant budgets and grant health" />
+        <dl className="facts"><dt>active policies</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(totalBudget)}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
+        <div className="sectionTitle">Tenants</div>
+        <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} policies · {tenant.providers.length} services</span></button>) : <p>No tenant policy coverage yet.</p>}</div>
         <div className="sectionTitle">Needs configuration</div>
         <div className="miniList">{blockedServices.length ? blockedServices.slice(0, 8).map((service) => <button type="button" key={service.id}>{service.name}<span>{readinessLabel(service.readiness)}</span></button>) : <p>All visible services are executable.</p>}</div>
       </aside>
     </div>
   );
+}
+
+function Metric({ label, value, meta }: { label: string; value: string; meta: string }) {
+  return <div className="metric"><span>{label}</span><strong>{value}</strong><small>{meta}</small></div>;
 }
 
 function EntityTable({ columns, columnTemplate, rows }: { columns: string[]; columnTemplate?: string; rows: Array<{ id: string; active?: boolean; onClick?: () => void; cells: React.ReactNode[] }> }) {
@@ -1237,6 +1334,40 @@ function effectiveAccess(user: AccessUser | undefined, policies: KeyPolicy[], se
   return { policies: userPolicies, services: services.filter((service) => providerIds.has(service.provider)) };
 }
 
+function policyUsageFallback(policy: KeyPolicy): AdminUsageRow {
+  return {
+    kid: policy.kid,
+    tenantId: policy.tenantId ?? "default",
+    enabled: policy.enabled,
+    providers: policy.providers,
+    tokenRole: policy.tokenRole,
+    monthlyBudgetMicros: policy.monthlyBudgetMicros,
+    requestCostMicros: policy.requestCostMicros,
+    budget: {
+      configured: false,
+      ledger: "untracked",
+      limitMicros: policy.monthlyBudgetMicros,
+      spentMicros: 0,
+      remainingMicros: policy.monthlyBudgetMicros,
+    },
+  };
+}
+
+function tenantSummaryFallback(keys: KeyPolicy[]): AdminTenantSummary[] {
+  const groups = keys.reduce((acc, key) => {
+    const tenantId = key.tenantId ?? "default";
+    const current = acc.get(tenantId) ?? { tenantId, keys: 0, activeKeys: 0, providers: new Set<string>(), monthlyBudgetMicros: 0, requestCostMicros: 0 };
+    current.keys += 1;
+    if (key.enabled) current.activeKeys += 1;
+    key.providers.forEach((provider) => current.providers.add(provider));
+    current.monthlyBudgetMicros += key.monthlyBudgetMicros ?? 0;
+    current.requestCostMicros += key.requestCostMicros ?? 0;
+    acc.set(tenantId, current);
+    return acc;
+  }, new Map<string, { tenantId: string; keys: number; activeKeys: number; providers: Set<string>; monthlyBudgetMicros: number; requestCostMicros: number }>());
+  return Array.from(groups.values()).map((tenant) => ({ ...tenant, providers: Array.from(tenant.providers).sort() }));
+}
+
 function serviceItems(providers: ProviderRow[], routes: RouteCatalog, readinessByProvider: Record<string, ProviderReadiness> = {}, accessByProvider: Map<string, ProviderAccess> = new Map()): ServiceItem[] {
   const providerById = new Map(providers.map((provider) => [provider.id, provider]));
   const modelServices = routes.openaiCompatible.map((route) => {
@@ -1488,7 +1619,19 @@ function demoData() {
   };
   const accessByProvider = accessMap(entitlements);
   const readinessByProvider = readinessMap(entitlements.providers.map((item) => item.readiness));
-  return { session, providers, routes, keys, users, entitlements, services: serviceItems(providers, routes, readinessByProvider, accessByProvider), models };
+  const usageRows = keys.map(policyUsageFallback);
+  const tenants = tenantSummaryFallback(keys);
+  const overview: AdminOverview = {
+    keysTotal: keys.length,
+    keysActive: keys.filter((key) => key.enabled).length,
+    tenantsTotal: tenants.length,
+    providerCount: providers.length,
+    openaiCompatibleProviders: routes.openaiCompatible.length,
+    manifestRoutes: routes.manifestProxy.length,
+    monthlyBudgetMicros: keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0),
+    requestCostMicros: keys.reduce((total, key) => total + (key.requestCostMicros ?? 0), 0),
+  };
+  return { session, providers, routes, keys, users, overview, tenants, usageRows, entitlements, services: serviceItems(providers, routes, readinessByProvider, accessByProvider), models };
 }
 
 function demoReadiness(provider: ProviderRow, routes: RouteCatalog): ProviderReadiness {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -413,7 +413,6 @@ function App() {
           request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
         ]);
         setKeys(keyData.keys);
-        setPolicyDataLoaded(true);
         setUsers(userData.users);
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
         const [overviewResult, tenantResult] = await Promise.all([
@@ -434,6 +433,7 @@ function App() {
         }
         setUsageRows([]);
         setUsageLoaded(false);
+        setPolicyDataLoaded(true);
         if (view === "usage") setUsageRefreshKey((current) => current + 1);
       } else {
         const user = {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -192,6 +192,7 @@ interface ServiceItem {
   capabilities: string[];
   surfaces: string[];
   route: string;
+  routeCount: number;
   models: number;
   modelIds: string[];
   access?: ProviderAccess;
@@ -388,20 +389,37 @@ function App() {
         }
       }
       if (sessionData.role === "admin") {
-        const [keyData, userData, readinessData, overviewData, tenantData, usageData] = await Promise.all([
+        const [keyData, userData, readinessData] = await Promise.all([
           request<{ keys: KeyPolicy[] }>(gatewayOrigin, "/v1/admin/keys"),
           request<{ users: AccessUser[] }>(gatewayOrigin, "/v1/admin/access-users"),
           request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
-          request<AdminOverview>(gatewayOrigin, "/v1/admin/overview"),
-          request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/users"),
-          request<{ keys: AdminUsageRow[] }>(gatewayOrigin, "/v1/admin/usage"),
         ]);
         setKeys(keyData.keys);
         setUsers(userData.users);
-        setAdminOverview(overviewData);
-        setTenantSummaries(tenantData.tenants);
-        setUsageRows(usageData.keys);
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
+        const [overviewResult, tenantResult, usageResult] = await Promise.all([
+          settled(() => request<AdminOverview>(gatewayOrigin, "/v1/admin/overview")),
+          settled(() => request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/users")),
+          settled(() => request<{ keys: AdminUsageRow[] }>(gatewayOrigin, "/v1/admin/usage")),
+        ]);
+        if (overviewResult.ok) {
+          setAdminOverview(overviewResult.value);
+        } else {
+          setAdminOverview(null);
+          refreshWarnings = [...refreshWarnings, `overview unavailable: ${overviewResult.error}`];
+        }
+        if (tenantResult.ok) {
+          setTenantSummaries(tenantResult.value.tenants);
+        } else {
+          setTenantSummaries(tenantSummaryFallback(keyData.keys));
+          refreshWarnings = [...refreshWarnings, `tenant summary unavailable: ${tenantResult.error}`];
+        }
+        if (usageResult.ok) {
+          setUsageRows(usageResult.value.keys);
+        } else {
+          setUsageRows(keyData.keys.map(policyUsageFallback));
+          refreshWarnings = [...refreshWarnings, `usage ledger unavailable: ${usageResult.error}`];
+        }
       } else {
         const user = {
           email: sessionData.email ?? "access-user",
@@ -791,8 +809,8 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
               cells: [
                 <EntityName brandIcon={service.brandIcon} icon={kindIcon(service.kind)} title={service.name} subtitle={`${service.provider} · ${kindLabel(service.kind)}`} />,
                 <OutcomeStatus outcome={outcome} />,
-                <PolicyChips policies={policiesForService} />,
-                service.models ? `${service.models} models` : `${service.surfaces.length} route${service.surfaces.length === 1 ? "" : "s"}`,
+                <GrantChips names={grantNamesForService(service, policiesForService)} />,
+                service.models ? `${service.models} models` : `${service.routeCount} route${service.routeCount === 1 ? "" : "s"}`,
                 service.surfaces.join(", "),
               ],
             };
@@ -817,7 +835,7 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
               <dt>routes</dt><dd>{selected.route}</dd>
               <dt>surfaces</dt><dd>{selected.surfaces.join(", ")}</dd>
               <dt>models</dt><dd>{selected.models || "n/a"}</dd>
-              <dt>grant</dt><dd>{selectedPolicies.length ? selectedPolicies.map((policy) => policy.kid).join(", ") : selected.access?.allowed ? selected.access.policies.join(", ") || "session" : "none"}</dd>
+              <dt>grant</dt><dd>{grantNamesForService(selected, selectedPolicies).join(", ") || "none"}</dd>
               <dt>readiness</dt><dd>{readinessLabel(selected.readiness)}</dd>
               <dt>missing</dt><dd>{selected.readiness?.missingConfig.length ? selected.readiness.missingConfig.join(", ") : "none"}</dd>
               <dt>oauth grants</dt><dd>{selected.readiness?.oauthGrantRequired ? selected.readiness.oauthGrantCount : "n/a"}</dd>
@@ -833,7 +851,7 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
             ) : null}
             <div className="sectionTitle">Granting access</div>
             <div className="miniList">
-              {selectedPolicies.length ? selectedPolicies.map((policy) => <button key={policy.kid} type="button">{policy.kid}<span>{policy.tenantId ?? "default"}</span></button>) : <p>No active grant includes this service yet.</p>}
+              {grantNamesForService(selected, selectedPolicies).length ? grantNamesForService(selected, selectedPolicies).map((grant) => <button key={grant} type="button">{grant}<span>{selectedPolicies.find((policy) => policy.kid === grant)?.tenantId ?? "entitlement"}</span></button>) : <p>No active grant includes this service yet.</p>}
             </div>
             <div className="inspectorActions">
               <button type="button" disabled={Boolean(playBlocker)} onClick={() => onPlay(selected)} title={playBlocker ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Try in playground</span></button>
@@ -849,13 +867,13 @@ function CatalogScreen({ services, allServices, selected, policies, query, setQu
   );
 }
 
-function PolicyChips({ policies }: { policies: KeyPolicy[] }) {
-  if (!policies.length) return <span className="emptyGrant">no grant</span>;
-  const first = policies[0];
+function GrantChips({ names }: { names: string[] }) {
+  if (!names.length) return <span className="emptyGrant">no grant</span>;
+  const first = names[0];
   return (
     <span className="grantChips">
-      <span className="grantChip" title={first.kid}>{first.kid}</span>
-      {policies.length > 1 ? <span className="grantMore" title={policies.slice(1).map((policy) => policy.kid).join(", ")}>+{policies.length - 1}</span> : null}
+      <span className="grantChip" title={first}>{first}</span>
+      {names.length > 1 ? <span className="grantMore" title={names.slice(1).join(", ")}>+{names.length - 1}</span> : null}
     </span>
   );
 }
@@ -1036,16 +1054,14 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
 }) {
   const accessForUser = (user: AccessUser | undefined) => effectiveAccess(user, policies, services);
   const selectedAccess = accessForUser(selected);
-  const selectedOutcomes = selectedAccess.services.map((service) => ({ service, outcome: serviceOutcome(service, selectedAccess.policies.filter((policy) => policy.providers.includes(service.provider))) }));
-  const selectedUsable = selectedOutcomes.filter((item) => item.outcome.playable).length;
-  const selectedBlocked = selectedOutcomes.filter((item) => item.outcome.blocked).length;
+  const selectedServices = selectedAccess.services.map((service) => ({ service, label: userServiceGrantLabel(service) }));
+  const selectedBlocked = selectedServices.filter(({ service }) => !service.readiness?.executable).length;
   return (
     <div className="entityLayout">
       <section className="mainPane">
-        <EntityTable columns={["identity", "role", "tenant", "grants", "usable", "status"]} columnTemplate="minmax(260px, 1.5fr) 90px 130px 96px 96px 116px" rows={users.map((user) => {
+        <EntityTable columns={["identity", "role", "tenant", "grants", "services", "status"]} columnTemplate="minmax(260px, 1.5fr) 90px 130px 96px 96px 116px" rows={users.map((user) => {
           const access = accessForUser(user);
-          const usable = access.services.filter((service) => serviceOutcome(service, access.policies.filter((policy) => policy.providers.includes(service.provider))).playable).length;
-          return { id: user.email, active: selected?.email === user.email, onClick: () => onSelect(user), cells: [<EntityName icon={Users} title={user.email} subtitle="Cloudflare Access" />, user.role, user.tenantId, String(access.policies.length), `${usable}/${access.services.length}`, <Status label={user.enabled ? "enabled" : "disabled"} tone={user.enabled ? "active" : "revoked"} />] };
+          return { id: user.email, active: selected?.email === user.email, onClick: () => onSelect(user), cells: [<EntityName icon={Users} title={user.email} subtitle="Cloudflare Access" />, user.role, user.tenantId, String(access.policies.length), String(access.services.length), <Status label={user.enabled ? "enabled" : "disabled"} tone={user.enabled ? "active" : "revoked"} />] };
         })} />
       </section>
       <aside className="inspector">
@@ -1058,11 +1074,11 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
             <label><span>tenant</span><input value={form.tenantId} onChange={(event) => setForm({ ...form, tenantId: event.target.value })} /></label>
             <label><span>status</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
           </div>
-          <dl className="facts"><dt>usable services</dt><dd>{selectedUsable}/{selectedAccess.services.length}</dd><dt>blocked services</dt><dd>{selectedBlocked}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
+          <dl className="facts"><dt>granted services</dt><dd>{selectedAccess.services.length}</dd><dt>blocked/unknown</dt><dd>{selectedBlocked}</dd><dt>active grants</dt><dd>{selectedAccess.policies.length}</dd><dt>role</dt><dd>{selected?.role ?? "user"}</dd><dt>tenant</dt><dd>{selected?.tenantId ?? form.tenantId}</dd></dl>
           <div className="sectionTitle">Tenant grants</div>
           <div className="miniList">{selectedAccess.policies.length ? selectedAccess.policies.map((policy) => <button type="button" key={policy.kid} onClick={() => onOpenPolicy(policy)}>{policy.kid}<span>{policy.providers.length} services · {formatBudget(policy.monthlyBudgetMicros)}</span></button>) : <p>No active grant gives this tenant service access.</p>}</div>
           <div className="sectionTitle">Effective access</div>
-          <div className="miniList">{selectedOutcomes.length ? selectedOutcomes.slice(0, 8).map(({ service, outcome }) => <button type="button" key={service.id}>{service.name}<span>{outcome.label} · {kindLabel(service.kind)}</span></button>) : <p>No services available for this user.</p>}</div>
+          <div className="miniList">{selectedServices.length ? selectedServices.slice(0, 8).map(({ service, label }) => <button type="button" key={service.id}>{service.name}<span>{label} · {kindLabel(service.kind)}</span></button>) : <p>No services available for this user.</p>}</div>
           <div className="inspectorActions"><button type="submit" disabled={busy}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save user</span></button></div>
         </form>
       </aside>
@@ -1278,6 +1294,10 @@ function readyCount(services: ServiceItem[]) {
   return services.filter((service) => service.readiness?.status === "ready").length;
 }
 
+function grantNamesForService(service: ServiceItem, policies: KeyPolicy[] = []) {
+  return unique([...policies.map((policy) => policy.kid), ...(service.access?.policies ?? [])]);
+}
+
 function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): ServiceOutcome {
   const grantedBySession = Boolean(service.access?.allowed);
   const explicitlyDenied = service.access ? !service.access.allowed : false;
@@ -1319,6 +1339,11 @@ function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): Servi
     playable: false,
     blocked: true,
   };
+}
+
+function userServiceGrantLabel(service: ServiceItem) {
+  if (!service.readiness) return "readiness unknown";
+  return service.readiness.executable ? "granted" : readinessLabel(service.readiness);
 }
 
 function readinessLabel(readiness: ProviderReadiness | undefined) {
@@ -1477,6 +1502,7 @@ function serviceItems(providers: ProviderRow[], routes: RouteCatalog, readinessB
       capabilities: unique([...(provider?.capabilities.map((capability) => capability.id) ?? []), ...modelCapabilities]),
       surfaces: unique([...route.endpoints, ...modelEndpoints]),
       route: route.endpoints.join(", ") || "/v1/chat/completions",
+      routeCount: unique([...route.endpoints, ...modelEndpoints]).length,
       models: route.models.length,
       modelIds: route.models.map((model) => model.id),
       access: accessByProvider.get(route.provider),
@@ -1499,6 +1525,7 @@ function serviceItems(providers: ProviderRow[], routes: RouteCatalog, readinessB
       capabilities: provider?.capabilities.map((capability) => capability.id) ?? [],
       surfaces: unique(providerRoutes.flatMap((route) => route.methods)),
       route: providerRoutes.map((route) => route.route).join(", "),
+      routeCount: providerRoutes.length,
       models: 0,
       modelIds: [],
       access: accessByProvider.get(providerId),
@@ -1517,6 +1544,7 @@ function serviceItems(providers: ProviderRow[], routes: RouteCatalog, readinessB
       capabilities: provider.capabilities.map((capability) => capability.id),
       surfaces: ["provider"],
       route: "/v1/proxy",
+      routeCount: 0,
       models: 0,
       modelIds: [],
       access: accessByProvider.get(provider.id),

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1471,9 +1471,10 @@ function accessFormFromUser(user: AccessUser): AccessForm {
 
 function effectiveAccess(user: AccessUser | undefined, policies: KeyPolicy[], services: ServiceItem[]) {
   if (!user || !user.enabled) return { policies: [] as KeyPolicy[], services: [] as ServiceItem[] };
-  const userPolicies = policies.filter((policy) => policy.enabled && (policy.tenantId ?? "default") === user.tenantId);
+  const userPolicies = policies.filter((policy) => policy.enabled && (user.role === "admin" || (policy.tenantId ?? "default") === user.tenantId));
+  const hasWildcardGrant = userPolicies.some((policy) => policy.providers.length === 0);
   const providerIds = new Set(userPolicies.flatMap((policy) => policy.providers));
-  return { policies: userPolicies, services: services.filter((service) => providerIds.has(service.provider)) };
+  return { policies: userPolicies, services: services.filter((service) => hasWildcardGrant || providerIds.has(service.provider)) };
 }
 
 function policyUsageFallback(policy: KeyPolicy): AdminUsageRow {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -359,10 +359,10 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (view === "usage" && session.role === "admin" && !demoMode && !usageLoaded) {
+    if (view === "usage" && session.role === "admin" && policyDataLoaded && !demoMode && !usageLoaded) {
       void refreshUsageLedger();
     }
-  }, [demoMode, session.role, usageLoaded, usageRefreshKey, view]);
+  }, [demoMode, policyDataLoaded, session.role, usageLoaded, usageRefreshKey, view]);
 
   useEffect(() => {
     if (models.length && !models.some((model) => model.id === playground.model)) {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1172,13 +1172,6 @@ function ReadinessStatus({ readiness }: { readiness?: ProviderReadiness }) {
   return <Status label={readinessLabel(readiness)} tone={tone} />;
 }
 
-function AccessStatus({ service, policies }: { service: ServiceItem; policies: KeyPolicy[] }) {
-  if (service.access) {
-    return <Status label={service.access.allowed ? "allowed" : "denied"} tone={service.access.allowed ? "active" : "revoked"} />;
-  }
-  return <PolicyChips policies={policies} />;
-}
-
 function viewTitle(view: View) {
   return ({ catalog: "Catalog", playground: "Playground", policies: "Access", users: "Users", usage: "Usage" } as const)[view];
 }
@@ -1283,10 +1276,6 @@ function accessMap(entitlements: EntitlementsResponse | null) {
 
 function readyCount(services: ServiceItem[]) {
   return services.filter((service) => service.readiness?.status === "ready").length;
-}
-
-function allowedCount(services: ServiceItem[]) {
-  return services.filter((service) => service.access?.allowed).length;
 }
 
 function serviceOutcome(service: ServiceItem, policies: KeyPolicy[] = []): ServiceOutcome {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -295,6 +295,7 @@ function App() {
   const [adminOverview, setAdminOverview] = useState<AdminOverview | null>(allowDemo ? demo.overview : null);
   const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
   const [usageRows, setUsageRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
+  const [usageLoaded, setUsageLoaded] = useState(allowDemo);
   const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
   const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {});
   const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromKey(demo.keys[0]) : defaultPolicy);
@@ -353,6 +354,12 @@ function App() {
   }, []);
 
   useEffect(() => {
+    if (view === "usage" && session.role === "admin" && !demoMode && !usageLoaded) {
+      void refreshUsageLedger();
+    }
+  }, [demoMode, session.role, usageLoaded, view]);
+
+  useEffect(() => {
     if (models.length && !models.some((model) => model.id === playground.model)) {
       setPlayground((current) => ({ ...current, model: models[0].id }));
     }
@@ -402,10 +409,9 @@ function App() {
         setKeys(keyData.keys);
         setUsers(userData.users);
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
-        const [overviewResult, tenantResult, usageResult] = await Promise.all([
+        const [overviewResult, tenantResult] = await Promise.all([
           settled(() => request<AdminOverview>(gatewayOrigin, "/v1/admin/overview")),
           settled(() => request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/users")),
-          settled(() => request<{ keys: AdminUsageRow[] }>(gatewayOrigin, "/v1/admin/usage")),
         ]);
         if (overviewResult.ok) {
           setAdminOverview(overviewResult.value);
@@ -419,12 +425,8 @@ function App() {
           setTenantSummaries(tenantSummaryFallback(keyData.keys));
           refreshWarnings = [...refreshWarnings, `tenant summary unavailable: ${tenantResult.error}`];
         }
-        if (usageResult.ok) {
-          setUsageRows(usageResult.value.keys);
-        } else {
-          setUsageRows(keyData.keys.map(policyUsageFallback));
-          refreshWarnings = [...refreshWarnings, `usage ledger unavailable: ${usageResult.error}`];
-        }
+        setUsageRows([]);
+        setUsageLoaded(false);
       } else {
         const user = {
           email: sessionData.email ?? "access-user",
@@ -437,6 +439,7 @@ function App() {
         setAdminOverview(null);
         setTenantSummaries([]);
         setUsageRows([]);
+        setUsageLoaded(false);
         setSelectedUserEmail(user.email);
         setAccessForm(accessFormFromUser(user));
       }
@@ -453,6 +456,7 @@ function App() {
         setAdminOverview(demo.overview);
         setTenantSummaries(demo.tenants);
         setUsageRows(demo.usageRows);
+        setUsageLoaded(true);
         setEntitlements(demo.entitlements);
         setProviderReadiness(readinessMap(demo.entitlements.providers.map((item) => item.readiness)));
         setSelectedPolicyId(demo.keys[0]?.kid ?? "");
@@ -506,6 +510,19 @@ function App() {
       setPolicyError(message);
       setStatus(message);
     }
+  }
+
+  async function refreshUsageLedger() {
+    if (demoMode || session.role !== "admin") return;
+    const result = await settled(() => request<{ keys: AdminUsageRow[] }>(gatewayOrigin, "/v1/admin/usage"));
+    if (result.ok) {
+      setUsageRows(result.value.keys);
+      setUsageLoaded(true);
+      return;
+    }
+    setUsageRows([]);
+    setUsageLoaded(false);
+    if (view === "usage") setStatus(`usage ledger unavailable: ${result.error}`);
   }
 
   async function saveUser(event: FormEvent) {
@@ -627,6 +644,7 @@ function App() {
       setAdminOverview(adminOverviewFromKeys(next, providers, routes));
       setTenantSummaries(tenantSummaryFallback(next));
       setUsageRows(next.map(policyUsageFallback));
+      setUsageLoaded(true);
       return next;
     });
   }
@@ -771,7 +789,7 @@ function App() {
           />
         ) : null}
 
-        {view === "usage" ? <UsageScreen keys={keys} services={services} overview={adminOverview} tenants={tenantSummaries} usageRows={usageRows} /> : null}
+        {view === "usage" ? <UsageScreen keys={keys} services={services} overview={adminOverview} tenants={tenantSummaries} usageRows={usageRows} usageLoaded={usageLoaded} /> : null}
       </section>
     </main>
   );
@@ -1100,7 +1118,7 @@ function UsersScreen({ users, selected, policies, services, form, setForm, error
   );
 }
 
-function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: KeyPolicy[]; services: ServiceItem[]; overview: AdminOverview | null; tenants: AdminTenantSummary[]; usageRows: AdminUsageRow[] }) {
+function UsageScreen({ keys, services, overview, tenants, usageRows, usageLoaded }: { keys: KeyPolicy[]; services: ServiceItem[]; overview: AdminOverview | null; tenants: AdminTenantSummary[]; usageRows: AdminUsageRow[]; usageLoaded: boolean }) {
   const activeKeys = keys.filter((key) => key.enabled);
   const readyServices = readyCount(services);
   const blockedServices = services.filter((service) => service.readiness && !service.readiness.executable);
@@ -1110,9 +1128,14 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
   const grantedServiceCount = activeKeys.some((key) => key.providers.length === 0)
     ? serviceProviderCount
     : new Set(activeKeys.flatMap((key) => key.providers)).size;
-  const totalBudget = overview?.monthlyBudgetMicros ?? keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
+  const hasUnlimitedBudget = activeKeys.some((key) => key.monthlyBudgetMicros === undefined || key.monthlyBudgetMicros === null);
+  const activeBudgetValues = activeKeys.map((key) => key.monthlyBudgetMicros);
+  const totalBudget = activeBudgetValues.some((value) => value === undefined || value === null)
+    ? null
+    : activeBudgetValues.reduce<number>((total, value) => total + (value ?? 0), 0);
+  const totalBudgetLabel = hasUnlimitedBudget ? "unlimited" : formatMicros(totalBudget);
   const trackedRows = rows.filter((row) => row.budget.configured);
-  const totalSpent = trackedRows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
+  const totalSpent = !usageLoaded || trackedRows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
     ? null
     : trackedRows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
   const routeTotal = services.reduce((total, service) => total + service.routeCount, 0);
@@ -1124,13 +1147,13 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
           <Metric label="active grants" value={String(overview?.keysActive ?? activeKeys.length)} meta={`${overview?.keysTotal ?? keys.length} total`} />
           <Metric label="tenants" value={String(overview?.tenantsTotal ?? tenantRows.length)} meta={`${grantedServiceCount} granted services`} />
           <Metric label="routes" value={String(routeTotal)} meta={`${providerTotal} providers`} />
-          <Metric label="budget" value={formatMicros(totalBudget)} meta={`${formatMicros(totalSpent)} spent`} />
+          <Metric label="budget" value={totalBudgetLabel} meta={`${formatMicros(totalSpent)} spent`} />
         </div>
         <EntityTable columns={["grant", "tenant", "budget", "spent", "remaining", "services", "status"]} columnTemplate="minmax(220px, 1.4fr) 128px 120px 120px 120px 94px 108px" rows={rows.map((row) => ({ id: row.kid, cells: [<EntityName icon={KeyRound} title={row.kid} subtitle={row.tokenRole ?? "custom"} />, row.tenantId, formatBudget(row.monthlyBudgetMicros), formatMicros(row.budget.spentMicros), row.budget.configured ? formatMicros(row.budget.remainingMicros) : "not tracked", effectiveProviderCount(row.providers, services), <Status label={row.enabled ? "active" : "revoked"} tone={row.enabled ? "active" : "revoked"} />] }))} />
       </section>
       <aside className="inspector">
         <InspectorHeader icon={BarChart3} title="Usage ledger" subtitle="tenant budgets and grant health" />
-        <dl className="facts"><dt>active grants</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{formatMicros(totalBudget)}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
+        <dl className="facts"><dt>active grants</dt><dd>{overview?.keysActive ?? activeKeys.length}</dd><dt>ready services</dt><dd>{readyServices}/{services.length}</dd><dt>blocked services</dt><dd>{blockedServices.length}</dd><dt>monthly budget</dt><dd>{totalBudgetLabel}</dd><dt>tracked spend</dt><dd>{formatMicros(totalSpent)}</dd></dl>
         <div className="sectionTitle">Tenants</div>
         <div className="miniList">{tenantRows.length ? tenantRows.slice(0, 8).map((tenant) => <button type="button" key={tenant.tenantId}>{tenant.tenantId}<span>{tenant.activeKeys}/{tenant.keys} grants · {effectiveProviderCount(tenant.providers, services)} services</span></button>) : <p>No tenant grants yet.</p>}</div>
         <div className="sectionTitle">Needs configuration</div>

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1102,9 +1102,12 @@ function UsageScreen({ keys, services, overview, tenants, usageRows }: { keys: K
   const rows = usageRows.length ? usageRows : keys.map(policyUsageFallback);
   const tenantRows = tenants.length ? tenants : tenantSummaryFallback(keys);
   const totalBudget = overview?.monthlyBudgetMicros ?? keys.reduce((total, key) => total + (key.monthlyBudgetMicros ?? 0), 0);
-  const totalSpent = rows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
-  const routeTotal = overview ? overview.openaiCompatibleProviders + overview.manifestRoutes : services.reduce((total, service) => total + service.routeCount, 0);
-  const providerTotal = overview?.providerCount ?? services.length;
+  const trackedRows = rows.filter((row) => row.budget.configured);
+  const totalSpent = trackedRows.some((row) => row.budget.spentMicros === undefined || row.budget.spentMicros === null)
+    ? null
+    : trackedRows.reduce((total, row) => total + (row.budget.spentMicros ?? 0), 0);
+  const routeTotal = services.reduce((total, service) => total + service.routeCount, 0);
+  const providerTotal = overview?.providerCount ?? new Set(services.map((service) => service.provider)).size;
   return (
     <div className="entityLayout">
       <section className="mainPane">

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -924,6 +924,40 @@ pre {
   line-height: 1.4;
 }
 
+.outcomeCallout,
+.grantSummary {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--soft-background);
+  padding: 8px;
+}
+
+.outcomeCallout {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+}
+
+.outcomeCallout p {
+  font-size: 12px;
+}
+
+.grantSummary strong {
+  overflow: hidden;
+  color: var(--foreground-strong);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.grantSummary span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .issuedKey {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -1410,11 +1410,30 @@ pre {
   }
 
   .topbar,
-  .topActions,
   .statusBar,
   .splitHeader {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .sidebar {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 6px;
+    padding: 6px 10px 8px;
+  }
+
+  .brandBlock {
+    min-height: 28px;
+  }
+
+  .tenantSwitch {
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .navTabs {
+    grid-column: auto;
   }
 
   .topbar {
@@ -1425,14 +1444,32 @@ pre {
     white-space: normal;
   }
 
-  .topActions,
   .inspectorActions {
     width: 100%;
   }
 
-  .topActions button,
   .inspectorActions button {
     width: 100%;
+  }
+
+  .topActions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .topActions button {
+    flex: 0 0 auto;
+  }
+
+  .statusBar {
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .statusBar span {
+    white-space: normal;
   }
 
   .catalogControls,

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -645,6 +645,54 @@ pre {
   padding-left: 28px;
 }
 
+.overviewStrip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--background);
+}
+
+.metric {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  border-right: 1px solid var(--border);
+  padding: 9px 10px;
+}
+
+.metric:last-child {
+  border-right: 0;
+}
+
+.metric span,
+.metric small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.metric strong {
+  overflow: hidden;
+  color: var(--foreground-strong);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metric small {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: none;
+}
+
 .entityTable {
   min-width: 0;
   overflow: auto;
@@ -1354,10 +1402,20 @@ pre {
   }
 
   .catalogControls,
+  .overviewStrip,
   .playgroundToolbar,
   .formGrid,
   .presetRow {
     grid-template-columns: 1fr;
+  }
+
+  .metric {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .metric:last-child {
+    border-bottom: 0;
   }
 
   .statusBar em {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1125,12 +1125,18 @@ async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {
                 );
             }
         };
+        let existing_policy = existing_key_policy(&kv, &kid).await?;
         let existing_secret_sha256 = if request.secret_sha256.is_none() {
-            existing_key_secret_sha256(&kv, &kid).await?
+            existing_policy
+                .as_ref()
+                .map(|policy| policy.secret_sha256.clone())
         } else {
             None
         };
-        let policy = match request.try_into_policy(existing_secret_sha256) {
+        let existing_all_providers = existing_policy
+            .as_ref()
+            .is_some_and(|policy| policy.providers.is_empty());
+        let policy = match request.try_into_policy(existing_secret_sha256, existing_all_providers) {
             Ok(policy) => policy,
             Err(message) => return json_error("invalid_admin_policy", message, 400),
         };
@@ -1480,6 +1486,7 @@ impl AdminKeyPolicyRequest {
     fn try_into_policy(
         self,
         existing_secret_sha256: Option<String>,
+        existing_all_providers: bool,
     ) -> std::result::Result<KeyPolicy, &'static str> {
         let secret_sha256 = match self.secret_sha256 {
             Some(secret_sha256) if is_sha256_hex(&secret_sha256) => secret_sha256,
@@ -1489,6 +1496,9 @@ impl AdminKeyPolicyRequest {
                 .ok_or("secretSha256 is required for new proxy keys")?,
         };
         let providers = self.providers.ok_or("providers is required")?;
+        if providers.is_empty() && !existing_all_providers {
+            return Err("providers must contain at least one provider id");
+        }
         if let Some(value) = self.monthly_budget_micros {
             validate_admin_budget(value, "monthlyBudgetMicros")?;
         }
@@ -1694,7 +1704,7 @@ fn sum_optional_micros(values: impl Iterator<Item = Option<u64>>) -> u64 {
     })
 }
 
-async fn existing_key_secret_sha256(kv: &KvStore, kid: &str) -> Result<Option<String>> {
+async fn existing_key_policy(kv: &KvStore, kid: &str) -> Result<Option<KeyPolicy>> {
     let Some(record) = kv
         .get(&format!("keys/{kid}"))
         .text()
@@ -1705,7 +1715,7 @@ async fn existing_key_secret_sha256(kv: &KvStore, kid: &str) -> Result<Option<St
     };
     let policy = serde_json::from_str::<KeyPolicy>(&record)
         .map_err(|error| Error::RustError(format!("key policy is invalid JSON: {error}")))?;
-    Ok(Some(policy.secret_sha256))
+    Ok(Some(policy))
 }
 
 async fn list_admin_key_policies(kv: &KvStore) -> Result<Vec<AdminKeyPolicyResponse>> {
@@ -4595,7 +4605,7 @@ mod tests {
             monthly_budget_micros: Some(100),
             request_cost_micros: Some(10),
         };
-        let policy = request.try_into_policy(None).unwrap();
+        let policy = request.try_into_policy(None, false).unwrap();
         validate_policy_providers(&policy).unwrap();
         let response = admin_policy_response("svc_docs", &policy);
         assert_eq!(response.kid, "svc_docs");
@@ -4618,7 +4628,7 @@ mod tests {
             request_cost_micros: Some(10),
         };
         assert_eq!(
-            request.try_into_policy(None).unwrap_err(),
+            request.try_into_policy(None, false).unwrap_err(),
             "tokenRole must be 32 or fewer ASCII letters, numbers, underscores, or hyphens"
         );
     }
@@ -4636,7 +4646,7 @@ mod tests {
             request_cost_micros: Some(20),
         };
         let policy = request
-            .try_into_policy(Some(existing_hash.clone()))
+            .try_into_policy(Some(existing_hash.clone()), false)
             .unwrap();
         assert_eq!(policy.secret_sha256, existing_hash);
 
@@ -4650,7 +4660,7 @@ mod tests {
             request_cost_micros: None,
         };
         assert_eq!(
-            new_key.try_into_policy(None).unwrap_err(),
+            new_key.try_into_policy(None, false).unwrap_err(),
             "secretSha256 is required for new proxy keys"
         );
     }
@@ -4768,7 +4778,7 @@ mod tests {
             request_cost_micros: None,
         };
         assert_eq!(
-            bad_hash.try_into_policy(None).unwrap_err(),
+            bad_hash.try_into_policy(None, false).unwrap_err(),
             "secretSha256 must be a 64-character hex string"
         );
 
@@ -4781,7 +4791,20 @@ mod tests {
             monthly_budget_micros: None,
             request_cost_micros: None,
         };
-        let wildcard_policy = wildcard_providers.try_into_policy(None).unwrap();
+        assert_eq!(
+            wildcard_providers.try_into_policy(None, false).unwrap_err(),
+            "providers must contain at least one provider id"
+        );
+        let wildcard_providers = AdminKeyPolicyRequest {
+            enabled: true,
+            secret_sha256: Some(sha256_hex("secret")),
+            providers: Some(Vec::new()),
+            tenant_id: None,
+            token_role: None,
+            monthly_budget_micros: None,
+            request_cost_micros: None,
+        };
+        let wildcard_policy = wildcard_providers.try_into_policy(None, true).unwrap();
         assert!(wildcard_policy.providers.is_empty());
         validate_policy_providers(&wildcard_policy).unwrap();
 
@@ -4795,7 +4818,7 @@ mod tests {
             request_cost_micros: None,
         };
         assert_eq!(
-            omitted_providers.try_into_policy(None).unwrap_err(),
+            omitted_providers.try_into_policy(None, false).unwrap_err(),
             "providers is required"
         );
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -220,7 +220,17 @@ fn service_index() -> Result<Response> {
 fn interface_path(path: &str) -> bool {
     matches!(
         path,
-        "/dashboard" | "/playground" | "/admin" | "/account" | "/console" | "/routes"
+        "/access"
+            | "/account"
+            | "/admin"
+            | "/catalog"
+            | "/console"
+            | "/dashboard"
+            | "/playground"
+            | "/policies"
+            | "/routes"
+            | "/usage"
+            | "/users"
     )
 }
 
@@ -4783,11 +4793,15 @@ mod tests {
 
     #[test]
     fn interface_routes_require_the_admin_shell() {
+        assert!(interface_path("/access"));
+        assert!(interface_path("/catalog"));
         assert!(interface_path("/dashboard"));
         assert!(interface_path("/playground"));
         assert!(interface_path("/admin"));
         assert!(interface_path("/account"));
         assert!(interface_path("/routes"));
+        assert!(interface_path("/usage"));
+        assert!(interface_path("/users"));
         assert!(!interface_path("/v1/admin/keys"));
     }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -58,10 +58,10 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return cors_preflight();
     }
     if req.method() == Method::Get && request_path == "/" {
-        return redirect_to(ROOT_REDIRECT_PATH);
+        return redirect_to(&redirect_location(ROOT_REDIRECT_PATH, url.query()));
     }
     if req.method() == Method::Get && request_path == ROOT_REDIRECT_PATH {
-        return redirect_to("/dashboard/catalog");
+        return redirect_to(&redirect_location("/dashboard/catalog", url.query()));
     }
     if req.method() == Method::Get {
         if let Some(target) = legacy_interface_redirect(url.path()) {
@@ -305,6 +305,12 @@ fn redirect_to(location: &str) -> Result<Response> {
         .headers_mut()
         .set("cache-control", "no-store, max-age=0")?;
     Ok(response)
+}
+
+fn redirect_location(location: &str, query: Option<&str>) -> String {
+    query
+        .map(|value| format!("{location}?{value}"))
+        .unwrap_or_else(|| location.to_string())
 }
 
 fn route_catalog(snapshot: &ProviderSnapshot) -> Value {
@@ -730,6 +736,7 @@ struct AdminTenantSummary {
     keys: usize,
     active_keys: usize,
     providers: Vec<String>,
+    all_providers: bool,
     monthly_budget_micros: u64,
     request_cost_micros: u64,
 }
@@ -739,6 +746,7 @@ struct TenantAccumulator {
     keys: usize,
     active_keys: usize,
     providers: BTreeSet<String>,
+    all_providers: bool,
     monthly_budget_micros: u64,
     request_cost_micros: u64,
 }
@@ -1637,7 +1645,11 @@ fn admin_tenant_summaries(entries: &[AdminKeyPolicyResponse]) -> Vec<AdminTenant
         summary.request_cost_micros = summary
             .request_cost_micros
             .saturating_add(entry.request_cost_micros.unwrap_or_default());
-        summary.providers.extend(entry.providers.iter().cloned());
+        if entry.providers.is_empty() {
+            summary.all_providers = true;
+        } else {
+            summary.providers.extend(entry.providers.iter().cloned());
+        }
     }
     tenants
         .into_iter()
@@ -1646,6 +1658,7 @@ fn admin_tenant_summaries(entries: &[AdminKeyPolicyResponse]) -> Vec<AdminTenant
             keys: summary.keys,
             active_keys: summary.active_keys,
             providers: summary.providers.into_iter().collect(),
+            all_providers: summary.all_providers,
             monthly_budget_micros: summary.monthly_budget_micros,
             request_cost_micros: summary.request_cost_micros,
         })
@@ -4692,7 +4705,7 @@ mod tests {
             AdminKeyPolicyResponse {
                 kid: "svc_ops".to_string(),
                 enabled: false,
-                providers: vec!["openai".to_string()],
+                providers: vec![],
                 tenant_id: Some("team_docs".to_string()),
                 token_role: Some("ops".to_string()),
                 monthly_budget_micros: Some(200),
@@ -4716,6 +4729,7 @@ mod tests {
         assert_eq!(docs.keys, 2);
         assert_eq!(docs.active_keys, 1);
         assert_eq!(docs.providers, vec!["openai", "tavily"]);
+        assert!(docs.all_providers);
         assert_eq!(docs.monthly_budget_micros, 300);
 
         let overview = admin_overview(&entries, &provider_snapshot().unwrap());
@@ -4815,13 +4829,22 @@ mod tests {
 
     #[test]
     fn legacy_interface_routes_redirect_under_dashboard() {
-        assert_eq!(legacy_interface_redirect("/access"), Some("/dashboard/access"));
-        assert_eq!(legacy_interface_redirect("/catalog"), Some("/dashboard/catalog"));
+        assert_eq!(
+            legacy_interface_redirect("/access"),
+            Some("/dashboard/access")
+        );
+        assert_eq!(
+            legacy_interface_redirect("/catalog"),
+            Some("/dashboard/catalog")
+        );
         assert_eq!(
             legacy_interface_redirect("/playground"),
             Some("/dashboard/playground")
         );
-        assert_eq!(legacy_interface_redirect("/usage"), Some("/dashboard/usage"));
+        assert_eq!(
+            legacy_interface_redirect("/usage"),
+            Some("/dashboard/usage")
+        );
         assert_eq!(legacy_interface_redirect("/v1/routes"), None);
     }
 
@@ -4853,6 +4876,14 @@ mod tests {
     #[test]
     fn root_redirect_points_to_dashboard() {
         assert_eq!(ROOT_REDIRECT_PATH, "/dashboard");
+        assert_eq!(
+            redirect_location(ROOT_REDIRECT_PATH, Some("demo")),
+            "/dashboard?demo"
+        );
+        assert_eq!(
+            redirect_location("/dashboard/catalog", Some("demo")),
+            "/dashboard/catalog?demo"
+        );
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1488,9 +1488,6 @@ impl AdminKeyPolicyRequest {
                 .filter(|value| is_sha256_hex(value))
                 .ok_or("secretSha256 is required for new proxy keys")?,
         };
-        if self.providers.is_empty() {
-            return Err("providers must contain at least one provider id");
-        }
         if let Some(value) = self.monthly_budget_micros {
             validate_admin_budget(value, "monthlyBudgetMicros")?;
         }
@@ -4774,7 +4771,7 @@ mod tests {
             "secretSha256 must be a 64-character hex string"
         );
 
-        let no_providers = AdminKeyPolicyRequest {
+        let wildcard_providers = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: Some(sha256_hex("secret")),
             providers: Vec::new(),
@@ -4783,10 +4780,9 @@ mod tests {
             monthly_budget_micros: None,
             request_cost_micros: None,
         };
-        assert_eq!(
-            no_providers.try_into_policy(None).unwrap_err(),
-            "providers must contain at least one provider id"
-        );
+        let wildcard_policy = wildcard_providers.try_into_policy(None).unwrap();
+        assert!(wildcard_policy.providers.is_empty());
+        validate_policy_providers(&wildcard_policy).unwrap();
 
         let unknown_provider = KeyPolicy {
             enabled: true,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -60,6 +60,15 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     if req.method() == Method::Get && request_path == "/" {
         return redirect_to(ROOT_REDIRECT_PATH);
     }
+    if req.method() == Method::Get {
+        if let Some(target) = legacy_interface_redirect(url.path()) {
+            let query = url
+                .query()
+                .map(|value| format!("?{value}"))
+                .unwrap_or_default();
+            return redirect_to(&format!("{target}{query}"));
+        }
+    }
     if req.method() == Method::Get && url.path() == "/v1" {
         return service_index().and_then(with_cors);
     }
@@ -218,20 +227,18 @@ fn service_index() -> Result<Response> {
 }
 
 fn interface_path(path: &str) -> bool {
-    matches!(
-        path,
-        "/access"
-            | "/account"
-            | "/admin"
-            | "/catalog"
-            | "/console"
-            | "/dashboard"
-            | "/playground"
-            | "/policies"
-            | "/routes"
-            | "/usage"
-            | "/users"
-    )
+    path == "/dashboard" || path.starts_with("/dashboard/")
+}
+
+fn legacy_interface_redirect(path: &str) -> Option<&'static str> {
+    match path {
+        "/access" | "/admin" | "/policies" => Some("/dashboard/access"),
+        "/account" | "/users" => Some("/dashboard/users"),
+        "/catalog" | "/console" | "/routes" => Some("/dashboard/catalog"),
+        "/playground" => Some("/dashboard/playground"),
+        "/usage" => Some("/dashboard/usage"),
+        _ => None,
+    }
 }
 
 fn canonical_api_path(path: &str) -> String {
@@ -4793,16 +4800,26 @@ mod tests {
 
     #[test]
     fn interface_routes_require_the_admin_shell() {
-        assert!(interface_path("/access"));
-        assert!(interface_path("/catalog"));
         assert!(interface_path("/dashboard"));
-        assert!(interface_path("/playground"));
-        assert!(interface_path("/admin"));
-        assert!(interface_path("/account"));
-        assert!(interface_path("/routes"));
-        assert!(interface_path("/usage"));
-        assert!(interface_path("/users"));
+        assert!(interface_path("/dashboard/access"));
+        assert!(interface_path("/dashboard/catalog"));
+        assert!(interface_path("/dashboard/playground"));
+        assert!(interface_path("/dashboard/usage"));
+        assert!(interface_path("/dashboard/users"));
+        assert!(!interface_path("/access"));
         assert!(!interface_path("/v1/admin/keys"));
+    }
+
+    #[test]
+    fn legacy_interface_routes_redirect_under_dashboard() {
+        assert_eq!(legacy_interface_redirect("/access"), Some("/dashboard/access"));
+        assert_eq!(legacy_interface_redirect("/catalog"), Some("/dashboard/catalog"));
+        assert_eq!(
+            legacy_interface_redirect("/playground"),
+            Some("/dashboard/playground")
+        );
+        assert_eq!(legacy_interface_redirect("/usage"), Some("/dashboard/usage"));
+        assert_eq!(legacy_interface_redirect("/v1/routes"), None);
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1125,7 +1125,13 @@ async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {
                 );
             }
         };
-        let existing_policy = existing_key_policy(&kv, &kid).await?;
+        let needs_existing_policy = request.secret_sha256.is_none()
+            || request.providers.as_ref().is_some_and(Vec::is_empty);
+        let existing_policy = if needs_existing_policy {
+            existing_key_policy(&kv, &kid).await?
+        } else {
+            None
+        };
         let existing_secret_sha256 = if request.secret_sha256.is_none() {
             existing_policy
                 .as_ref()

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -60,6 +60,9 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     if req.method() == Method::Get && request_path == "/" {
         return redirect_to(ROOT_REDIRECT_PATH);
     }
+    if req.method() == Method::Get && request_path == ROOT_REDIRECT_PATH {
+        return redirect_to("/dashboard/catalog");
+    }
     if req.method() == Method::Get {
         if let Some(target) = legacy_interface_redirect(url.path()) {
             let query = url
@@ -227,7 +230,7 @@ fn service_index() -> Result<Response> {
 }
 
 fn interface_path(path: &str) -> bool {
-    path == "/dashboard" || path.starts_with("/dashboard/")
+    path.starts_with("/dashboard/")
 }
 
 fn legacy_interface_redirect(path: &str) -> Option<&'static str> {
@@ -4800,7 +4803,7 @@ mod tests {
 
     #[test]
     fn interface_routes_require_the_admin_shell() {
-        assert!(interface_path("/dashboard"));
+        assert!(!interface_path("/dashboard"));
         assert!(interface_path("/dashboard/access"));
         assert!(interface_path("/dashboard/catalog"));
         assert!(interface_path("/dashboard/playground"));

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1645,10 +1645,12 @@ fn admin_tenant_summaries(entries: &[AdminKeyPolicyResponse]) -> Vec<AdminTenant
         summary.request_cost_micros = summary
             .request_cost_micros
             .saturating_add(entry.request_cost_micros.unwrap_or_default());
-        if entry.providers.is_empty() {
-            summary.all_providers = true;
-        } else {
-            summary.providers.extend(entry.providers.iter().cloned());
+        if entry.enabled {
+            if entry.providers.is_empty() {
+                summary.all_providers = true;
+            } else {
+                summary.providers.extend(entry.providers.iter().cloned());
+            }
         }
     }
     tenants
@@ -4704,7 +4706,7 @@ mod tests {
             },
             AdminKeyPolicyResponse {
                 kid: "svc_ops".to_string(),
-                enabled: false,
+                enabled: true,
                 providers: vec![],
                 tenant_id: Some("team_docs".to_string()),
                 token_role: Some("ops".to_string()),
@@ -4720,6 +4722,15 @@ mod tests {
                 monthly_budget_micros: None,
                 request_cost_micros: Some(5),
             },
+            AdminKeyPolicyResponse {
+                kid: "svc_retired".to_string(),
+                enabled: false,
+                providers: vec![],
+                tenant_id: Some("retired".to_string()),
+                token_role: Some("sandbox".to_string()),
+                monthly_budget_micros: Some(50),
+                request_cost_micros: None,
+            },
         ];
         let tenants = admin_tenant_summaries(&entries);
         let docs = tenants
@@ -4727,16 +4738,23 @@ mod tests {
             .find(|tenant| tenant.tenant_id == "team_docs")
             .unwrap();
         assert_eq!(docs.keys, 2);
-        assert_eq!(docs.active_keys, 1);
+        assert_eq!(docs.active_keys, 2);
         assert_eq!(docs.providers, vec!["openai", "tavily"]);
         assert!(docs.all_providers);
         assert_eq!(docs.monthly_budget_micros, 300);
+        let retired = tenants
+            .iter()
+            .find(|tenant| tenant.tenant_id == "retired")
+            .unwrap();
+        assert_eq!(retired.active_keys, 0);
+        assert!(!retired.all_providers);
+        assert!(retired.providers.is_empty());
 
         let overview = admin_overview(&entries, &provider_snapshot().unwrap());
-        assert_eq!(overview.keys_total, 3);
-        assert_eq!(overview.keys_active, 2);
-        assert_eq!(overview.tenants_total, 2);
-        assert_eq!(overview.monthly_budget_micros, 300);
+        assert_eq!(overview.keys_total, 4);
+        assert_eq!(overview.keys_active, 3);
+        assert_eq!(overview.tenants_total, 3);
+        assert_eq!(overview.monthly_budget_micros, 350);
         assert_eq!(overview.request_cost_micros, 15);
     }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -668,7 +668,7 @@ struct AdminKeyPolicyRequest {
     #[serde(default)]
     secret_sha256: Option<String>,
     #[serde(default)]
-    providers: Vec<String>,
+    providers: Option<Vec<String>>,
     #[serde(default)]
     tenant_id: Option<String>,
     #[serde(default)]
@@ -1488,6 +1488,7 @@ impl AdminKeyPolicyRequest {
                 .filter(|value| is_sha256_hex(value))
                 .ok_or("secretSha256 is required for new proxy keys")?,
         };
+        let providers = self.providers.ok_or("providers is required")?;
         if let Some(value) = self.monthly_budget_micros {
             validate_admin_budget(value, "monthlyBudgetMicros")?;
         }
@@ -1498,7 +1499,7 @@ impl AdminKeyPolicyRequest {
         Ok(KeyPolicy {
             enabled: self.enabled,
             secret_sha256: secret_sha256.to_ascii_lowercase(),
-            providers: self.providers,
+            providers,
             tenant_id: self.tenant_id,
             token_role,
             monthly_budget_micros: self.monthly_budget_micros,
@@ -4588,7 +4589,7 @@ mod tests {
         let request = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: Some(sha256_hex("secret")),
-            providers: vec!["openai".to_string(), "tavily".to_string()],
+            providers: Some(vec!["openai".to_string(), "tavily".to_string()]),
             tenant_id: Some("team_docs".to_string()),
             token_role: Some("User".to_string()),
             monthly_budget_micros: Some(100),
@@ -4610,7 +4611,7 @@ mod tests {
         let request = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: Some(sha256_hex("secret")),
-            providers: vec!["openai".to_string()],
+            providers: Some(vec!["openai".to_string()]),
             tenant_id: Some("team_docs".to_string()),
             token_role: Some("bad role!".to_string()),
             monthly_budget_micros: Some(100),
@@ -4628,7 +4629,7 @@ mod tests {
         let request = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: None,
-            providers: vec!["openai".to_string()],
+            providers: Some(vec!["openai".to_string()]),
             tenant_id: Some("team_docs".to_string()),
             token_role: Some("service".to_string()),
             monthly_budget_micros: Some(200),
@@ -4642,7 +4643,7 @@ mod tests {
         let new_key = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: None,
-            providers: vec!["openai".to_string()],
+            providers: Some(vec!["openai".to_string()]),
             tenant_id: None,
             token_role: None,
             monthly_budget_micros: None,
@@ -4760,7 +4761,7 @@ mod tests {
         let bad_hash = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: Some("not-a-hash".to_string()),
-            providers: vec!["openai".to_string()],
+            providers: Some(vec!["openai".to_string()]),
             tenant_id: None,
             token_role: None,
             monthly_budget_micros: None,
@@ -4774,7 +4775,7 @@ mod tests {
         let wildcard_providers = AdminKeyPolicyRequest {
             enabled: true,
             secret_sha256: Some(sha256_hex("secret")),
-            providers: Vec::new(),
+            providers: Some(Vec::new()),
             tenant_id: None,
             token_role: None,
             monthly_budget_micros: None,
@@ -4783,6 +4784,20 @@ mod tests {
         let wildcard_policy = wildcard_providers.try_into_policy(None).unwrap();
         assert!(wildcard_policy.providers.is_empty());
         validate_policy_providers(&wildcard_policy).unwrap();
+
+        let omitted_providers = AdminKeyPolicyRequest {
+            enabled: true,
+            secret_sha256: Some(sha256_hex("secret")),
+            providers: None,
+            tenant_id: None,
+            token_role: None,
+            monthly_budget_micros: None,
+            request_cost_micros: None,
+        };
+        assert_eq!(
+            omitted_providers.try_into_policy(None).unwrap_err(),
+            "providers is required"
+        );
 
         let unknown_provider = KeyPolicy {
             enabled: true,

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -45,8 +45,8 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
-destinations are `/dashboard`, `/v1/session`, `/v1/entitlements`,
-`/v1/playground/*`, and `/v1/admin/*`. This stays within Cloudflare's
+destinations are `/dashboard`, `/dashboard/*`, `/v1/session`,
+`/v1/entitlements`, `/v1/playground/*`, and `/v1/admin/*`. This stays within Cloudflare's
 per-application destination limit while still protecting the console entrypoint
 and the Access-backed session, entitlement, playground, and admin APIs. Override
 them with `CLAWROUTER_ACCESS_PATHS` only if the API contract changes. Do not add
@@ -206,16 +206,16 @@ the `cf-access-jwt-assertion` signature against the team certs endpoint before
 it trusts the email or role.
 
 The browser console is fail-closed in the Worker. `/` redirects to
-`/dashboard`; the default Access app protects `/dashboard`, and the Worker
-still refuses `/playground`, `/admin`, `/account`, `/routes`, and `/console`
-without a verified Access JWT. Public and client-facing surfaces stay under
+`/dashboard`; the default Access app protects `/dashboard` and `/dashboard/*`.
+Old top-level console paths such as `/playground`, `/admin`, `/account`,
+`/routes`, and `/console` redirect under `/dashboard`. Public and client-facing surfaces stay under
 the API paths such as `/v1`, `/v1/health`, `/v1/providers`, `/v1/routes`, and
 proxy endpoints.
 
 After Access is configured, an unauthenticated request to `/` should be handled
 by the Worker with a redirect to `/dashboard`, and `/dashboard` should be
 handled by Cloudflare Access before it reaches the Worker. A raw `401` JSON
-response with `access_session_required` on `/dashboard` means the Access
+response with `access_session_required` on `/dashboard` or `/dashboard/*` means the Access
 application is not protecting the console path or the Worker was deployed
 without the Access team/AUD vars.
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -45,8 +45,8 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
-destinations are `/dashboard`, `/dashboard/*`, `/v1/session`,
-`/v1/entitlements`, `/v1/playground/*`, and `/v1/admin/*`. This stays within Cloudflare's
+destinations are `/dashboard/*`, `/v1/session`, `/v1/entitlements`,
+`/v1/playground/*`, and `/v1/admin/*`. This stays within Cloudflare's
 per-application destination limit while still protecting the console entrypoint
 and the Access-backed session, entitlement, playground, and admin APIs. Override
 them with `CLAWROUTER_ACCESS_PATHS` only if the API contract changes. Do not add
@@ -206,16 +206,18 @@ the `cf-access-jwt-assertion` signature against the team certs endpoint before
 it trusts the email or role.
 
 The browser console is fail-closed in the Worker. `/` redirects to
-`/dashboard`; the default Access app protects `/dashboard` and `/dashboard/*`.
+`/dashboard`, and `/dashboard` redirects to `/dashboard/catalog`; the default
+Access app protects `/dashboard/*`.
 Old top-level console paths such as `/playground`, `/admin`, `/account`,
 `/routes`, and `/console` redirect under `/dashboard`. Public and client-facing surfaces stay under
 the API paths such as `/v1`, `/v1/health`, `/v1/providers`, `/v1/routes`, and
 proxy endpoints.
 
 After Access is configured, an unauthenticated request to `/` should be handled
-by the Worker with a redirect to `/dashboard`, and `/dashboard` should be
-handled by Cloudflare Access before it reaches the Worker. A raw `401` JSON
-response with `access_session_required` on `/dashboard` or `/dashboard/*` means the Access
+by the Worker with a redirect to `/dashboard`, `/dashboard` should redirect to
+`/dashboard/catalog`, and `/dashboard/catalog` should be handled by Cloudflare
+Access before it reaches the Worker. A raw `401` JSON response with
+`access_session_required` on `/dashboard/*` means the Access
 application is not protecting the console path or the Worker was deployed
 without the Access team/AUD vars.
 

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -339,7 +339,6 @@ function destinationUris(app) {
 
 function defaultAccessPaths() {
   return [
-    "/dashboard",
     "/dashboard/*",
     "/v1/session",
     "/v1/entitlements",
@@ -422,7 +421,7 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   console.log("");
   console.log("Expected live root check after redeploy:");
   console.log(`curl -sS -D - -o /dev/null https://${host}/`);
-  console.log("Root should 302 to /dashboard; Cloudflare Access should challenge /dashboard and /dashboard/*.");
+  console.log("Root should 302 to /dashboard, /dashboard should 302 to /dashboard/catalog, and Cloudflare Access should challenge /dashboard/*.");
 }
 
 function syncGitHubVariable(repoName, name, value) {

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -340,6 +340,7 @@ function destinationUris(app) {
 function defaultAccessPaths() {
   return [
     "/dashboard",
+    "/dashboard/*",
     "/v1/session",
     "/v1/entitlements",
     "/v1/playground/*",
@@ -421,7 +422,7 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   console.log("");
   console.log("Expected live root check after redeploy:");
   console.log(`curl -sS -D - -o /dev/null https://${host}/`);
-  console.log("Root should 302 to /dashboard; Cloudflare Access should challenge /dashboard.");
+  console.log("Root should 302 to /dashboard; Cloudflare Access should challenge /dashboard and /dashboard/*.");
 }
 
 function syncGitHubVariable(repoName, name, value) {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -10,7 +10,7 @@ const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 
 await expectOk(`${baseUrl}/v1/health`, "health");
 await expectRedirect(`${baseUrl}/`, "root redirect", "/dashboard");
-await expectAccessGate(`${baseUrl}/dashboard`, "dashboard access gate");
+await expectRedirect(`${baseUrl}/dashboard`, "dashboard redirect", "/dashboard/catalog");
 await expectAccessGate(`${baseUrl}/dashboard/catalog`, "catalog access gate");
 await expectRedirect(`${baseUrl}/catalog`, "legacy catalog redirect", "/dashboard/catalog");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -77,8 +77,11 @@ async function expectRedirectOrAccessGate(url, name, location) {
   if (response.status >= 300 && response.status < 400 && actual === location) {
     return;
   }
-  if (response.status >= 300 && response.status < 400 && looksLikeAccessRedirect(actual)) {
+  if (response.status >= 300 && response.status < 400 && looksLikeAccessRedirect(actual, url)) {
     return;
+  }
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error(`${name} redirected to ${actual || "<missing>"}, expected ${location} or Cloudflare Access`);
   }
   const contentType = response.headers.get("content-type") ?? "";
   const body = await response.text();
@@ -119,8 +122,15 @@ function assertAccessGateResponse(response, contentType, body, name) {
   throw new Error(`${name} returned ${response.status}, expected Cloudflare Access challenge`);
 }
 
-function looksLikeAccessRedirect(location) {
-  return location.includes("cloudflareaccess.com") || location.includes("/cdn-cgi/access/");
+function looksLikeAccessRedirect(location, requestUrl) {
+  if (location.includes("cloudflareaccess.com") || location.includes("/cdn-cgi/access/")) {
+    return true;
+  }
+  try {
+    return new URL(location, requestUrl).origin !== new URL(requestUrl).origin;
+  } catch {
+    return false;
+  }
 }
 
 function expectRouteCatalog(catalog, name) {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -10,7 +10,7 @@ const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 
 await expectOk(`${baseUrl}/v1/health`, "health");
 await expectRedirect(`${baseUrl}/`, "root redirect", "/dashboard");
-await expectRedirect(`${baseUrl}/dashboard`, "dashboard redirect", "/dashboard/catalog");
+await expectRedirectOrAccessGate(`${baseUrl}/dashboard`, "dashboard redirect", "/dashboard/catalog");
 await expectAccessGate(`${baseUrl}/dashboard/catalog`, "catalog access gate");
 await expectRedirect(`${baseUrl}/catalog`, "legacy catalog redirect", "/dashboard/catalog");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");
@@ -68,6 +68,23 @@ async function expectRedirect(url, name, location) {
   }
 }
 
+async function expectRedirectOrAccessGate(url, name, location) {
+  const response = await fetch(url, {
+    headers: { accept: "text/html,application/json" },
+    redirect: "manual",
+  });
+  const actual = response.headers.get("location") ?? "";
+  if (response.status >= 300 && response.status < 400 && actual === location) {
+    return;
+  }
+  if (response.status >= 300 && response.status < 400 && looksLikeAccessRedirect(actual)) {
+    return;
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = await response.text();
+  assertAccessGateResponse(response, contentType, body, name);
+}
+
 async function expectAccessGate(url, name) {
   const response = await fetch(url, {
     headers: { accept: "text/html,application/json" },
@@ -75,6 +92,10 @@ async function expectAccessGate(url, name) {
   });
   const contentType = response.headers.get("content-type") ?? "";
   const body = await response.text();
+  assertAccessGateResponse(response, contentType, body, name);
+}
+
+function assertAccessGateResponse(response, contentType, body, name) {
   if (contentType.includes("application/json")) {
     let json = null;
     try {
@@ -96,6 +117,10 @@ async function expectAccessGate(url, name) {
     return;
   }
   throw new Error(`${name} returned ${response.status}, expected Cloudflare Access challenge`);
+}
+
+function looksLikeAccessRedirect(location) {
+  return location.includes("cloudflareaccess.com") || location.includes("/cdn-cgi/access/");
 }
 
 function expectRouteCatalog(catalog, name) {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -11,6 +11,8 @@ const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 await expectOk(`${baseUrl}/v1/health`, "health");
 await expectRedirect(`${baseUrl}/`, "root redirect", "/dashboard");
 await expectAccessGate(`${baseUrl}/dashboard`, "dashboard access gate");
+await expectAccessGate(`${baseUrl}/dashboard/catalog`, "catalog access gate");
+await expectRedirect(`${baseUrl}/catalog`, "legacy catalog redirect", "/dashboard/catalog");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");
 if (!Array.isArray(providers.providers) || providers.providers.length < 20) {
   throw new Error("provider snapshot is unexpectedly small");


### PR DESCRIPTION
## Summary
- Rework the admin console around service access outcomes, grants, users, usage, and the playground.
- Move canonical console routes under `/dashboard/*` while preserving legacy redirects.
- Tighten Cloudflare Access provisioning paths and deployed smoke compatibility.
- Fix wildcard/all-provider grant semantics so existing wildcard grants are preserved, new wildcard grants fail closed unless already present, and UI labels stay truthful.
- Lazy-load usage ledger data and avoid duplicate expensive refreshes.

## Verification
- `node --check scripts/smoke-deployed.mjs`
- `admin/node_modules/.bin/tsc --noEmit -p admin/tsconfig.json`
- `(cd admin && ../admin/node_modules/.bin/vite build)`
- `cargo test --workspace`
- `CLOUDFLARE_ACCOUNT_ID=test CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai node scripts/provision-access.mjs --dry-run | sed -n '1,18p'`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean: no accepted/actionable findings

## Deployment
- Not deployed yet. Merge first, then run the `Deploy Cloudflare` workflow from `main`.

## Remaining risk
- Vite emits known lucide `"use client"` bundle warnings; build succeeds.
