### PR TITLE
fix(deploy): validate smoke policy before publish

### DIFF
--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -215,10 +215,13 @@ pnpm cf:smoke
 ```
 
 For GitHub Actions deploys, `worker_url`, `live_providers`, and the smoke key
-are mandatory. `all` runs every provider smoke target and requires a proxy smoke
-key with access to every selected provider. Readiness reports live checks as
-`verified`, `failed`, or `stale`; a configured provider without a live check is
-`unverified`.
+are mandatory. When the current Worker exposes key inspection, preflight blocks
+deployment if the smoke credential is invalid or its policy denies a selected
+live provider. An unavailable current Worker only warns so first and recovery
+deploys remain possible. `all` runs every provider smoke target and requires a
+proxy smoke key with access to every selected provider. Readiness reports live
+checks as `verified`, `failed`, or `stale`; a configured provider without a live
+check is `unverified`.
 
 ## Cloudflare Access Console
 
@@ -322,7 +325,8 @@ policy provider allowlists, provider readiness, OAuth grants, and budget limits.
 Admin requests use either a verified Cloudflare Access admin session or
 `Authorization: Bearer <admin-token>`. For bearer auth, the Worker compares the
 SHA-256 hash of that token with `CLAWROUTER_ADMIN_TOKEN_SHA256`; the raw admin
-token is never configured in the Worker.
+token is never configured in the Worker. Retain the raw token in the operator
+secret manager; only its SHA-256 hash belongs in the Worker and GitHub Actions.
 
 ```text
 GET /v1/admin/overview

--- a/scripts/deploy-preflight.mjs
+++ b/scripts/deploy-preflight.mjs
@@ -1,8 +1,10 @@
 import {
   buildProviderSmokePlan,
   compileProviderSnapshot,
+  inspectSmokeKeyProviderAccess,
   liveProviderList,
   selectLiveProviderPlans,
+  SmokeKeyInspectionUnavailableError,
 } from "./provider-smoke-plan.mjs";
 
 const requiredDeployEnv = [
@@ -55,6 +57,23 @@ if (liveProviders.length > 0) {
     selectedProviders = selectLiveProviderPlans(plan, liveProviders);
   } catch (error) {
     errors.push(error.message);
+  }
+}
+
+if (selectedProviders.length > 0 && baseUrl && process.env.CLAWROUTER_SMOKE_KEY) {
+  try {
+    await inspectSmokeKeyProviderAccess({
+      baseUrl,
+      smokeKey: process.env.CLAWROUTER_SMOKE_KEY,
+      liveProviders: selectedProviders.map((provider) => provider.id),
+    });
+    console.log("smoke key policy: permits selected live providers");
+  } catch (error) {
+    if (error instanceof SmokeKeyInspectionUnavailableError) {
+      console.warn(`smoke key policy preflight unavailable: ${error.message}`);
+    } else {
+      errors.push(`smoke key policy preflight failed: ${error.message}`);
+    }
   }
 }
 

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -110,12 +110,14 @@ export async function inspectSmokeKeyProviderAccess({
   smokeKey,
   liveProviders,
   fetchImpl = fetch,
+  timeoutMs = 10_000,
 }) {
   let response;
   try {
     response = await fetchImpl(`${baseUrl.replace(/\/$/, "")}/v1/key/inspect`, {
       headers: { authorization: `Bearer ${smokeKey}` },
       redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {
     throw new SmokeKeyInspectionUnavailableError(

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -123,17 +123,17 @@ export async function inspectSmokeKeyProviderAccess({
     );
   }
   if (!response.ok) {
-    if (response.status === 404 || response.status >= 500) {
-      throw new SmokeKeyInspectionUnavailableError(
-        `/v1/key/inspect failed with ${response.status}`,
-      );
-    }
-    let detail = "";
+    let errorCode = "";
     try {
       const body = await response.json();
-      detail = body?.error?.code ? `: ${body.error.code}` : "";
+      errorCode = body?.error?.code ?? "";
     } catch {}
-    throw new Error(`/v1/key/inspect failed with ${response.status}${detail}`);
+    if (response.status === 400 && errorCode === "invalid_key_syntax") {
+      throw new Error(`/v1/key/inspect failed with 400: invalid_key_syntax`);
+    }
+    throw new SmokeKeyInspectionUnavailableError(
+      `/v1/key/inspect failed with ${response.status}${errorCode ? `: ${errorCode}` : ""}`,
+    );
   }
   let inspection;
   try {

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -123,7 +123,17 @@ export async function inspectSmokeKeyProviderAccess({
     );
   }
   if (!response.ok) {
-    throw new SmokeKeyInspectionUnavailableError(`/v1/key/inspect failed with ${response.status}`);
+    if (response.status === 404 || response.status >= 500) {
+      throw new SmokeKeyInspectionUnavailableError(
+        `/v1/key/inspect failed with ${response.status}`,
+      );
+    }
+    let detail = "";
+    try {
+      const body = await response.json();
+      detail = body?.error?.code ? `: ${body.error.code}` : "";
+    } catch {}
+    throw new Error(`/v1/key/inspect failed with ${response.status}${detail}`);
   }
   let inspection;
   try {
@@ -131,6 +141,11 @@ export async function inspectSmokeKeyProviderAccess({
   } catch (error) {
     throw new SmokeKeyInspectionUnavailableError(
       `/v1/key/inspect returned invalid JSON: ${error.message}`,
+    );
+  }
+  if (inspection?.verification === "policy_store_unavailable") {
+    throw new SmokeKeyInspectionUnavailableError(
+      "/v1/key/inspect reported policy_store_unavailable",
     );
   }
   if (inspection?.verified !== true) {

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -7,6 +7,8 @@ const DEFAULT_OPTIONAL_CONFIG_KEYS = new Set([
   "AZURE_OPENAI_COMPLETION_TOKEN_DEPLOYMENTS",
 ]);
 
+export class SmokeKeyInspectionUnavailableError extends Error {}
+
 export function buildProviderSmokePlan(snapshot, env = process.env) {
   const providers = Array.isArray(snapshot?.providers) ? snapshot.providers : [];
   const optionalConfigKeys = new Set([
@@ -101,6 +103,53 @@ export function liveProviderList(env = process.env) {
     providers.push("openai");
   }
   return providers;
+}
+
+export async function inspectSmokeKeyProviderAccess({
+  baseUrl,
+  smokeKey,
+  liveProviders,
+  fetchImpl = fetch,
+}) {
+  let response;
+  try {
+    response = await fetchImpl(`${baseUrl.replace(/\/$/, "")}/v1/key/inspect`, {
+      headers: { authorization: `Bearer ${smokeKey}` },
+      redirect: "manual",
+    });
+  } catch (error) {
+    throw new SmokeKeyInspectionUnavailableError(
+      `could not reach /v1/key/inspect: ${error.message}`,
+    );
+  }
+  if (!response.ok) {
+    throw new SmokeKeyInspectionUnavailableError(`/v1/key/inspect failed with ${response.status}`);
+  }
+  let inspection;
+  try {
+    inspection = await response.json();
+  } catch (error) {
+    throw new SmokeKeyInspectionUnavailableError(
+      `/v1/key/inspect returned invalid JSON: ${error.message}`,
+    );
+  }
+  if (inspection?.verified !== true) {
+    throw new Error(
+      `/v1/key/inspect rejected the smoke key: ${inspection?.verification ?? "unknown"}`,
+    );
+  }
+  if (!Array.isArray(inspection.providers)) {
+    throw new SmokeKeyInspectionUnavailableError(
+      "/v1/key/inspect did not expose the smoke key provider scope",
+    );
+  }
+  const denied = liveProviders.filter(
+    (provider) => inspection.providers.length > 0 && !inspection.providers.includes(provider),
+  );
+  if (denied.length > 0) {
+    throw new Error(`smoke key policy does not allow live providers: ${denied.join(",")}`);
+  }
+  return inspection;
 }
 
 export function compileProviderSnapshot() {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -3,6 +3,7 @@ import {
   inspectSmokeKeyProviderAccess,
   liveProviderList,
   runLiveProviderSmokes,
+  selectLiveProviderPlans,
   summarizePlan,
 } from "./provider-smoke-plan.mjs";
 
@@ -37,7 +38,14 @@ if (liveProviders.length === 0) {
 if (!smokeKey) {
   throw new Error("CLAWROUTER_SMOKE_KEY is required for live provider smoke");
 }
-await inspectSmokeKeyProviderAccess({ baseUrl, smokeKey, liveProviders });
+const selectedLiveProviders = selectLiveProviderPlans(plan, liveProviders).map(
+  (provider) => provider.id,
+);
+await inspectSmokeKeyProviderAccess({
+  baseUrl,
+  smokeKey,
+  liveProviders: selectedLiveProviders,
+});
 const results = await runLiveProviderSmokes({
   baseUrl,
   smokeKey,

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -1,5 +1,6 @@
 import {
   buildProviderSmokePlan,
+  inspectSmokeKeyProviderAccess,
   liveProviderList,
   runLiveProviderSmokes,
   summarizePlan,
@@ -29,19 +30,6 @@ if (plan.targetCount !== plan.providerCount) {
 }
 console.log(summarizePlan(plan));
 
-if (smokeKey) {
-  const inspect = await fetch(`${baseUrl}/v1/key/inspect`, {
-    headers: { authorization: `Bearer ${smokeKey}` },
-  });
-  if (!inspect.ok) {
-    throw new Error(`/v1/key/inspect failed with ${inspect.status}`);
-  }
-  const inspection = await inspect.json();
-  if (inspection?.verified !== true) {
-    throw new Error(`/v1/key/inspect rejected the smoke key: ${inspection?.verification ?? "unknown"}`);
-  }
-}
-
 const liveProviders = liveProviderList();
 if (liveProviders.length === 0) {
   throw new Error("CLAWROUTER_SMOKE_LIVE_PROVIDERS must name at least one golden provider");
@@ -49,6 +37,7 @@ if (liveProviders.length === 0) {
 if (!smokeKey) {
   throw new Error("CLAWROUTER_SMOKE_KEY is required for live provider smoke");
 }
+await inspectSmokeKeyProviderAccess({ baseUrl, smokeKey, liveProviders });
 const results = await runLiveProviderSmokes({
   baseUrl,
   smokeKey,

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { runLiveProviderSmokes } from "../scripts/provider-smoke-plan.mjs";
+import {
+  inspectSmokeKeyProviderAccess,
+  runLiveProviderSmokes,
+  SmokeKeyInspectionUnavailableError,
+} from "../scripts/provider-smoke-plan.mjs";
 
 const plan = {
   providers: [
@@ -37,6 +41,75 @@ test("gateway failures do not overwrite provider health", async () => {
       );
       assert.deepEqual(recorded, []);
     },
+  );
+});
+
+test("smoke key inspection rejects selected providers outside policy scope", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example/",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      fetchImpl: async (url, init) => {
+        assert.equal(url, "https://clawrouter.example/v1/key/inspect");
+        assert.equal(init.headers.authorization, "Bearer smoke-key");
+        assert.equal(init.redirect, "manual");
+        return Response.json({
+          verified: true,
+          verification: "verified",
+          providers: ["openrouter"],
+        });
+      },
+    }),
+    /smoke key policy does not allow live providers: openai/,
+  );
+});
+
+test("smoke key inspection accepts explicit and wildcard provider scope", async () => {
+  for (const providers of [["openai"], []]) {
+    const inspection = await inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      fetchImpl: async () =>
+        Response.json({
+          verified: true,
+          verification: "verified",
+          providers,
+        }),
+    });
+    assert.deepEqual(inspection.providers, providers);
+  }
+});
+
+test("smoke key inspection reports revoked or stale credentials before provider smoke", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      fetchImpl: async () =>
+        Response.json({
+          verified: false,
+          verification: "policy_generation_mismatch",
+          providers: null,
+        }),
+    }),
+    /rejected the smoke key: policy_generation_mismatch/,
+  );
+});
+
+test("smoke key inspection distinguishes unavailable current deployments", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+    }),
+    SmokeKeyInspectionUnavailableError,
   );
 });
 

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -147,6 +147,24 @@ test("smoke key inspection keeps malformed credentials fatal", async () => {
   );
 });
 
+test("smoke key inspection treats redirects and access challenges as unavailable", async () => {
+  for (const response of [
+    new Response(null, { status: 302, headers: { location: "https://access.example" } }),
+    Response.json({ error: { code: "access_required" } }, { status: 403 }),
+    Response.json({ error: { code: "rate_limited" } }, { status: 429 }),
+  ]) {
+    await assert.rejects(
+      inspectSmokeKeyProviderAccess({
+        baseUrl: "https://clawrouter.example",
+        smokeKey: "smoke-key",
+        liveProviders: ["openai"],
+        fetchImpl: async () => response,
+      }),
+      SmokeKeyInspectionUnavailableError,
+    );
+  }
+});
+
 test("all live provider selection expands to concrete provider ids", () => {
   const selected = selectLiveProviderPlans(
     {

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   inspectSmokeKeyProviderAccess,
   runLiveProviderSmokes,
+  selectLiveProviderPlans,
   SmokeKeyInspectionUnavailableError,
 } from "../scripts/provider-smoke-plan.mjs";
 
@@ -110,6 +111,62 @@ test("smoke key inspection distinguishes unavailable current deployments", async
       },
     }),
     SmokeKeyInspectionUnavailableError,
+  );
+});
+
+test("smoke key inspection treats missing policy authority as unavailable", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      fetchImpl: async () =>
+        Response.json({
+          verified: false,
+          verification: "policy_store_unavailable",
+          providers: null,
+        }),
+    }),
+    SmokeKeyInspectionUnavailableError,
+  );
+});
+
+test("smoke key inspection keeps malformed credentials fatal", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "malformed",
+      liveProviders: ["openai"],
+      fetchImpl: async () =>
+        Response.json(
+          { error: { code: "invalid_key_syntax", message: "invalid" } },
+          { status: 400 },
+        ),
+    }),
+    /failed with 400: invalid_key_syntax/,
+  );
+});
+
+test("all live provider selection expands to concrete provider ids", () => {
+  const selected = selectLiveProviderPlans(
+    {
+      providers: [
+        ...plan.providers,
+        {
+          id: "anthropic",
+          target: {
+            kind: "openai_chat",
+            route: "/v1/chat/completions",
+            body: { model: "anthropic/test" },
+          },
+        },
+      ],
+    },
+    ["all"],
+  );
+  assert.deepEqual(
+    selected.map((provider) => provider.id),
+    ["openai", "anthropic"],
   );
 });
 

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -114,6 +114,23 @@ test("smoke key inspection distinguishes unavailable current deployments", async
   );
 });
 
+test("smoke key inspection bounds requests and treats timeouts as unavailable", async () => {
+  await assert.rejects(
+    inspectSmokeKeyProviderAccess({
+      baseUrl: "https://clawrouter.example",
+      smokeKey: "smoke-key",
+      liveProviders: ["openai"],
+      timeoutMs: 1,
+      fetchImpl: async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          assert.equal(init.signal instanceof AbortSignal, true);
+          init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        }),
+    }),
+    SmokeKeyInspectionUnavailableError,
+  );
+});
+
 test("smoke key inspection treats missing policy authority as unavailable", async () => {
   await assert.rejects(
     inspectSmokeKeyProviderAccess({


### PR DESCRIPTION
## Summary
- verify the current smoke credential and selected provider scope before publishing a Worker
- preserve first-deploy and recovery paths when inspection is unavailable, access-gated, or times out
- make post-deploy smoke use the same strict policy validation and support the documented `all` selector

## Verification
- `npm run test:scripts` (24 tests)
- script syntax checks
- `actionlint`
- `git diff --check`
- autoreview: clean, no actionable findings (0.93 confidence)

## Deployment status
- pending merge and Cloudflare redeploy
- current production Worker is deployed, but mandatory OpenAI smoke is blocked by the existing smoke policy scope

## Remaining risk
- live `smoke260614` policy must be updated to allow OpenAI before the deployment smoke can pass