### PR TITLE
fix(providers): use live OpenAI smoke model

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The legacy revoke alias treats `<kid>` as a credential id and never disables a
 shared policy.
 
 OpenAI-compatible proxy requests route by the request body `model` field, for
-example `openai/gpt-5.5-mini`. Before an upstream provider secret is used, the
+example `openai/gpt-4.1-mini`. Before an upstream provider secret is used, the
 Worker verifies the issued credential and its policy from serialized
 `ACCESS_CONTROL` Durable Object authority. `credentials/<credential-id>` and
 `policies/<policy-id>` in `POLICY_KV` seed migration and remain compatibility

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -2321,7 +2321,7 @@ function demoData() {
       modelRoute("huggingface", ["/models/{model}"], [modelEntry("huggingface/model", ["llm.invoke"], ["/models/{model}"])]),
       modelRoute("minimax", ["/v1/chat/completions"], [modelEntry("minimax/MiniMax-M3", ["llm.chat"], ["/v1/chat/completions"])]),
       modelRoute("mistral", ["/v1/chat/completions", "/v1/embeddings"], [modelEntry("mistral/default", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("openai", ["/v1/responses", "/v1/chat/completions", "/v1/embeddings"], [modelEntry("openai/gpt-5.5-mini", ["llm.responses", "llm.chat"], ["/v1/responses", "/v1/chat/completions"]), modelEntry("openai/text-embedding-3-large", ["llm.embeddings"], ["/v1/embeddings"])]),
+      modelRoute("openai", ["/v1/responses", "/v1/chat/completions", "/v1/embeddings"], [modelEntry("openai/gpt-4.1-mini", ["llm.responses", "llm.chat"], ["/v1/responses", "/v1/chat/completions"]), modelEntry("openai/text-embedding-3-large", ["llm.embeddings"], ["/v1/embeddings"])]),
       modelRoute("openrouter", ["/v1/chat/completions"], [modelEntry("openrouter/auto", ["llm.chat"], ["/v1/chat/completions"])]),
       modelRoute("perplexity", ["/chat/completions"], [modelEntry("perplexity/default", ["llm.chat"], ["/chat/completions"])]),
       modelRoute("together", ["/v1/chat/completions"], [modelEntry("together/default", ["llm.chat"], ["/v1/chat/completions"])]),

--- a/crates/core/src/routing.rs
+++ b/crates/core/src/routing.rs
@@ -39,9 +39,9 @@ mod tests {
 
     #[test]
     fn matches_provider_prefixes() {
-        assert!(match_model("openai/", "openai/gpt-5.5-mini"));
+        assert!(match_model("openai/", "openai/gpt-4.1-mini"));
         assert!(match_model("tavily/", "tavily/search"));
-        assert!(match_model("openai/gpt-*", "openai/gpt-5.5-mini"));
+        assert!(match_model("openai/gpt-*", "openai/gpt-4.1-mini"));
         assert!(match_model("minimax/*", "minimax/MiniMax-M3"));
         assert!(!match_model("openai/", "openrouter/auto"));
         assert!(!match_model("openai/*", "tavily/search"));

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -9245,9 +9245,9 @@ mod tests {
     #[test]
     fn catalog_models_use_mapped_upstream_model() {
         let snapshot = provider_snapshot().unwrap();
-        let route = select_model_route(&snapshot, "openai/gpt-5.5-mini").unwrap();
+        let route = select_model_route(&snapshot, "openai/gpt-4.1-mini").unwrap();
         assert_eq!(route.provider.id, "openai");
-        assert_eq!(route.upstream_model, "gpt-5.5-mini");
+        assert_eq!(route.upstream_model, "gpt-4.1-mini");
     }
 
     #[test]

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -508,7 +508,7 @@ OpenAI-compatible calls use normal OpenAI paths and route by `model`:
 curl "$CLAWROUTER_BASE_URL/v1/chat/completions" \
   -H "authorization: Bearer $CLAWROUTER_KEY" \
   -H "content-type: application/json" \
-  --data '{"model":"openai/gpt-5.5-mini","messages":[{"role":"user","content":"ok"}]}'
+  --data '{"model":"openai/gpt-4.1-mini","messages":[{"role":"user","content":"ok"}]}'
 ```
 
 Manifest REST/tool calls use:

--- a/providers/README.md
+++ b/providers/README.md
@@ -60,7 +60,7 @@ billing:
   policy grants.
 - `routing.nativePrefixes` lets OpenClaw route native keys such as
   `clawrouter-openai-*` to a provider without users setting `base_url`.
-- `routing.modelPrefixes` maps model names like `openai/gpt-5.5-mini` to the
+- `routing.modelPrefixes` maps model names like `openai/gpt-4.1-mini` to the
   provider snapshot.
 - `auth.schemes` declares how ClawRouter injects the upstream credential.
 - `adapter` declares the request/response family. Use `custom_adapter` only after

--- a/providers/_fixtures/cloudflare-ai-gateway/universal-basic.request.json
+++ b/providers/_fixtures/cloudflare-ai-gateway/universal-basic.request.json
@@ -3,7 +3,7 @@
     "provider": "openai",
     "endpoint": "chat/completions",
     "query": {
-      "model": "openai/gpt-5.5-mini",
+      "model": "openai/gpt-4.1-mini",
       "messages": [{ "role": "user", "content": "ping" }]
     }
   }

--- a/providers/_fixtures/openai/chat-basic.request.json
+++ b/providers/_fixtures/openai/chat-basic.request.json
@@ -1,5 +1,4 @@
 {
-  "model": "openai/gpt-5.5-mini",
+  "model": "openai/gpt-4.1-mini",
   "messages": [{ "role": "user", "content": "ping" }]
 }
-

--- a/providers/_fixtures/openai/chat-basic.response.json
+++ b/providers/_fixtures/openai/chat-basic.response.json
@@ -1,8 +1,7 @@
 {
   "id": "chatcmpl_test",
   "object": "chat.completion",
-  "model": "gpt-5.5-mini",
+  "model": "gpt-4.1-mini",
   "choices": [{ "index": 0, "message": { "role": "assistant", "content": "pong" }, "finish_reason": "stop" }],
   "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
 }
-

--- a/providers/openai.provider.yaml
+++ b/providers/openai.provider.yaml
@@ -56,10 +56,10 @@ endpoints:
     timeoutMs: 120000
 models:
   entries:
-    - id: openai/gpt-5.5-mini
-      upstream: gpt-5.5-mini
+    - id: openai/gpt-4.1-mini
+      upstream: gpt-4.1-mini
       capabilities: [llm.responses, llm.chat]
-      pricingRef: openai-gpt-5.5-mini
+      pricingRef: openai-gpt-4.1-mini
     - id: openai/text-embedding-3-large
       upstream: text-embedding-3-large
       capabilities: [llm.embeddings]

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -533,7 +533,7 @@ function sampleBody(provider, endpoint, method, env) {
       provider: "openai",
       endpoint: "chat/completions",
       query: {
-        model: env.CLOUDFLARE_AI_GATEWAY_SMOKE_MODEL ?? "openai/gpt-5.5-mini",
+        model: env.CLOUDFLARE_AI_GATEWAY_SMOKE_MODEL ?? "openai/gpt-4.1-mini",
         messages: [{ role: "user", content: "reply with ok" }],
         max_tokens: 8,
       },

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildProviderSmokePlan,
+  compileProviderSnapshot,
   inspectSmokeKeyProviderAccess,
   runLiveProviderSmokes,
   selectLiveProviderPlans,
@@ -20,6 +22,13 @@ const plan = {
     },
   ],
 };
+
+test("bundled OpenAI smoke target uses the catalog default model", () => {
+  const provider = buildProviderSmokePlan(compileProviderSnapshot(), {}).providers.find(
+    (entry) => entry.id === "openai",
+  );
+  assert.equal(provider.target.body.model, "openai/gpt-4.1-mini");
+});
 
 test("gateway failures do not overwrite provider health", async () => {
   await withFetch(


### PR DESCRIPTION
## Summary
- replace the fictional bundled OpenAI model with verified `gpt-4.1-mini`
- keep runtime catalog, smoke fallback, demo data, fixtures, route tests, and docs consistent
- add a regression test for the bundled OpenAI smoke target

## Root cause
The provider manifest advertised `gpt-5.5-mini`, which does not exist. Once a real OpenAI key was configured, the live smoke reached upstream and failed with HTTP 404.

## Verification
- direct OpenAI `gpt-4.1-mini` chat request: HTTP 200
- `cargo test --workspace`
- `npm run test:scripts`
- `npm --prefix admin run check`
- `npm --prefix admin test`
- `npm --prefix admin run build`
- provider snapshot compile confirms `openai/gpt-4.1-mini` maps to `gpt-4.1-mini`
- structured autoreview clean: no actionable findings