### PR TITLE
feat(edge): add native provider credential broker

### DIFF
--- a/.spec/2026-06-16-clawrouter-native-broker.md
+++ b/.spec/2026-06-16-clawrouter-native-broker.md
@@ -1,0 +1,375 @@
+# ClawRouter Native Broker Spec
+
+Status: implementation target
+
+## Purpose
+
+ClawRouter is the credential broker and policy-enforced transport for OpenClaw
+provider traffic.
+
+Users keep canonical provider and model identities such as
+`anthropic/claude-opus-*`, `openai/gpt-*`, and `google/gemini-*`. OpenClaw
+authenticates once to ClawRouter instead of storing every upstream provider key.
+ClawRouter selects an allowed upstream connection, injects its credential, and
+forwards the provider-native request without changing its wire contract.
+
+This phase implements the ClawRouter side only. Changes to `openclaw/openclaw`
+and the OpenClaw ClawRouter plugin are explicitly out of scope.
+
+## Product Contract
+
+A maintainer must be able to:
+
+1. Authenticate to ClawRouter using a scoped machine credential or a verified
+   Cloudflare Access session.
+2. Discover the providers, models, routes, and upstream connection types they
+   are entitled to use.
+3. Send a native provider request through ClawRouter without possessing the
+   upstream provider credential.
+4. Receive the upstream status, body, stream, and safe headers without
+   ClawRouter normalizing or reserializing the payload.
+5. Use an API-key, OAuth, or subscription-backed upstream connection selected
+   by policy.
+6. Have access revoked immediately through the existing policy and credential
+   authority.
+
+An administrator must be able to:
+
+1. Register, inspect, disable, and revoke named upstream grants.
+2. Scope grants to a policy or tenant.
+3. Distinguish API-key, OAuth, and subscription-backed grants without exposing
+   their secrets.
+4. See which transport routes and grants make a provider executable.
+
+## Security Boundaries
+
+- OpenClaw never receives an upstream provider secret, OAuth access token,
+  refresh token, or subscription credential.
+- ClawRouter client authentication and upstream provider authentication are
+  separate credentials.
+- The native broker is manifest-allowlisted. It is not an unrestricted forward
+  proxy.
+- Incoming provider auth headers and cookies are never forwarded upstream.
+- Hop-by-hop and Cloudflare Access headers are never forwarded upstream.
+- Upstream response cookies and unsafe hop-by-hop headers are never returned.
+- Request and response bodies are never logged.
+- Policy authorization, provider connection state, and budget preflight happen
+  before the upstream request.
+- Revocation and budget checks remain on the authoritative data-plane path.
+
+## Public Data-Plane API
+
+### Native provider transport
+
+```text
+<METHOD> /v1/native/<provider>/<provider-native-path>
+```
+
+Examples:
+
+```text
+POST /v1/native/anthropic/v1/messages
+POST /v1/native/openai/v1/responses
+POST /v1/native/google-gemini/v1beta/models/gemini-2.5-pro:generateContent
+GET  /v1/native/replicate/v1/predictions/<id>
+```
+
+The provider-native path must match an endpoint declared by that provider's
+manifest. Endpoint path parameters use the existing safe segment and safe
+relative-path validation.
+
+The native route:
+
+1. Resolves the provider and manifest endpoint from method and path.
+2. Authorizes the ClawRouter caller for that provider.
+3. Selects the caller's policy-scoped or tenant-scoped upstream grant.
+4. Preserves the original query string.
+5. Preserves the original request body bytes.
+6. Copies only manifest-declared safe request headers.
+7. Removes incoming provider authorization and injects the selected upstream
+   grant.
+8. Preserves the upstream response body/stream and status.
+9. Copies only safe response headers.
+10. Emits the existing audit, usage, and budget events.
+
+The route accepts both:
+
+- ClawRouter proxy credentials in `Authorization: Bearer clawrouter-*`.
+- Verified Cloudflare Access sessions when the request is not browser-only and
+  the application token is valid.
+
+Access-session support must not reuse the playground CSRF exception. The
+playground remains a browser surface; `/v1/native/*` is a client API surface.
+
+### Discovery
+
+```text
+GET /v1/models
+GET /v1/catalog
+```
+
+`/v1/models` returns the OpenAI-compatible model-list shape and only includes
+models allowed by the caller's effective policies.
+
+`/v1/catalog` returns the richer ClawRouter contract:
+
+```json
+{
+  "providers": [
+    {
+      "id": "anthropic",
+      "allowed": true,
+      "executable": true,
+      "nativeBaseUrl": "/v1/native/anthropic",
+      "routes": [
+        {
+          "endpoint": "messages",
+          "methods": ["POST"],
+          "path": "/v1/messages",
+          "streaming": "sse"
+        }
+      ],
+      "models": [],
+      "connectionTypes": ["api_key", "oauth", "subscription"],
+      "reasons": []
+    }
+  ]
+}
+```
+
+Discovery responses are private to the authenticated caller. They may use
+private caching and `ETag`, but must never be shared across policies or users.
+
+## Provider Manifest Contract
+
+Provider manifests remain the authority for executable upstream paths.
+
+Each existing endpoint is automatically eligible for native proxying when:
+
+- its method is declared;
+- its path template is valid;
+- its auth scheme is executable; and
+- its runtime base URL/config placeholders are resolvable.
+
+New optional endpoint fields:
+
+```yaml
+endpoints:
+  responses:
+    path: /v1/responses
+    methods: [POST]
+    nativeProxy: true
+    requestHeaders: [OpenAI-Organization, OpenAI-Project]
+    responseHeaders: [content-type, request-id, x-request-id]
+```
+
+Defaults:
+
+- `nativeProxy: true`
+- request headers inherit `adapter.passthroughHeaders`
+- safe response headers include content type, content encoding, cache metadata,
+  retry metadata, rate-limit metadata, and request-id metadata
+
+An endpoint may set `nativeProxy: false` when its provider-native contract
+cannot safely be brokered.
+
+## Wire Preservation
+
+Native transport is intentionally separate from the normalized OpenAI and
+manifest-wrapper routes.
+
+Native transport must not:
+
+- parse or serialize a JSON body;
+- rename fields;
+- rewrite a model identifier;
+- wrap a request body;
+- convert a multipart body;
+- buffer or parse an SSE response;
+- reinterpret an upstream error response.
+
+Native transport may:
+
+- buffer request bytes when required by the Cloudflare Worker runtime;
+- replace upstream auth;
+- apply manifest-declared static headers and query parameters;
+- perform SigV4 signing;
+- add ClawRouter trace/audit headers;
+- remove unsafe headers;
+- clone a small JSON response only for usage extraction when doing so does not
+  alter the returned response.
+
+Conformance fixtures must prove exact request-body preservation for:
+
+- JSON with unknown fields and non-canonical whitespace;
+- multipart/binary bodies;
+- empty GET/HEAD bodies;
+- SSE/streaming responses;
+- upstream JSON and non-JSON errors.
+
+## Upstream Grant Model
+
+The existing `oauth/<policy-or-tenant>/<tokenRef>` records become versioned
+upstream grant records while retaining compatibility with legacy access-token
+records.
+
+Canonical record:
+
+```json
+{
+  "version": 1,
+  "enabled": true,
+  "kind": "oauth",
+  "provider": "openai",
+  "label": "maintainer subscription",
+  "tokenType": "Bearer",
+  "accessToken": "<secret>",
+  "refreshToken": "<secret>",
+  "expiresAt": "2026-06-16T12:00:00Z",
+  "scopes": ["..."],
+  "accountId": "redacted-stable-identifier",
+  "subscription": {
+    "plan": "plus",
+    "subject": "redacted-stable-identifier"
+  },
+  "refresh": {
+    "tokenUrl": "https://provider.example/oauth/token",
+    "clientIdConfig": "PROVIDER_OAUTH_CLIENT_ID",
+    "clientSecretConfig": "PROVIDER_OAUTH_CLIENT_SECRET",
+    "extraParams": {}
+  },
+  "createdAt": "2026-06-16T00:00:00Z",
+  "updatedAt": "2026-06-16T00:00:00Z"
+}
+```
+
+Supported kinds:
+
+- `api_key`
+- `oauth`
+- `subscription`
+
+`subscription` means that the credential was acquired through a user
+subscription flow. It does not bypass provider terms or imply that every
+subscription transport can be safely proxied.
+
+Legacy records containing only `accessToken`, `access_token`, or a raw token
+remain readable.
+
+### Grant selection
+
+Selection order:
+
+1. policy-scoped explicit token reference;
+2. policy-scoped provider/OAuth-provider grant;
+3. tenant-scoped explicit token reference;
+4. tenant-scoped provider/OAuth-provider grant.
+
+The first enabled, usable grant wins. A policy-scoped revoked or invalid grant
+fails closed and must not silently fall through to a personal or broader tenant
+grant.
+
+### Refresh
+
+When an OAuth/subscription grant is expired or within the refresh window:
+
+1. Resolve the manifest-approved token URL and client config bindings.
+2. Exchange the refresh token using the standard OAuth refresh-token grant.
+3. Persist the rotated access token, refresh token, and expiry.
+4. Retry the upstream authorization step once.
+
+Refresh requests must never accept an arbitrary token URL supplied by a client.
+Provider-specific non-standard refresh flows require an explicit adapter.
+
+## Control-Plane API
+
+New admin endpoints:
+
+```text
+GET    /v1/admin/upstream-grants
+PUT    /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>
+POST   /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>/revoke
+POST   /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>/refresh
+```
+
+`scope` is `policies` or `tenants`.
+
+List/read responses return metadata only. They must never include access tokens,
+refresh tokens, API keys, or client secrets.
+
+Mutation bodies may contain secrets, but errors, logs, audit records, and
+responses must not echo them.
+
+The existing `cf:oauth:put` and `cf:oauth:revoke` scripts remain compatibility
+tools and are updated to write the canonical record.
+
+## Cloudflare Access And Auto Assignment
+
+ClawRouter already creates a first-login Access user as enabled `user` with no
+groups or grants. That fail-closed behavior remains.
+
+Assignment reconciliation is a separate control-plane concern:
+
+- exact email -> group/policy;
+- verified email domain -> group/policy;
+- GitHub organization/team -> group/policy.
+
+Rules must carry provenance, priority, and revoke-on-membership-loss behavior.
+Reconciliation runs on login and asynchronously/scheduled, never on every
+provider request.
+
+This spec reserves:
+
+```text
+GET /v1/admin/assignment-rules
+PUT /v1/admin/assignment-rules/<rule-id>
+POST /v1/admin/assignment-rules/reconcile
+```
+
+The native broker and grant lifecycle must not depend on assignment-rule
+implementation.
+
+## Compatibility
+
+The following existing surfaces remain supported:
+
+- `/v1/chat/completions`
+- `/v1/responses`
+- `/v1/embeddings`
+- `/v1/proxy/<provider>/<endpoint>`
+- `/v1/playground/*`
+- legacy OAuth grant records and scripts
+
+They may internally reuse the new grant parser and selection logic. They do not
+become wire-preserving routes.
+
+## Delivery Order
+
+1. Add this specification and executable manifest metadata.
+2. Add native route matching and byte-preserving request/response transport.
+3. Add authenticated entitlement-filtered `/v1/models` and `/v1/catalog`.
+4. Add canonical upstream-grant records and metadata-only admin APIs.
+5. Add standard OAuth refresh and subscription metadata support.
+6. Update scripts, docs, smoke coverage, and admin readiness.
+7. Add assignment-rule reconciliation in a later isolated change.
+8. Implement OpenClaw core/plugin integration after the ClawRouter contract is
+   deployed and proven.
+
+## Acceptance Criteria
+
+- A caller allowed for Anthropic can send a native `/v1/messages` request
+  through `/v1/native/anthropic/v1/messages` without an Anthropic key.
+- A caller denied for Anthropic receives `provider_not_allowed` before any
+  upstream request.
+- Unknown provider-native paths and methods fail closed.
+- Native transport preserves request body bytes and upstream response status and
+  body bytes.
+- Incoming provider auth and cookies never reach the upstream.
+- API-key, OAuth, and subscription grant metadata are represented and listed
+  without returning secrets.
+- Expiring standard OAuth grants can refresh through manifest-approved
+  configuration.
+- `/v1/models` and `/v1/catalog` show only caller-entitled providers/models.
+- Existing normalized and manifest-wrapper routes remain compatible.
+- Focused Rust, manifest, script, and deployed smoke tests cover the new
+  contract.

--- a/.spec/2026-06-16-clawrouter-native-broker.md
+++ b/.spec/2026-06-16-clawrouter-native-broker.md
@@ -40,6 +40,8 @@ An administrator must be able to:
 3. Distinguish API-key, OAuth, and subscription-backed grants without exposing
    their secrets.
 4. See which transport routes and grants make a provider executable.
+5. Start and complete provider-approved browser OAuth flows without manually
+   handling access or refresh tokens.
 
 ## Security Boundaries
 
@@ -222,6 +224,9 @@ Canonical record:
   "kind": "oauth",
   "provider": "openai",
   "label": "maintainer subscription",
+  "credentials": {
+    "providerSpecificField": "<secret>"
+  },
   "tokenType": "Bearer",
   "accessToken": "<secret>",
   "refreshToken": "<secret>",
@@ -253,8 +258,52 @@ Supported kinds:
 subscription flow. It does not bypass provider terms or imply that every
 subscription transport can be safely proxied.
 
+`credentials` is an optional opaque, write-only credential bundle for auth
+schemes that require multiple fields. ClawRouter interprets only fields
+declared by the provider auth scheme. For SigV4, the canonical fields are
+`accessKeyId`, `secretAccessKey`, and optional `sessionToken`.
+
 Legacy records containing only `accessToken`, `access_token`, or a raw token
 remain readable.
+
+### Browser authorization
+
+A provider may declare a standard browser authorization flow:
+
+```yaml
+auth:
+  authorization:
+    authorizeUrl: https://provider.example/oauth/authorize
+    tokenUrl: https://provider.example/oauth/token
+    clientId: public-client-id
+    scopes: [openid, profile, offline_access]
+    grantKind: subscription
+    extraAuthorizeParams:
+      originator: clawrouter
+    accountIdJsonPointer: /provider/account_id
+```
+
+ClawRouter accepts only authorization and token endpoints, client bindings,
+scopes, extra parameters, grant kind, and JWT metadata pointers approved by the
+provider manifest. It never accepts those values from an admin request.
+
+The browser flow:
+
+1. Requires a verified Cloudflare Access admin session.
+2. Generates a high-entropy state and PKCE verifier.
+3. Stores the state, verifier, initiating admin, target grant key, provider,
+   redirect URI, and expiry in the authoritative Access Control Durable Object.
+4. Returns a provider authorization URL containing the one-time state and
+   `S256` PKCE challenge.
+5. Requires the same verified Access admin on callback.
+6. Atomically consumes the state before exchanging the authorization code.
+7. Exchanges the code only at the manifest-approved token URL.
+8. Persists the resulting canonical upstream grant and redirects back to the
+   upstream-grant admin surface.
+
+Authorization state expires after ten minutes. State values and PKCE verifiers
+are never written to KV, logs, or admin responses after the authorization URL
+is created.
 
 ### Grant selection
 
@@ -288,8 +337,10 @@ New admin endpoints:
 ```text
 GET    /v1/admin/upstream-grants
 PUT    /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>
+POST   /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>/authorize
 POST   /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>/revoke
 POST   /v1/admin/upstream-grants/<scope>/<scope-id>/<token-ref>/refresh
+GET    /v1/oauth/callback
 ```
 
 `scope` is `policies` or `tenants`.
@@ -350,9 +401,12 @@ become wire-preserving routes.
 3. Add authenticated entitlement-filtered `/v1/models` and `/v1/catalog`.
 4. Add canonical upstream-grant records and metadata-only admin APIs.
 5. Add standard OAuth refresh and subscription metadata support.
-6. Update scripts, docs, smoke coverage, and admin readiness.
-7. Add assignment-rule reconciliation in a later isolated change.
-8. Implement OpenClaw core/plugin integration after the ClawRouter contract is
+6. Add one-time browser OAuth authorization and callback handling.
+7. Add opaque multi-field credential bundles for provider auth schemes such as
+   SigV4.
+8. Update scripts, docs, smoke coverage, and admin readiness.
+9. Add assignment-rule reconciliation in a later isolated change.
+10. Implement OpenClaw core/plugin integration after the ClawRouter contract is
    deployed and proven.
 
 ## Acceptance Criteria
@@ -369,6 +423,10 @@ become wire-preserving routes.
   without returning secrets.
 - Expiring standard OAuth grants can refresh through manifest-approved
   configuration.
+- Browser OAuth uses a one-time, expiring, admin-bound PKCE state and persists
+  a canonical grant without exposing tokens to the browser.
+- SigV4 requests can use policy- or tenant-scoped multi-field credential
+  bundles without requiring Worker-global AWS credentials.
 - `/v1/models` and `/v1/catalog` show only caller-entitled providers/models.
 - Existing normalized and manifest-wrapper routes remain compatible.
 - Focused Rust, manifest, script, and deployed smoke tests cover the new

--- a/.spec/2026-06-16-clawrouter-native-broker.md
+++ b/.spec/2026-06-16-clawrouter-native-broker.md
@@ -94,14 +94,10 @@ The native route:
 9. Copies only safe response headers.
 10. Emits the existing audit, usage, and budget events.
 
-The route accepts both:
-
-- ClawRouter proxy credentials in `Authorization: Bearer clawrouter-*`.
-- Verified Cloudflare Access sessions when the request is not browser-only and
-  the application token is valid.
-
-Access-session support must not reuse the playground CSRF exception. The
-playground remains a browser surface; `/v1/native/*` is a client API surface.
+The route accepts ClawRouter proxy credentials in
+`Authorization: Bearer clawrouter-*`. Cloudflare Access sessions are limited to
+the explicitly same-origin playground surface; `/v1/native/*` is a machine
+client API and never falls back to browser Access identity.
 
 ### Discovery
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
 `/dashboard` path, `/dashboard` redirects to `/dashboard/catalog`, and canonical console views live under `/dashboard/*`, while
 public `/v1` catalog and proxy routes stay normal. The Access app must also
-protect `/v1/session` and `/v1/playground/*` so the browser console can
-bootstrap identity, entitlements, and playground calls from a verified Access
-session. A ClawRouter `access_session_required` JSON body on `/dashboard/*`,
-`/v1/session`, or `/v1/playground/*` means the Access app is not
+protect `/v1/session`, `/v1/playground/*`, `/v1/admin/*`, and
+`/v1/oauth/callback` so the browser console can bootstrap identity,
+entitlements, playground calls, admin mutations, and OAuth callbacks from a
+verified Access session. A ClawRouter `access_session_required` JSON body on
+`/dashboard/*`, `/v1/session`, `/v1/playground/*`, or `/v1/oauth/callback` means the Access app is not
 in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
 deployment smoke.
 
@@ -96,6 +97,7 @@ The Worker currently exposes:
 - `GET /v1/usage`
 - `GET /v1/models`
 - `GET /v1/catalog`
+- `GET /v1/oauth/callback`
 - `GET /v1/key/inspect`
 - `POST /v1/chat/completions`
 - `POST /v1/responses`
@@ -126,6 +128,7 @@ The Worker currently exposes:
 - `POST /v1/admin/credentials/<credential-id>/revoke`
 - `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke`
 - `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh`
+- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/authorize`
 - `POST /v1/admin/assignment-rules/reconcile`
 
 Legacy `GET|PUT /v1/admin/keys...`, `POST /v1/admin/keys/<kid>/revoke`, and
@@ -174,12 +177,16 @@ registration, and smoke commands.
 The legacy-named `pnpm cf:oauth:put` and `pnpm cf:oauth:revoke` helpers write
 canonical version 1 upstream-grant records for `api_key`, `oauth`, and
 `subscription` connections. They accept access tokens, refresh tokens, and
-credentials only through stdin, environment variables, or files, never argv.
+single- or multi-field credentials only through stdin, environment variables,
+or files, never argv.
 Revocation retains grant metadata in a disabled tombstone while removing
 secrets. See `docs/deploy-cloudflare.md` for the complete operator flow.
 
 Admin endpoints accept a verified Cloudflare Access admin session or
 `Authorization: Bearer <admin-token>` against `CLAWROUTER_ADMIN_TOKEN_SHA256`.
+Provider-approved browser OAuth starts only from a verified Access admin
+session, uses a one-time PKCE state, and stores the resulting grant without
+returning provider tokens to the browser.
 The browser console hashes generated proxy key secrets in-browser before
 issuing a credential, manages policies separately from credentials and provider
 connections, assigns explicit user/group policy bindings, shows provider
@@ -215,5 +222,7 @@ charged fail-closed. Messages that exhaust automatic retries move to the
 separate usage DLQ for operator inspection and replay before Cloudflare's
 four-day unconsumed-DLQ retention expires. Internal reservation ids are
 generated independently from caller-supplied request ids.
-OAuth, SigV4, and deployment-templated providers are still cataloged, but the
-edge path rejects them until the required token/signing/runtime mapping exists.
+OAuth, SigV4, and deployment-templated providers execute through the same
+policy-enforced proxy when their manifest-declared grant and remaining runtime
+configuration are present. Provider secrets can come from scoped upstream
+grants instead of Worker-global bindings.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ClawRouter is a high-throughput API gateway and provider router for OpenClaw services.
 
-It brokers proxy keys, service identities, provider credentials, OAuth grants, budgets, and metered usage across model providers, search APIs, tool APIs, and future service providers.
+It brokers proxy keys, service identities, versioned upstream grants, budgets, and metered usage across model providers, search APIs, tool APIs, and future service providers.
 
 Current implementation target:
 
@@ -12,8 +12,8 @@ Current implementation target:
 - TypeScript admin/control UI
 - declarative service provider manifests
 - OpenClaw-native `clawrouter-` key routing
-- Cloudflare KV-backed migration and compatibility records, OAuth grants, and
-  provider health
+- Cloudflare KV-backed migration and compatibility records, version 1
+  API-key/OAuth/subscription grants, and provider health
 
 ## Provider Registry
 
@@ -94,11 +94,14 @@ The Worker currently exposes:
 - `GET /v1/entitlements`
 - `GET /v1/me`
 - `GET /v1/usage`
+- `GET /v1/models`
+- `GET /v1/catalog`
 - `GET /v1/key/inspect`
 - `POST /v1/chat/completions`
 - `POST /v1/responses`
 - `POST /v1/embeddings`
 - `POST /v1/proxy/<provider>/<endpoint>`
+- `<METHOD> /v1/native/<provider>/<provider-native-path>`
 - `GET /v1/admin/overview`
 - `GET /v1/admin/tenants`
 - `GET /v1/admin/usage`
@@ -109,14 +112,18 @@ The Worker currently exposes:
 - `GET /v1/admin/policy-bindings`
 - `GET /v1/admin/provider-status`
 - `GET /v1/admin/provider-health`
+- `GET /v1/admin/upstream-grants`
 - `PUT /v1/admin/access-users/<email>`
 - `PUT /v1/admin/access-user-grants/<email>`
 - `PUT /v1/admin/policy-bindings`
 - `PUT /v1/admin/policies/<policy-id>`
 - `PUT /v1/admin/credentials/<credential-id>`
 - `PUT /v1/admin/connections/<provider-id>`
+- `PUT /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>`
 - `POST /v1/admin/policies/<policy-id>/revoke`
 - `POST /v1/admin/credentials/<credential-id>/revoke`
+- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke`
+- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh`
 
 Legacy `GET|PUT /v1/admin/keys...`, `POST /v1/admin/keys/<kid>/revoke`, and
 `GET /v1/admin/users` remain compatibility aliases during migration. New
@@ -160,6 +167,13 @@ migration only when they are genuine pre-migration records. Generation-bearing
 compatibility records stay disabled and are never authorization fallback. See
 `docs/deploy-cloudflare.md` for Cloudflare provisioning, deployment, key
 registration, and smoke commands.
+
+The legacy-named `pnpm cf:oauth:put` and `pnpm cf:oauth:revoke` helpers write
+canonical version 1 upstream-grant records for `api_key`, `oauth`, and
+`subscription` connections. They accept access tokens, refresh tokens, and
+credentials only through stdin, environment variables, or files, never argv.
+Revocation retains grant metadata in a disabled tombstone while removing
+secrets. See `docs/deploy-cloudflare.md` for the complete operator flow.
 
 Admin endpoints accept a verified Cloudflare Access admin session or
 `Authorization: Bearer <admin-token>` against `CLAWROUTER_ADMIN_TOKEN_SHA256`.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The Worker currently exposes:
 - `GET /v1/admin/provider-status`
 - `GET /v1/admin/provider-health`
 - `GET /v1/admin/upstream-grants`
+- `GET /v1/admin/assignment-rules`
 - `PUT /v1/admin/access-users/<email>`
 - `PUT /v1/admin/access-user-grants/<email>`
 - `PUT /v1/admin/policy-bindings`
@@ -120,10 +121,12 @@ The Worker currently exposes:
 - `PUT /v1/admin/credentials/<credential-id>`
 - `PUT /v1/admin/connections/<provider-id>`
 - `PUT /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>`
+- `PUT /v1/admin/assignment-rules/<rule-id>`
 - `POST /v1/admin/policies/<policy-id>/revoke`
 - `POST /v1/admin/credentials/<credential-id>/revoke`
 - `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke`
 - `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh`
+- `POST /v1/admin/assignment-rules/reconcile`
 
 Legacy `GET|PUT /v1/admin/keys...`, `POST /v1/admin/keys/<kid>/revoke`, and
 `GET /v1/admin/users` remain compatibility aliases during migration. New

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -43,6 +43,7 @@ export interface ProviderReadiness {
   configPresent: boolean;
   oauthGrantRequired: boolean;
   oauthGrantCount: number;
+  upstreamGrantCount: number;
   openaiCompatible: boolean;
   manifestRoutes: number;
   modelCount: number;

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -83,7 +83,7 @@ function initialViewFromPath(): View {
 
 function initialAccessTab(): AccessTab {
   const resource = new URLSearchParams(window.location.search).get("resource");
-  return resource === "credentials" || resource === "bindings" ? resource : "policies";
+  return resource === "credentials" || resource === "bindings" || resource === "upstream" || resource === "assignments" ? resource : "policies";
 }
 type AccessRole = "admin" | "user";
 type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
@@ -144,6 +144,47 @@ interface ProviderConnection {
   label?: string | null;
 }
 
+interface UpstreamGrant {
+  key: string;
+  scope: "policies" | "tenants";
+  scopeId: string;
+  tokenRef: string;
+  version: number;
+  enabled: boolean;
+  kind: "api_key" | "oauth" | "subscription";
+  provider?: string | null;
+  label?: string | null;
+  tokenType: string;
+  expiresAt?: string | null;
+  scopes: string[];
+  accountId?: string | null;
+  subscription?: { plan?: string | null; subject?: string | null } | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  revokedAt?: string | null;
+  hasCredential: boolean;
+  hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  refreshConfigured: boolean;
+  usable: boolean;
+}
+
+interface AssignmentRule {
+  ruleId: string;
+  version: number;
+  enabled: boolean;
+  kind: "exact_email" | "email_domain" | "github_org" | "github_team";
+  subject: string;
+  groups: string[];
+  policyIds: string[];
+  priority: number;
+  revokeOnLoss: boolean;
+  provenance: string;
+  generatedGroup: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
 interface SessionResponse {
   authenticated: boolean;
   auth: string;
@@ -167,6 +208,7 @@ interface ProviderReadiness {
   configPresent: boolean;
   oauthGrantRequired: boolean;
   oauthGrantCount: number;
+  upstreamGrantCount: number;
   openaiCompatible: boolean;
   manifestRoutes: number;
   modelCount: number;
@@ -364,7 +406,34 @@ interface BindingForm {
   priority: string;
 }
 
-type AccessTab = "policies" | "credentials" | "bindings";
+interface UpstreamGrantForm {
+  scope: "policies" | "tenants";
+  scopeId: string;
+  tokenRef: string;
+  kind: UpstreamGrant["kind"];
+  provider: string;
+  label: string;
+  enabled: boolean;
+  credential: string;
+  accessToken: string;
+  refreshToken: string;
+  accountId: string;
+  expiresAt: string;
+}
+
+interface AssignmentRuleForm {
+  ruleId: string;
+  enabled: boolean;
+  kind: AssignmentRule["kind"];
+  subject: string;
+  groups: string;
+  policyIds: string[];
+  priority: string;
+  revokeOnLoss: boolean;
+  provenance: string;
+}
+
+type AccessTab = "policies" | "credentials" | "bindings" | "upstream" | "assignments";
 
 interface PlaygroundForm {
   mode: "model" | "service";
@@ -413,6 +482,8 @@ const defaultAccess: AccessForm = {
 };
 const defaultCredential: CredentialForm = { credentialId: "", policyId: "" };
 const defaultBinding: BindingForm = { policyId: "", principalType: "group", principalId: "", enabled: true, priority: "100" };
+const defaultUpstreamGrant: UpstreamGrantForm = { scope: "policies", scopeId: "", tokenRef: "", kind: "api_key", provider: "", label: "", enabled: true, credential: "", accessToken: "", refreshToken: "", accountId: "", expiresAt: "" };
+const defaultAssignmentRule: AssignmentRuleForm = { ruleId: "", enabled: true, kind: "email_domain", subject: "", groups: "", policyIds: [], priority: "100", revokeOnLoss: true, provenance: "cloudflare_access" };
 
 const rolePresets = {
   sandbox: { budget: "5000000", request: "500", providers: ["openai", "openrouter"] },
@@ -440,6 +511,8 @@ function App() {
   const [keys, setKeys] = useState<AccessPolicy[]>(allowDemo ? demo.keys : []);
   const [credentials, setCredentials] = useState<ProxyCredential[]>(allowDemo ? demo.credentials : []);
   const [connections, setConnections] = useState<ProviderConnection[]>(allowDemo ? demo.connections : []);
+  const [upstreamGrants, setUpstreamGrants] = useState<UpstreamGrant[]>(allowDemo ? demo.upstreamGrants : []);
+  const [assignmentRules, setAssignmentRules] = useState<AssignmentRule[]>(allowDemo ? demo.assignmentRules : []);
   const [policyDataLoaded, setPolicyDataLoaded] = useState(allowDemo);
   const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
   const [bindings, setBindings] = useState<PolicyBinding[]>(allowDemo ? demo.bindings : []);
@@ -454,6 +527,8 @@ function App() {
   const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
   const [credentialForm, setCredentialForm] = useState<CredentialForm>(allowDemo && demo.keys[0] ? { credentialId: "", policyId: demo.keys[0].policyId } : defaultCredential);
   const [bindingForm, setBindingForm] = useState<BindingForm>(allowDemo && demo.keys[0] ? { ...defaultBinding, policyId: demo.keys[0].policyId } : defaultBinding);
+  const [upstreamGrantForm, setUpstreamGrantForm] = useState<UpstreamGrantForm>(allowDemo && demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
+  const [assignmentRuleForm, setAssignmentRuleForm] = useState<AssignmentRuleForm>(allowDemo && demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
   const [accessTab, setAccessTab] = useState<AccessTab>(initialAccessTab);
   const [accessForm, setAccessForm] = useState<AccessForm>(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
   const [query, setQuery] = useState("");
@@ -462,6 +537,8 @@ function App() {
   const [selectedPolicyId, setSelectedPolicyId] = useState(allowDemo ? demo.keys[0]?.policyId ?? "" : "");
   const [selectedCredentialId, setSelectedCredentialId] = useState(allowDemo ? demo.credentials[0]?.credentialId ?? "" : "");
   const [selectedBindingKey, setSelectedBindingKey] = useState(allowDemo ? bindingKey(demo.bindings[0]) : "");
+  const [selectedUpstreamGrantKey, setSelectedUpstreamGrantKey] = useState(allowDemo ? demo.upstreamGrants[0]?.key ?? "" : "");
+  const [selectedAssignmentRuleId, setSelectedAssignmentRuleId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
   const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
   const [status, setStatus] = useState(allowDemo ? "local demo data loaded" : "loading");
   const [demoMode, setDemoMode] = useState(allowDemo);
@@ -497,6 +574,8 @@ function App() {
   const selectedPolicy = keys.find((key) => key.policyId === selectedPolicyId);
   const selectedCredential = credentials.find((credential) => credential.credentialId === selectedCredentialId);
   const selectedBinding = bindings.find((binding) => bindingKey(binding) === selectedBindingKey);
+  const selectedUpstreamGrant = upstreamGrants.find((grant) => grant.key === selectedUpstreamGrantKey);
+  const selectedAssignmentRule = assignmentRules.find((rule) => rule.ruleId === selectedAssignmentRuleId);
   const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
   const selectedModel = models.find((model) => model.id === playground.model) ?? models[0];
   const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === playground.serviceRoute) ?? serviceRoutes[0];
@@ -566,17 +645,21 @@ function App() {
         }
       }
       if (sessionData.role === "admin") {
-        const [policyData, credentialData, connectionData, userData, bindingData, readinessData] = await Promise.all([
+        const [policyData, credentialData, connectionData, userData, bindingData, readinessData, upstreamGrantData, assignmentRuleData] = await Promise.all([
           request<{ policies: AccessPolicy[] }>(gatewayOrigin, "/v1/admin/policies"),
           request<{ credentials: ProxyCredential[] }>(gatewayOrigin, "/v1/admin/credentials"),
           request<{ connections: ProviderConnection[] }>(gatewayOrigin, "/v1/admin/connections"),
           request<{ users: AccessUser[] }>(gatewayOrigin, "/v1/admin/access-users"),
           request<{ bindings: PolicyBinding[] }>(gatewayOrigin, "/v1/admin/policy-bindings"),
           request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
+          request<{ grants: UpstreamGrant[] }>(gatewayOrigin, "/v1/admin/upstream-grants"),
+          request<{ rules: AssignmentRule[] }>(gatewayOrigin, "/v1/admin/assignment-rules"),
         ]);
         setKeys(policyData.policies);
         setCredentials(credentialData.credentials);
         setConnections(connectionData.connections);
+        setUpstreamGrants(upstreamGrantData.grants);
+        setAssignmentRules(assignmentRuleData.rules);
         const refreshedPolicy = policyData.policies.find((policy) => policy.policyId === selectedPolicyId) ?? policyData.policies[0];
         setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
         setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
@@ -586,6 +669,12 @@ function App() {
         const refreshedBinding = bindingData.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? bindingData.bindings[0];
         setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
         setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
+        const refreshedGrant = upstreamGrantData.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? upstreamGrantData.grants[0];
+        setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
+        setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerData.providers[0]?.id ?? "", tokenRef: providerData.providers[0]?.id ?? "" });
+        const refreshedRule = assignmentRuleData.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? assignmentRuleData.rules[0];
+        setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
+        setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
         setUsers(userData.users);
         setBindings(bindingData.bindings);
         const refreshedUser = userData.users.find((user) => user.email === selectedUserEmail) ?? userData.users[0];
@@ -624,6 +713,8 @@ function App() {
         setKeys([]);
         setCredentials([]);
         setConnections([]);
+        setUpstreamGrants([]);
+        setAssignmentRules([]);
         setPolicyDataLoaded(false);
         setUsers([user]);
         setBindings([]);
@@ -646,6 +737,8 @@ function App() {
         setKeys(demo.keys);
         setCredentials(demo.credentials);
         setConnections(demo.connections);
+        setUpstreamGrants(demo.upstreamGrants);
+        setAssignmentRules(demo.assignmentRules);
         setPolicyDataLoaded(true);
         setUsers(demo.users);
         setBindings(demo.bindings);
@@ -662,6 +755,10 @@ function App() {
         setCredentialForm({ credentialId: "", policyId: demo.keys[0]?.policyId ?? "" });
         setSelectedBindingKey(demo.bindings[0] ? bindingKey(demo.bindings[0]) : "");
         setBindingForm(demo.bindings[0] ? bindingFormFromBinding(demo.bindings[0]) : defaultBinding);
+        setSelectedUpstreamGrantKey(demo.upstreamGrants[0]?.key ?? "");
+        setUpstreamGrantForm(demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
+        setSelectedAssignmentRuleId(demo.assignmentRules[0]?.ruleId ?? "");
+        setAssignmentRuleForm(demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
         setSelectedUserEmail(demo.users[0]?.email ?? "");
         setAccessForm(demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
         setDemoMode(true);
@@ -803,6 +900,156 @@ function App() {
       setSelectedBindingKey(bindingKey(next));
       setBindingForm(bindingFormFromBinding(next));
       setStatus("saved binding");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function saveUpstreamGrant(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const scopeId = upstreamGrantForm.scopeId.trim();
+      const tokenRef = upstreamGrantForm.tokenRef.trim();
+      const provider = upstreamGrantForm.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() : upstreamGrantForm.accessToken.trim();
+      if (!selectedUpstreamGrant && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
+      const body = {
+        version: 1,
+        enabled: upstreamGrantForm.enabled,
+        kind: upstreamGrantForm.kind,
+        provider,
+        label: upstreamGrantForm.label.trim() || undefined,
+        tokenType: selectedUpstreamGrant?.tokenType ?? "Bearer",
+        expiresAt: upstreamGrantForm.expiresAt.trim() || undefined,
+        scopes: selectedUpstreamGrant?.scopes ?? [],
+        accountId: upstreamGrantForm.accountId.trim() || undefined,
+        subscription: selectedUpstreamGrant?.subscription ?? undefined,
+        ...(upstreamGrantForm.credential.trim() ? { credential: upstreamGrantForm.credential.trim() } : {}),
+        ...(upstreamGrantForm.accessToken.trim() ? { accessToken: upstreamGrantForm.accessToken.trim() } : {}),
+        ...(upstreamGrantForm.refreshToken.trim() ? { refreshToken: upstreamGrantForm.refreshToken.trim() } : {}),
+      };
+      const path = `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}`;
+      setStatus("saving upstream grant");
+      let saved: UpstreamGrant;
+      if (demoMode) {
+        saved = demoGrantFromForm(upstreamGrantForm, selectedUpstreamGrant);
+        setUpstreamGrants((current) => [saved, ...current.filter((grant) => grant.key !== saved.key)]);
+      } else {
+        saved = await request<UpstreamGrant>(gatewayOrigin, path, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        await refresh();
+      }
+      setSelectedUpstreamGrantKey(saved.key);
+      setUpstreamGrantForm(upstreamGrantFormFromGrant(saved));
+      setStatus("saved upstream grant");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function revokeUpstreamGrant(grant: UpstreamGrant) {
+    try {
+      setPolicyError("");
+      setStatus("revoking upstream grant");
+      let revoked: UpstreamGrant;
+      if (demoMode) {
+        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
+        setUpstreamGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
+      } else {
+        revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" });
+        await refresh();
+      }
+      setSelectedUpstreamGrantKey(revoked.key);
+      setUpstreamGrantForm(upstreamGrantFormFromGrant(revoked));
+      setStatus("revoked upstream grant");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function refreshUpstreamGrant(grant: UpstreamGrant) {
+    try {
+      setPolicyError("");
+      setStatus("refreshing upstream grant");
+      if (!demoMode) {
+        const refreshed = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/refresh`, { method: "POST" });
+        await refresh();
+        setSelectedUpstreamGrantKey(refreshed.key);
+        setUpstreamGrantForm(upstreamGrantFormFromGrant(refreshed));
+      }
+      setStatus("refreshed upstream grant");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function saveAssignmentRule(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const ruleId = assignmentRuleForm.ruleId.trim();
+      if (!/^[a-z0-9_]{4,48}$/.test(ruleId)) throw new Error("rule id must use 4-48 lowercase letters, numbers, or underscores");
+      if (!assignmentRuleForm.subject.trim()) throw new Error("rule subject is required");
+      const body = {
+        version: 1,
+        enabled: assignmentRuleForm.enabled,
+        kind: assignmentRuleForm.kind,
+        subject: assignmentRuleForm.subject.trim(),
+        groups: parseGroups(assignmentRuleForm.groups),
+        policyIds: assignmentRuleForm.policyIds,
+        priority: optionalNumber(assignmentRuleForm.priority) ?? 100,
+        revokeOnLoss: assignmentRuleForm.revokeOnLoss,
+        provenance: assignmentRuleForm.provenance.trim(),
+      };
+      setStatus("saving assignment rule");
+      let saved: AssignmentRule;
+      if (demoMode) {
+        saved = demoRuleFromForm(assignmentRuleForm);
+        setAssignmentRules((current) => [saved, ...current.filter((rule) => rule.ruleId !== saved.ruleId)]);
+      } else {
+        saved = await request<AssignmentRule>(gatewayOrigin, `/v1/admin/assignment-rules/${encodeURIComponent(ruleId)}`, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        await refresh();
+      }
+      setSelectedAssignmentRuleId(saved.ruleId);
+      setAssignmentRuleForm(assignmentRuleFormFromRule(saved));
+      setStatus("saved assignment rule");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function reconcileAssignments() {
+    try {
+      setPolicyError("");
+      setStatus("reconciling assignments");
+      if (!demoMode) {
+        await request<{ results: unknown[] }>(gatewayOrigin, "/v1/admin/assignment-rules/reconcile", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ all: true }),
+        });
+        await refresh();
+      }
+      setStatus("reconciled assignments");
     } catch (error) {
       const message = errorMessage(error);
       setPolicyError(message);
@@ -980,6 +1227,27 @@ function App() {
   function editBinding(binding: PolicyBinding) {
     setSelectedBindingKey(bindingKey(binding));
     setBindingForm(bindingFormFromBinding(binding));
+  }
+
+  function editUpstreamGrant(grant: UpstreamGrant) {
+    setSelectedUpstreamGrantKey(grant.key);
+    setUpstreamGrantForm(upstreamGrantFormFromGrant(grant));
+  }
+
+  function startNewUpstreamGrant() {
+    const provider = providers[0]?.id ?? "";
+    setSelectedUpstreamGrantKey("");
+    setUpstreamGrantForm({ ...defaultUpstreamGrant, scopeId: selectedPolicyId || keys[0]?.policyId || "default", provider, tokenRef: provider });
+  }
+
+  function editAssignmentRule(rule: AssignmentRule) {
+    setSelectedAssignmentRuleId(rule.ruleId);
+    setAssignmentRuleForm(assignmentRuleFormFromRule(rule));
+  }
+
+  function startNewAssignmentRule() {
+    setSelectedAssignmentRuleId("");
+    setAssignmentRuleForm({ ...defaultAssignmentRule, policyIds: [] });
   }
 
   function applyPreset(role: keyof typeof rolePresets) {
@@ -1175,6 +1443,10 @@ function App() {
             selectedCredential={selectedCredential}
             bindings={bindings}
             selectedBinding={selectedBinding}
+            upstreamGrants={upstreamGrants}
+            selectedUpstreamGrant={selectedUpstreamGrant}
+            assignmentRules={assignmentRules}
+            selectedAssignmentRule={selectedAssignmentRule}
             providers={providers}
             form={policyForm}
             setForm={setPolicyForm}
@@ -1182,12 +1454,21 @@ function App() {
             setCredentialForm={setCredentialForm}
             bindingForm={bindingForm}
             setBindingForm={setBindingForm}
+            upstreamGrantForm={upstreamGrantForm}
+            setUpstreamGrantForm={setUpstreamGrantForm}
+            assignmentRuleForm={assignmentRuleForm}
+            setAssignmentRuleForm={setAssignmentRuleForm}
             issuedKey={issuedKey}
             error={policyError}
             onSave={savePolicy}
             onIssueCredential={issueCredential}
             onRevokeCredential={revokeCredential}
             onSaveBinding={saveBinding}
+            onSaveUpstreamGrant={saveUpstreamGrant}
+            onRevokeUpstreamGrant={revokeUpstreamGrant}
+            onRefreshUpstreamGrant={refreshUpstreamGrant}
+            onSaveAssignmentRule={saveAssignmentRule}
+            onReconcileAssignments={reconcileAssignments}
             onNew={startNewPolicy}
             onEdit={editPolicy}
             onEditCredential={(credential) => {
@@ -1200,6 +1481,10 @@ function App() {
               setSelectedBindingKey("");
               setBindingForm({ ...defaultBinding, policyId: selectedPolicyId || keys[0]?.policyId || "" });
             }}
+            onEditUpstreamGrant={editUpstreamGrant}
+            onNewUpstreamGrant={startNewUpstreamGrant}
+            onEditAssignmentRule={editAssignmentRule}
+            onNewAssignmentRule={startNewAssignmentRule}
             onRevoke={revoke}
             onPreset={applyPreset}
             onToggleProvider={togglePolicyProvider}
@@ -1455,7 +1740,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
   );
 }
 
-function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCredential, bindings, selectedBinding, providers, form, setForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, issuedKey, error, onSave, onIssueCredential, onRevokeCredential, onSaveBinding, onNew, onEdit, onEditCredential, onEditBinding, onNewBinding, onRevoke, onPreset, onToggleProvider, onSetProviderGroup, busy }: {
+function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCredential, bindings, selectedBinding, upstreamGrants, selectedUpstreamGrant, assignmentRules, selectedAssignmentRule, providers, form, setForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, upstreamGrantForm, setUpstreamGrantForm, assignmentRuleForm, setAssignmentRuleForm, issuedKey, error, onSave, onIssueCredential, onRevokeCredential, onSaveBinding, onSaveUpstreamGrant, onRevokeUpstreamGrant, onRefreshUpstreamGrant, onSaveAssignmentRule, onReconcileAssignments, onNew, onEdit, onEditCredential, onEditBinding, onNewBinding, onEditUpstreamGrant, onNewUpstreamGrant, onEditAssignmentRule, onNewAssignmentRule, onRevoke, onPreset, onToggleProvider, onSetProviderGroup, busy }: {
   tab: AccessTab;
   setTab: (tab: AccessTab) => void;
   keys: AccessPolicy[];
@@ -1464,6 +1749,10 @@ function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCred
   selectedCredential?: ProxyCredential;
   bindings: PolicyBinding[];
   selectedBinding?: PolicyBinding;
+  upstreamGrants: UpstreamGrant[];
+  selectedUpstreamGrant?: UpstreamGrant;
+  assignmentRules: AssignmentRule[];
+  selectedAssignmentRule?: AssignmentRule;
   providers: ProviderRow[];
   form: PolicyForm;
   setForm: (form: PolicyForm) => void;
@@ -1471,17 +1760,30 @@ function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCred
   setCredentialForm: (form: CredentialForm) => void;
   bindingForm: BindingForm;
   setBindingForm: (form: BindingForm) => void;
+  upstreamGrantForm: UpstreamGrantForm;
+  setUpstreamGrantForm: (form: UpstreamGrantForm) => void;
+  assignmentRuleForm: AssignmentRuleForm;
+  setAssignmentRuleForm: (form: AssignmentRuleForm) => void;
   issuedKey: string;
   error: string;
   onSave: (event: FormEvent) => void;
   onIssueCredential: (event: FormEvent) => void;
   onRevokeCredential: (credentialId: string) => void;
   onSaveBinding: (event: FormEvent) => void;
+  onSaveUpstreamGrant: (event: FormEvent) => void;
+  onRevokeUpstreamGrant: (grant: UpstreamGrant) => void;
+  onRefreshUpstreamGrant: (grant: UpstreamGrant) => void;
+  onSaveAssignmentRule: (event: FormEvent) => void;
+  onReconcileAssignments: () => void;
   onNew: () => void;
   onEdit: (policy: AccessPolicy) => void;
   onEditCredential: (credential: ProxyCredential) => void;
   onEditBinding: (binding: PolicyBinding) => void;
   onNewBinding: () => void;
+  onEditUpstreamGrant: (grant: UpstreamGrant) => void;
+  onNewUpstreamGrant: () => void;
+  onEditAssignmentRule: (rule: AssignmentRule) => void;
+  onNewAssignmentRule: () => void;
   onRevoke: (policyId: string) => void;
   onPreset: (role: keyof typeof rolePresets) => void;
   onToggleProvider: (id: string) => void;
@@ -1494,10 +1796,120 @@ function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCred
         <button type="button" role="tab" aria-selected={tab === "policies"} className={tab === "policies" ? "active" : ""} onClick={() => setTab("policies")}>Policies <span>{keys.length}</span></button>
         <button type="button" role="tab" aria-selected={tab === "credentials"} className={tab === "credentials" ? "active" : ""} onClick={() => setTab("credentials")}>Credentials <span>{credentials.length}</span></button>
         <button type="button" role="tab" aria-selected={tab === "bindings"} className={tab === "bindings" ? "active" : ""} onClick={() => setTab("bindings")}>Bindings <span>{bindings.filter((binding) => binding.enabled).length}</span></button>
+        <button type="button" role="tab" aria-selected={tab === "upstream"} className={tab === "upstream" ? "active" : ""} onClick={() => setTab("upstream")}>Upstream <span>{upstreamGrants.filter((grant) => grant.enabled).length}</span></button>
+        <button type="button" role="tab" aria-selected={tab === "assignments"} className={tab === "assignments" ? "active" : ""} onClick={() => setTab("assignments")}>Assignments <span>{assignmentRules.filter((rule) => rule.enabled).length}</span></button>
       </div>
       {tab === "policies" ? <PolicyPanel keys={keys} selected={selected} providers={providers} form={form} setForm={setForm} error={error} onSave={onSave} onNew={onNew} onEdit={onEdit} onRevoke={onRevoke} onPreset={onPreset} onToggleProvider={onToggleProvider} onSetProviderGroup={onSetProviderGroup} busy={busy} /> : null}
       {tab === "credentials" ? <CredentialPanel policies={keys} credentials={credentials} selected={selectedCredential} form={credentialForm} setForm={setCredentialForm} issuedKey={issuedKey} error={error} onIssue={onIssueCredential} onEdit={onEditCredential} onRevoke={onRevokeCredential} busy={busy} /> : null}
       {tab === "bindings" ? <BindingPanel policies={keys} bindings={bindings} selected={selectedBinding} form={bindingForm} setForm={setBindingForm} error={error} onSave={onSaveBinding} onEdit={onEditBinding} onNew={onNewBinding} busy={busy} /> : null}
+      {tab === "upstream" ? <UpstreamGrantPanel policies={keys} providers={providers} grants={upstreamGrants} selected={selectedUpstreamGrant} form={upstreamGrantForm} setForm={setUpstreamGrantForm} error={error} onSave={onSaveUpstreamGrant} onEdit={onEditUpstreamGrant} onNew={onNewUpstreamGrant} onRefresh={onRefreshUpstreamGrant} onRevoke={onRevokeUpstreamGrant} busy={busy} /> : null}
+      {tab === "assignments" ? <AssignmentRulePanel policies={keys} rules={assignmentRules} selected={selectedAssignmentRule} form={assignmentRuleForm} setForm={setAssignmentRuleForm} error={error} onSave={onSaveAssignmentRule} onEdit={onEditAssignmentRule} onNew={onNewAssignmentRule} onReconcile={onReconcileAssignments} busy={busy} /> : null}
+    </div>
+  );
+}
+
+function UpstreamGrantPanel({ policies, providers, grants, selected, form, setForm, error, onSave, onEdit, onNew, onRefresh, onRevoke, busy }: {
+  policies: AccessPolicy[];
+  providers: ProviderRow[];
+  grants: UpstreamGrant[];
+  selected?: UpstreamGrant;
+  form: UpstreamGrantForm;
+  setForm: (form: UpstreamGrantForm) => void;
+  error: string;
+  onSave: (event: FormEvent) => void;
+  onEdit: (grant: UpstreamGrant) => void;
+  onNew: () => void;
+  onRefresh: (grant: UpstreamGrant) => void;
+  onRevoke: (grant: UpstreamGrant) => void;
+  busy: boolean;
+}) {
+  const active = grants.filter((grant) => grant.enabled).length;
+  const usable = grants.filter((grant) => grant.usable).length;
+  const refreshable = grants.filter((grant) => grant.refreshConfigured && grant.hasRefreshToken).length;
+  return (
+    <div className="entityLayout">
+      <section className="mainPane">
+        <div className="overviewStrip">
+          <Metric label="active grants" value={String(active)} meta={`${grants.length} total`} />
+          <Metric label="usable" value={String(usable)} meta="ready for routing" />
+          <Metric label="refreshable" value={String(refreshable)} meta="rotatable OAuth grants" />
+        </div>
+        <div className="tableSectionHeader"><div><strong>Upstream credentials</strong><span>Policy and tenant scoped provider access</span></div><button type="button" onClick={onNew} disabled={busy}><Plus className="buttonIcon" aria-hidden="true" /><span>New grant</span></button></div>
+        <EntityTable
+          columns={["connection", "scope", "provider", "kind", "state"]}
+          columnTemplate="minmax(220px, 1.4fr) minmax(150px, 1fr) minmax(130px, .8fr) 100px 100px"
+          rows={grants.map((grant) => ({ id: grant.key, active: selected?.key === grant.key, onClick: () => onEdit(grant), cells: [<EntityName icon={ServerCog} title={grant.label || grant.tokenRef} subtitle={grant.tokenRef} />, `${grant.scope === "policies" ? "policy" : "tenant"} · ${grant.scopeId}`, grant.provider ?? "legacy", grant.kind.replace("_", " "), <Status label={grant.usable ? "usable" : grant.enabled ? "blocked" : "revoked"} tone={grant.usable ? "active" : "revoked"} />] }))}
+        />
+      </section>
+      <aside className="inspector">
+        <form onSubmit={onSave}>
+          <InspectorHeader icon={ServerCog} title={selected ? "Edit upstream grant" : "New upstream grant"} subtitle={selected?.key ?? "provider credential"} />
+          {error ? <InlineError message={error} /> : null}
+          <div className="formGrid compact">
+            <label><span>scope</span><select value={form.scope} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, scope: event.target.value as UpstreamGrantForm["scope"], scopeId: event.target.value === "policies" ? policies[0]?.policyId ?? "" : "default" })}><option value="policies">policy</option><option value="tenants">tenant</option></select></label>
+            <label><span>scope id</span>{form.scope === "policies" ? <select value={form.scopeId} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, scopeId: event.target.value })}>{policies.map((policy) => <option key={policy.policyId} value={policy.policyId}>{policy.policyId}</option>)}</select> : <input value={form.scopeId} readOnly={Boolean(selected)} onChange={(event) => setForm({ ...form, scopeId: event.target.value })} />}</label>
+            <label><span>provider</span><select value={form.provider} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, provider: event.target.value, tokenRef: !form.tokenRef || form.tokenRef === form.provider ? event.target.value : form.tokenRef })}>{providers.map((provider) => <option key={provider.id} value={provider.id}>{provider.display_name}</option>)}</select></label>
+            <label><span>kind</span><select value={form.kind} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, kind: event.target.value as UpstreamGrant["kind"], credential: "", accessToken: "", refreshToken: "" })}><option value="api_key">API key</option><option value="oauth">OAuth</option><option value="subscription">subscription</option></select></label>
+            <label className="full"><span>token reference</span><input value={form.tokenRef} readOnly={Boolean(selected)} onChange={(event) => setForm({ ...form, tokenRef: event.target.value })} /></label>
+            <label className="full"><span>label</span><input value={form.label} onChange={(event) => setForm({ ...form, label: event.target.value })} /></label>
+            {form.kind === "api_key" ? <label className="full"><span>{selected?.hasCredential ? "replace API key" : "API key"}</span><input type="password" autoComplete="off" value={form.credential} onChange={(event) => setForm({ ...form, credential: event.target.value })} /></label> : <label className="full"><span>{selected?.hasAccessToken ? "replace access token" : "access token"}</span><input type="password" autoComplete="off" value={form.accessToken} onChange={(event) => setForm({ ...form, accessToken: event.target.value })} /></label>}
+            {form.kind !== "api_key" ? <label className="full"><span>{selected?.hasRefreshToken ? "replace refresh token" : "refresh token"}</span><input type="password" autoComplete="off" value={form.refreshToken} onChange={(event) => setForm({ ...form, refreshToken: event.target.value })} /></label> : null}
+            {form.kind === "subscription" ? <label className="full"><span>account id</span><input value={form.accountId} onChange={(event) => setForm({ ...form, accountId: event.target.value })} /></label> : null}
+            <label><span>expires at</span><input value={form.expiresAt} onChange={(event) => setForm({ ...form, expiresAt: event.target.value })} placeholder="ISO-8601 or blank" /></label>
+            <label><span>state</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
+          </div>
+          <InlineNote>Secret values are write-only and never returned by ClawRouter.</InlineNote>
+          {selected ? <dl className="facts"><dt>primary secret</dt><dd>{selected.hasCredential || selected.hasAccessToken ? "stored" : "missing"}</dd><dt>refresh token</dt><dd>{selected.hasRefreshToken ? "stored" : "none"}</dd><dt>refresh config</dt><dd>{selected.refreshConfigured ? "manifest approved" : "none"}</dd><dt>state</dt><dd>{selected.usable ? "usable" : "blocked"}</dd></dl> : null}
+          <div className="inspectorActions"><button type="submit" disabled={busy || !form.scopeId || !form.tokenRef || !form.provider}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected?.refreshConfigured && selected.hasRefreshToken ? <button type="button" className="buttonSecondary" disabled={busy || !selected.enabled} onClick={() => onRefresh(selected)}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Refresh</span></button> : null}{selected ? <button type="button" className="buttonDanger" disabled={busy || !selected.enabled} onClick={() => onRevoke(selected)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke</span></button> : null}</div>
+        </form>
+      </aside>
+    </div>
+  );
+}
+
+function AssignmentRulePanel({ policies, rules, selected, form, setForm, error, onSave, onEdit, onNew, onReconcile, busy }: {
+  policies: AccessPolicy[];
+  rules: AssignmentRule[];
+  selected?: AssignmentRule;
+  form: AssignmentRuleForm;
+  setForm: (form: AssignmentRuleForm) => void;
+  error: string;
+  onSave: (event: FormEvent) => void;
+  onEdit: (rule: AssignmentRule) => void;
+  onNew: () => void;
+  onReconcile: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="entityLayout">
+      <section className="mainPane">
+        <div className="overviewStrip">
+          <Metric label="active rules" value={String(rules.filter((rule) => rule.enabled).length)} meta={`${rules.length} total`} />
+          <Metric label="email rules" value={String(rules.filter((rule) => rule.kind.startsWith("email") || rule.kind === "exact_email").length)} meta="reconcile on first login" />
+          <Metric label="GitHub rules" value={String(rules.filter((rule) => rule.kind.startsWith("github")).length)} meta="verified evidence only" />
+        </div>
+        <div className="tableSectionHeader"><div><strong>Automatic assignments</strong><span>Identity evidence to managed group access</span></div><div className="inlineActions"><button type="button" className="buttonSecondary" onClick={onReconcile} disabled={busy}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Reconcile all</span></button><button type="button" onClick={onNew} disabled={busy}><Plus className="buttonIcon" aria-hidden="true" /><span>New rule</span></button></div></div>
+        <EntityTable columns={["rule", "match", "groups", "policies", "state"]} columnTemplate="minmax(180px, 1fr) minmax(220px, 1.4fr) 90px 90px 100px" rows={rules.map((rule) => ({ id: rule.ruleId, active: selected?.ruleId === rule.ruleId, onClick: () => onEdit(rule), cells: [<EntityName icon={Users} title={rule.ruleId} subtitle={rule.provenance} />, `${rule.kind.replaceAll("_", " ")} · ${rule.subject}`, String(rule.groups.length), String(rule.policyIds.length), <Status label={rule.enabled ? "active" : "disabled"} tone={rule.enabled ? "active" : "revoked"} />] }))} />
+      </section>
+      <aside className="inspector">
+        <form onSubmit={onSave}>
+          <InspectorHeader icon={Users} title={selected ? "Edit assignment rule" : "New assignment rule"} subtitle={selected?.generatedGroup ?? "managed identity access"} />
+          {error ? <InlineError message={error} /> : null}
+          <div className="formGrid compact">
+            <label className="full"><span>rule id</span><input value={form.ruleId} readOnly={Boolean(selected)} onChange={(event) => setForm({ ...form, ruleId: event.target.value })} /></label>
+            <label><span>match kind</span><select value={form.kind} onChange={(event) => setForm({ ...form, kind: event.target.value as AssignmentRule["kind"] })}><option value="exact_email">exact email</option><option value="email_domain">email domain</option><option value="github_org">GitHub organization</option><option value="github_team">GitHub team</option></select></label>
+            <label><span>priority</span><input inputMode="numeric" value={form.priority} onChange={(event) => setForm({ ...form, priority: event.target.value })} /></label>
+            <label className="full"><span>subject</span><input value={form.subject} onChange={(event) => setForm({ ...form, subject: event.target.value })} placeholder={form.kind === "exact_email" ? "user@example.com" : form.kind === "email_domain" ? "example.com" : form.kind === "github_team" ? "org/team" : "organization"} /></label>
+            <label className="full"><span>groups</span><input value={form.groups} onChange={(event) => setForm({ ...form, groups: event.target.value })} placeholder="maintainers, docs" /></label>
+            <label className="full"><span>provenance</span><input value={form.provenance} onChange={(event) => setForm({ ...form, provenance: event.target.value })} /></label>
+            <label><span>state</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
+            <label className="checkLabel"><input type="checkbox" checked={form.revokeOnLoss} onChange={(event) => setForm({ ...form, revokeOnLoss: event.target.checked })} /><span>revoke on loss</span></label>
+          </div>
+          <div className="sectionTitle">Managed policies</div>
+          <div className="serviceMatrix">{policies.map((policy) => <label key={policy.policyId}><input type="checkbox" checked={form.policyIds.includes(policy.policyId)} onChange={() => setForm({ ...form, policyIds: form.policyIds.includes(policy.policyId) ? form.policyIds.filter((id) => id !== policy.policyId) : [...form.policyIds, policy.policyId].sort() })} /><span>{policy.policyId}</span><small>{policy.providers.length ? `${policy.providers.length} services` : "all services"}</small></label>)}</div>
+          <div className="inspectorActions"><button type="submit" disabled={busy || !form.ruleId || !form.subject.trim() || !form.provenance.trim()}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save rule</span></button></div>
+        </form>
+      </aside>
     </div>
   );
 }
@@ -2021,6 +2433,90 @@ async function sha256Hex(value: string) {
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+function upstreamGrantFormFromGrant(grant: UpstreamGrant): UpstreamGrantForm {
+  return {
+    scope: grant.scope,
+    scopeId: grant.scopeId,
+    tokenRef: grant.tokenRef,
+    kind: grant.kind,
+    provider: grant.provider ?? "",
+    label: grant.label ?? "",
+    enabled: grant.enabled,
+    credential: "",
+    accessToken: "",
+    refreshToken: "",
+    accountId: grant.accountId ?? "",
+    expiresAt: grant.expiresAt ?? "",
+  };
+}
+
+function assignmentRuleFormFromRule(rule: AssignmentRule): AssignmentRuleForm {
+  return {
+    ruleId: rule.ruleId,
+    enabled: rule.enabled,
+    kind: rule.kind,
+    subject: rule.subject,
+    groups: rule.groups.join(", "),
+    policyIds: rule.policyIds,
+    priority: String(rule.priority),
+    revokeOnLoss: rule.revokeOnLoss,
+    provenance: rule.provenance,
+  };
+}
+
+function demoGrantFromForm(form: UpstreamGrantForm, existing?: UpstreamGrant): UpstreamGrant {
+  const key = form.scope === "tenants"
+    ? `oauth/tenants/${form.scopeId.trim()}/${form.tokenRef.trim()}`
+    : `oauth/${form.scopeId.trim()}/${form.tokenRef.trim()}`;
+  const now = new Date().toISOString();
+  const hasCredential = Boolean(form.credential.trim()) || Boolean(existing?.hasCredential);
+  const hasAccessToken = Boolean(form.accessToken.trim()) || Boolean(existing?.hasAccessToken);
+  const hasRefreshToken = Boolean(form.refreshToken.trim()) || Boolean(existing?.hasRefreshToken);
+  return {
+    key,
+    scope: form.scope,
+    scopeId: form.scopeId.trim(),
+    tokenRef: form.tokenRef.trim(),
+    version: 1,
+    enabled: form.enabled,
+    kind: form.kind,
+    provider: form.provider.trim(),
+    label: form.label.trim() || null,
+    tokenType: existing?.tokenType ?? "Bearer",
+    expiresAt: form.expiresAt.trim() || null,
+    scopes: existing?.scopes ?? [],
+    accountId: form.accountId.trim() || null,
+    subscription: existing?.subscription ?? null,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    revokedAt: form.enabled ? null : now,
+    hasCredential,
+    hasAccessToken,
+    hasRefreshToken,
+    refreshConfigured: existing?.refreshConfigured ?? hasRefreshToken,
+    usable: form.enabled && (form.kind === "api_key" ? hasCredential : hasAccessToken || form.kind === "subscription" && hasCredential),
+  };
+}
+
+function demoRuleFromForm(form: AssignmentRuleForm): AssignmentRule {
+  const now = new Date().toISOString();
+  return {
+    ruleId: form.ruleId.trim(),
+    version: 1,
+    enabled: form.enabled,
+    kind: form.kind,
+    subject: form.subject.trim().toLowerCase(),
+    groups: parseGroups(form.groups),
+    policyIds: [...form.policyIds].sort(),
+    priority: optionalNumber(form.priority) ?? 100,
+    revokeOnLoss: form.revokeOnLoss,
+    provenance: form.provenance.trim(),
+    generatedGroup: `assignment.${form.ruleId.trim()}`,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 function formatBudget(value: number | null | undefined) {
   if (value === undefined || value === null) return "unlimited";
   if (value === 0) return "blocked";
@@ -2347,6 +2843,13 @@ function demoData() {
     { credentialId: "research_notebook", policyId: "user_research", enabled: false },
   ];
   const connections: ProviderConnection[] = providers.map((item) => ({ providerId: item.id, enabled: !demoDisabledProviderIds.has(item.id) }));
+  const upstreamGrants: UpstreamGrant[] = [
+    { key: "oauth/maintainer_models/openai", scope: "policies", scopeId: "maintainer_models", tokenRef: "openai", version: 1, enabled: true, kind: "subscription", provider: "openai", label: "maintainer subscription", tokenType: "Bearer", scopes: ["openid", "profile"], accountId: "acct_demo", subscription: { plan: "plus" }, createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: false, hasAccessToken: true, hasRefreshToken: true, refreshConfigured: true, usable: true },
+    { key: "oauth/tenants/openclaw/anthropic", scope: "tenants", scopeId: "openclaw", tokenRef: "anthropic", version: 1, enabled: true, kind: "api_key", provider: "anthropic", label: "shared Anthropic key", tokenType: "Bearer", scopes: [], createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: true, hasAccessToken: false, hasRefreshToken: false, refreshConfigured: false, usable: true },
+  ];
+  const assignmentRules: AssignmentRule[] = [
+    { ruleId: "maintainers", version: 1, enabled: true, kind: "email_domain", subject: "example.com", groups: ["maintainers"], policyIds: ["maintainer_models", "openclaw_tools"], priority: 10, revokeOnLoss: true, provenance: "cloudflare_access", generatedGroup: "assignment.maintainers", createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z" },
+  ];
   const users: AccessUser[] = [
     { email: "admin@example.com", role: "admin", tenantId: "openclaw", enabled: true, groups: ["maintainers"] },
     { email: "maintainer@example.com", role: "user", tenantId: "docs", enabled: true, groups: ["maintainers"] },
@@ -2380,7 +2883,7 @@ function demoData() {
   const usage = demoUsageSnapshot();
   const tenants = tenantSummaryFallback(keys, credentials);
   const overview = adminOverviewFromPolicies(keys, credentials, providers, routes);
-  return { session, providers, routes, keys, credentials, connections, users, bindings, overview, tenants, usageRows, usage, entitlements, services: serviceItems(providers, routes, readinessByProvider, accessByProvider), models };
+  return { session, providers, routes, keys, credentials, connections, upstreamGrants, assignmentRules, users, bindings, overview, tenants, usageRows, usage, entitlements, services: serviceItems(providers, routes, readinessByProvider, accessByProvider), models };
 }
 
 function demoReadiness(provider: ProviderRow, routes: RouteCatalog): ProviderReadiness {
@@ -2403,6 +2906,7 @@ function demoReadiness(provider: ProviderRow, routes: RouteCatalog): ProviderRea
     connectionEnabled,
     oauthGrantRequired: grantRequired,
     oauthGrantCount: 0,
+    upstreamGrantCount: 0,
     openaiCompatible: Boolean(openaiRoute),
     manifestRoutes: manifestRoutes.length,
     modelCount: openaiRoute?.models.length ?? 0,

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -8,6 +8,7 @@ import {
   CircleSlash2,
   FlaskConical,
   KeyRound,
+  LogIn,
   Play,
   Plus,
   RefreshCw,
@@ -96,6 +97,11 @@ interface ProviderRow {
   service_kind: string;
   meter?: string | null;
   capabilities: Array<{ id: string }>;
+  auth?: {
+    authorization?: {
+      grantKind?: "oauth" | "subscription";
+    } | null;
+  };
 }
 
 interface ProviderResponse {
@@ -163,6 +169,7 @@ interface UpstreamGrant {
   updatedAt?: string | null;
   revokedAt?: string | null;
   hasCredential: boolean;
+  credentialFields: string[];
   hasAccessToken: boolean;
   hasRefreshToken: boolean;
   refreshConfigured: boolean;
@@ -415,6 +422,7 @@ interface UpstreamGrantForm {
   label: string;
   enabled: boolean;
   credential: string;
+  credentialBundle: string;
   accessToken: string;
   refreshToken: string;
   accountId: string;
@@ -482,7 +490,7 @@ const defaultAccess: AccessForm = {
 };
 const defaultCredential: CredentialForm = { credentialId: "", policyId: "" };
 const defaultBinding: BindingForm = { policyId: "", principalType: "group", principalId: "", enabled: true, priority: "100" };
-const defaultUpstreamGrant: UpstreamGrantForm = { scope: "policies", scopeId: "", tokenRef: "", kind: "api_key", provider: "", label: "", enabled: true, credential: "", accessToken: "", refreshToken: "", accountId: "", expiresAt: "" };
+const defaultUpstreamGrant: UpstreamGrantForm = { scope: "policies", scopeId: "", tokenRef: "", kind: "api_key", provider: "", label: "", enabled: true, credential: "", credentialBundle: "", accessToken: "", refreshToken: "", accountId: "", expiresAt: "" };
 const defaultAssignmentRule: AssignmentRuleForm = { ruleId: "", enabled: true, kind: "email_domain", subject: "", groups: "", policyIds: [], priority: "100", revokeOnLoss: true, provenance: "cloudflare_access" };
 
 const rolePresets = {
@@ -579,7 +587,7 @@ function App() {
   const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
   const selectedModel = models.find((model) => model.id === playground.model) ?? models[0];
   const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === playground.serviceRoute) ?? serviceRoutes[0];
-  const busy = status === "loading" || ["saving", "running", "revoking", "issuing", "enabling", "disabling"].some((prefix) => status.startsWith(prefix));
+  const busy = status === "loading" || ["saving", "running", "revoking", "issuing", "enabling", "disabling", "connecting"].some((prefix) => status.startsWith(prefix));
   const statusTone = statusKind(status);
 
   useEffect(() => {
@@ -727,7 +735,7 @@ function App() {
         setAccessForm(accessFormFromUser(user, []));
       }
       setDemoMode(false);
-      setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : "connected");
+      setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : oauthCallbackStatus() ?? "connected");
     } catch (error) {
       const message = errorMessage(error);
       if (allowDemo) {
@@ -915,7 +923,8 @@ function App() {
       const tokenRef = upstreamGrantForm.tokenRef.trim();
       const provider = upstreamGrantForm.provider.trim();
       if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
-      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() : upstreamGrantForm.accessToken.trim();
+      const credentialBundle = parseCredentialBundle(upstreamGrantForm.credentialBundle);
+      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() || Object.keys(credentialBundle).length : upstreamGrantForm.accessToken.trim();
       if (!selectedUpstreamGrant && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
       const body = {
         version: 1,
@@ -929,6 +938,7 @@ function App() {
         accountId: upstreamGrantForm.accountId.trim() || undefined,
         subscription: selectedUpstreamGrant?.subscription ?? undefined,
         ...(upstreamGrantForm.credential.trim() ? { credential: upstreamGrantForm.credential.trim() } : {}),
+        ...(Object.keys(credentialBundle).length ? { credentials: credentialBundle } : {}),
         ...(upstreamGrantForm.accessToken.trim() ? { accessToken: upstreamGrantForm.accessToken.trim() } : {}),
         ...(upstreamGrantForm.refreshToken.trim() ? { refreshToken: upstreamGrantForm.refreshToken.trim() } : {}),
       };
@@ -962,7 +972,7 @@ function App() {
       setStatus("revoking upstream grant");
       let revoked: UpstreamGrant;
       if (demoMode) {
-        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
+        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
         setUpstreamGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
       } else {
         revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" });
@@ -989,6 +999,32 @@ function App() {
         setUpstreamGrantForm(upstreamGrantFormFromGrant(refreshed));
       }
       setStatus("refreshed upstream grant");
+    } catch (error) {
+      const message = errorMessage(error);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function authorizeUpstreamGrant() {
+    try {
+      setPolicyError("");
+      const scopeId = upstreamGrantForm.scopeId.trim();
+      const tokenRef = upstreamGrantForm.tokenRef.trim();
+      const provider = upstreamGrantForm.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      if (!providers.find((item) => item.id === provider)?.auth?.authorization) throw new Error("selected provider does not support browser OAuth");
+      setStatus("connecting upstream grant");
+      if (demoMode) {
+        setStatus("browser OAuth unavailable in local demo");
+        return;
+      }
+      const result = await request<{ authorizationUrl: string }>(gatewayOrigin, `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}/authorize`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider }),
+      });
+      window.location.assign(result.authorizationUrl);
     } catch (error) {
       const message = errorMessage(error);
       setPolicyError(message);
@@ -1467,6 +1503,7 @@ function App() {
             onSaveUpstreamGrant={saveUpstreamGrant}
             onRevokeUpstreamGrant={revokeUpstreamGrant}
             onRefreshUpstreamGrant={refreshUpstreamGrant}
+            onAuthorizeUpstreamGrant={authorizeUpstreamGrant}
             onSaveAssignmentRule={saveAssignmentRule}
             onReconcileAssignments={reconcileAssignments}
             onNew={startNewPolicy}
@@ -1740,7 +1777,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
   );
 }
 
-function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCredential, bindings, selectedBinding, upstreamGrants, selectedUpstreamGrant, assignmentRules, selectedAssignmentRule, providers, form, setForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, upstreamGrantForm, setUpstreamGrantForm, assignmentRuleForm, setAssignmentRuleForm, issuedKey, error, onSave, onIssueCredential, onRevokeCredential, onSaveBinding, onSaveUpstreamGrant, onRevokeUpstreamGrant, onRefreshUpstreamGrant, onSaveAssignmentRule, onReconcileAssignments, onNew, onEdit, onEditCredential, onEditBinding, onNewBinding, onEditUpstreamGrant, onNewUpstreamGrant, onEditAssignmentRule, onNewAssignmentRule, onRevoke, onPreset, onToggleProvider, onSetProviderGroup, busy }: {
+function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCredential, bindings, selectedBinding, upstreamGrants, selectedUpstreamGrant, assignmentRules, selectedAssignmentRule, providers, form, setForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, upstreamGrantForm, setUpstreamGrantForm, assignmentRuleForm, setAssignmentRuleForm, issuedKey, error, onSave, onIssueCredential, onRevokeCredential, onSaveBinding, onSaveUpstreamGrant, onRevokeUpstreamGrant, onRefreshUpstreamGrant, onAuthorizeUpstreamGrant, onSaveAssignmentRule, onReconcileAssignments, onNew, onEdit, onEditCredential, onEditBinding, onNewBinding, onEditUpstreamGrant, onNewUpstreamGrant, onEditAssignmentRule, onNewAssignmentRule, onRevoke, onPreset, onToggleProvider, onSetProviderGroup, busy }: {
   tab: AccessTab;
   setTab: (tab: AccessTab) => void;
   keys: AccessPolicy[];
@@ -1773,6 +1810,7 @@ function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCred
   onSaveUpstreamGrant: (event: FormEvent) => void;
   onRevokeUpstreamGrant: (grant: UpstreamGrant) => void;
   onRefreshUpstreamGrant: (grant: UpstreamGrant) => void;
+  onAuthorizeUpstreamGrant: () => void;
   onSaveAssignmentRule: (event: FormEvent) => void;
   onReconcileAssignments: () => void;
   onNew: () => void;
@@ -1802,13 +1840,13 @@ function PoliciesScreen({ tab, setTab, keys, selected, credentials, selectedCred
       {tab === "policies" ? <PolicyPanel keys={keys} selected={selected} providers={providers} form={form} setForm={setForm} error={error} onSave={onSave} onNew={onNew} onEdit={onEdit} onRevoke={onRevoke} onPreset={onPreset} onToggleProvider={onToggleProvider} onSetProviderGroup={onSetProviderGroup} busy={busy} /> : null}
       {tab === "credentials" ? <CredentialPanel policies={keys} credentials={credentials} selected={selectedCredential} form={credentialForm} setForm={setCredentialForm} issuedKey={issuedKey} error={error} onIssue={onIssueCredential} onEdit={onEditCredential} onRevoke={onRevokeCredential} busy={busy} /> : null}
       {tab === "bindings" ? <BindingPanel policies={keys} bindings={bindings} selected={selectedBinding} form={bindingForm} setForm={setBindingForm} error={error} onSave={onSaveBinding} onEdit={onEditBinding} onNew={onNewBinding} busy={busy} /> : null}
-      {tab === "upstream" ? <UpstreamGrantPanel policies={keys} providers={providers} grants={upstreamGrants} selected={selectedUpstreamGrant} form={upstreamGrantForm} setForm={setUpstreamGrantForm} error={error} onSave={onSaveUpstreamGrant} onEdit={onEditUpstreamGrant} onNew={onNewUpstreamGrant} onRefresh={onRefreshUpstreamGrant} onRevoke={onRevokeUpstreamGrant} busy={busy} /> : null}
+      {tab === "upstream" ? <UpstreamGrantPanel policies={keys} providers={providers} grants={upstreamGrants} selected={selectedUpstreamGrant} form={upstreamGrantForm} setForm={setUpstreamGrantForm} error={error} onSave={onSaveUpstreamGrant} onEdit={onEditUpstreamGrant} onNew={onNewUpstreamGrant} onRefresh={onRefreshUpstreamGrant} onAuthorize={onAuthorizeUpstreamGrant} onRevoke={onRevokeUpstreamGrant} busy={busy} /> : null}
       {tab === "assignments" ? <AssignmentRulePanel policies={keys} rules={assignmentRules} selected={selectedAssignmentRule} form={assignmentRuleForm} setForm={setAssignmentRuleForm} error={error} onSave={onSaveAssignmentRule} onEdit={onEditAssignmentRule} onNew={onNewAssignmentRule} onReconcile={onReconcileAssignments} busy={busy} /> : null}
     </div>
   );
 }
 
-function UpstreamGrantPanel({ policies, providers, grants, selected, form, setForm, error, onSave, onEdit, onNew, onRefresh, onRevoke, busy }: {
+function UpstreamGrantPanel({ policies, providers, grants, selected, form, setForm, error, onSave, onEdit, onNew, onRefresh, onAuthorize, onRevoke, busy }: {
   policies: AccessPolicy[];
   providers: ProviderRow[];
   grants: UpstreamGrant[];
@@ -1820,12 +1858,15 @@ function UpstreamGrantPanel({ policies, providers, grants, selected, form, setFo
   onEdit: (grant: UpstreamGrant) => void;
   onNew: () => void;
   onRefresh: (grant: UpstreamGrant) => void;
+  onAuthorize: () => void;
   onRevoke: (grant: UpstreamGrant) => void;
   busy: boolean;
 }) {
   const active = grants.filter((grant) => grant.enabled).length;
   const usable = grants.filter((grant) => grant.usable).length;
   const refreshable = grants.filter((grant) => grant.refreshConfigured && grant.hasRefreshToken).length;
+  const selectedProvider = providers.find((provider) => provider.id === form.provider);
+  const authorizationKind = selectedProvider?.auth?.authorization?.grantKind;
   return (
     <div className="entityLayout">
       <section className="mainPane">
@@ -1848,19 +1889,20 @@ function UpstreamGrantPanel({ policies, providers, grants, selected, form, setFo
           <div className="formGrid compact">
             <label><span>scope</span><select value={form.scope} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, scope: event.target.value as UpstreamGrantForm["scope"], scopeId: event.target.value === "policies" ? policies[0]?.policyId ?? "" : "default" })}><option value="policies">policy</option><option value="tenants">tenant</option></select></label>
             <label><span>scope id</span>{form.scope === "policies" ? <select value={form.scopeId} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, scopeId: event.target.value })}>{policies.map((policy) => <option key={policy.policyId} value={policy.policyId}>{policy.policyId}</option>)}</select> : <input value={form.scopeId} readOnly={Boolean(selected)} onChange={(event) => setForm({ ...form, scopeId: event.target.value })} />}</label>
-            <label><span>provider</span><select value={form.provider} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, provider: event.target.value, tokenRef: !form.tokenRef || form.tokenRef === form.provider ? event.target.value : form.tokenRef })}>{providers.map((provider) => <option key={provider.id} value={provider.id}>{provider.display_name}</option>)}</select></label>
-            <label><span>kind</span><select value={form.kind} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, kind: event.target.value as UpstreamGrant["kind"], credential: "", accessToken: "", refreshToken: "" })}><option value="api_key">API key</option><option value="oauth">OAuth</option><option value="subscription">subscription</option></select></label>
+            <label><span>provider</span><select value={form.provider} disabled={Boolean(selected)} onChange={(event) => { const provider = providers.find((item) => item.id === event.target.value); setForm({ ...form, provider: event.target.value, kind: provider?.auth?.authorization?.grantKind ?? form.kind, tokenRef: !form.tokenRef || form.tokenRef === form.provider ? event.target.value : form.tokenRef }); }}>{providers.map((provider) => <option key={provider.id} value={provider.id}>{provider.display_name}</option>)}</select></label>
+            <label><span>kind</span><select value={form.kind} disabled={Boolean(selected)} onChange={(event) => setForm({ ...form, kind: event.target.value as UpstreamGrant["kind"], credential: "", credentialBundle: "", accessToken: "", refreshToken: "" })}><option value="api_key">API key</option><option value="oauth">OAuth</option><option value="subscription">subscription</option></select></label>
             <label className="full"><span>token reference</span><input value={form.tokenRef} readOnly={Boolean(selected)} onChange={(event) => setForm({ ...form, tokenRef: event.target.value })} /></label>
             <label className="full"><span>label</span><input value={form.label} onChange={(event) => setForm({ ...form, label: event.target.value })} /></label>
             {form.kind === "api_key" ? <label className="full"><span>{selected?.hasCredential ? "replace API key" : "API key"}</span><input type="password" autoComplete="off" value={form.credential} onChange={(event) => setForm({ ...form, credential: event.target.value })} /></label> : <label className="full"><span>{selected?.hasAccessToken ? "replace access token" : "access token"}</span><input type="password" autoComplete="off" value={form.accessToken} onChange={(event) => setForm({ ...form, accessToken: event.target.value })} /></label>}
+            {form.kind === "api_key" ? <label className="full"><span>{selected?.credentialFields.length ? "replace credential bundle JSON" : "credential bundle JSON"}</span><textarea value={form.credentialBundle} onChange={(event) => setForm({ ...form, credentialBundle: event.target.value })} placeholder={'{"accessKeyId":"...","secretAccessKey":"...","sessionToken":"..."}'} /></label> : null}
             {form.kind !== "api_key" ? <label className="full"><span>{selected?.hasRefreshToken ? "replace refresh token" : "refresh token"}</span><input type="password" autoComplete="off" value={form.refreshToken} onChange={(event) => setForm({ ...form, refreshToken: event.target.value })} /></label> : null}
             {form.kind === "subscription" ? <label className="full"><span>account id</span><input value={form.accountId} onChange={(event) => setForm({ ...form, accountId: event.target.value })} /></label> : null}
             <label><span>expires at</span><input value={form.expiresAt} onChange={(event) => setForm({ ...form, expiresAt: event.target.value })} placeholder="ISO-8601 or blank" /></label>
             <label><span>state</span><select value={form.enabled ? "enabled" : "disabled"} onChange={(event) => setForm({ ...form, enabled: event.target.value === "enabled" })}><option value="enabled">enabled</option><option value="disabled">disabled</option></select></label>
           </div>
           <InlineNote>Secret values are write-only and never returned by ClawRouter.</InlineNote>
-          {selected ? <dl className="facts"><dt>primary secret</dt><dd>{selected.hasCredential || selected.hasAccessToken ? "stored" : "missing"}</dd><dt>refresh token</dt><dd>{selected.hasRefreshToken ? "stored" : "none"}</dd><dt>refresh config</dt><dd>{selected.refreshConfigured ? "manifest approved" : "none"}</dd><dt>state</dt><dd>{selected.usable ? "usable" : "blocked"}</dd></dl> : null}
-          <div className="inspectorActions"><button type="submit" disabled={busy || !form.scopeId || !form.tokenRef || !form.provider}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected?.refreshConfigured && selected.hasRefreshToken ? <button type="button" className="buttonSecondary" disabled={busy || !selected.enabled} onClick={() => onRefresh(selected)}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Refresh</span></button> : null}{selected ? <button type="button" className="buttonDanger" disabled={busy || !selected.enabled} onClick={() => onRevoke(selected)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke</span></button> : null}</div>
+          {selected ? <dl className="facts"><dt>primary secret</dt><dd>{selected.hasCredential || selected.hasAccessToken || selected.credentialFields.length ? "stored" : "missing"}</dd><dt>credential fields</dt><dd>{selected.credentialFields.length ? selected.credentialFields.join(", ") : "none"}</dd><dt>refresh token</dt><dd>{selected.hasRefreshToken ? "stored" : "none"}</dd><dt>refresh config</dt><dd>{selected.refreshConfigured ? "manifest approved" : "none"}</dd><dt>state</dt><dd>{selected.usable ? "usable" : "blocked"}</dd></dl> : null}
+          <div className="inspectorActions">{authorizationKind ? <button type="button" disabled={busy || !form.scopeId || !form.tokenRef || !form.provider} onClick={onAuthorize}><LogIn className="buttonIcon" aria-hidden="true" /><span>{selected ? "Reconnect" : "Connect"} with provider</span></button> : null}<button type="submit" className={authorizationKind ? "buttonSecondary" : undefined} disabled={busy || !form.scopeId || !form.tokenRef || !form.provider}><ShieldCheck className="buttonIcon" aria-hidden="true" /><span>Save grant</span></button>{selected?.refreshConfigured && selected.hasRefreshToken ? <button type="button" className="buttonSecondary" disabled={busy || !selected.enabled} onClick={() => onRefresh(selected)}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Refresh</span></button> : null}{selected ? <button type="button" className="buttonDanger" disabled={busy || !selected.enabled} onClick={() => onRevoke(selected)}><CircleSlash2 className="buttonIcon" aria-hidden="true" /><span>Revoke</span></button> : null}</div>
         </form>
       </aside>
     </div>
@@ -2364,10 +2406,19 @@ function kindIcon(kind: string): IconComponent {
 }
 
 function statusKind(status: string) {
-  if (status.includes("error") || status.includes("select") || status.includes("invalid") || status.includes("must") || status.includes("returned") || status.includes("paste")) return "error";
-  if (status === "loading" || status.startsWith("saving") || status.startsWith("running") || status.startsWith("revoking")) return "pending";
+  if (status.includes("error") || status.includes("failed") || status.includes("select") || status.includes("invalid") || status.includes("must") || status.includes("returned") || status.includes("paste")) return "error";
+  if (status === "loading" || status.startsWith("saving") || status.startsWith("running") || status.startsWith("revoking") || status.startsWith("connecting")) return "pending";
   if (status.includes("loaded") || status.includes("saved") || status.includes("connected") || status.includes("ready") || status.includes("revoked")) return "success";
   return "neutral";
+}
+
+function oauthCallbackStatus() {
+  const params = new URLSearchParams(window.location.search);
+  const outcome = params.get("oauth");
+  const provider = params.get("provider") ?? "provider";
+  if (outcome === "connected") return `${provider} connected`;
+  if (outcome === "failed") return `${provider} OAuth failed`;
+  return null;
 }
 
 function statusLabel(kind: ReturnType<typeof statusKind>) {
@@ -2443,6 +2494,7 @@ function upstreamGrantFormFromGrant(grant: UpstreamGrant): UpstreamGrantForm {
     label: grant.label ?? "",
     enabled: grant.enabled,
     credential: "",
+    credentialBundle: "",
     accessToken: "",
     refreshToken: "",
     accountId: grant.accountId ?? "",
@@ -2470,6 +2522,8 @@ function demoGrantFromForm(form: UpstreamGrantForm, existing?: UpstreamGrant): U
     : `oauth/${form.scopeId.trim()}/${form.tokenRef.trim()}`;
   const now = new Date().toISOString();
   const hasCredential = Boolean(form.credential.trim()) || Boolean(existing?.hasCredential);
+  const credentialFields = Object.keys(parseCredentialBundle(form.credentialBundle)).sort();
+  const effectiveCredentialFields = credentialFields.length ? credentialFields : existing?.credentialFields ?? [];
   const hasAccessToken = Boolean(form.accessToken.trim()) || Boolean(existing?.hasAccessToken);
   const hasRefreshToken = Boolean(form.refreshToken.trim()) || Boolean(existing?.hasRefreshToken);
   return {
@@ -2491,11 +2545,24 @@ function demoGrantFromForm(form: UpstreamGrantForm, existing?: UpstreamGrant): U
     updatedAt: now,
     revokedAt: form.enabled ? null : now,
     hasCredential,
+    credentialFields: effectiveCredentialFields,
     hasAccessToken,
     hasRefreshToken,
     refreshConfigured: existing?.refreshConfigured ?? hasRefreshToken,
-    usable: form.enabled && (form.kind === "api_key" ? hasCredential : hasAccessToken || form.kind === "subscription" && hasCredential),
+    usable: form.enabled && (form.kind === "api_key" ? hasCredential || effectiveCredentialFields.length > 0 : hasAccessToken || form.kind === "subscription" && hasCredential),
   };
+}
+
+function parseCredentialBundle(raw: string): Record<string, string> {
+  if (!raw.trim()) return {};
+  const value = JSON.parse(raw) as unknown;
+  if (!value || Array.isArray(value) || typeof value !== "object") throw new Error("credential bundle must be a JSON object");
+  const credentials: Record<string, string> = {};
+  for (const [name, secret] of Object.entries(value)) {
+    if (!/^[A-Za-z0-9_.-]{1,128}$/.test(name) || typeof secret !== "string" || !secret) throw new Error("credential bundle fields must use non-empty string secrets");
+    credentials[name] = secret;
+  }
+  return credentials;
 }
 
 function demoRuleFromForm(form: AssignmentRuleForm): AssignmentRule {
@@ -2795,7 +2862,7 @@ function demoData() {
     provider("huggingface", "Hugging Face", "rest_json", "model_provider", ["llm.invoke"]),
     provider("minimax", "MiniMax", "openai_compatible", "model_provider", ["llm.chat"]),
     provider("mistral", "Mistral AI", "openai_compatible", "model_provider", ["llm.chat", "llm.embeddings"]),
-    provider("openai", "OpenAI", "openai_compatible", "model_provider", ["llm.responses", "llm.chat", "llm.embeddings"]),
+    provider("openai", "OpenAI", "openai_compatible", "model_provider", ["llm.responses", "llm.chat", "llm.embeddings"], "subscription"),
     provider("openrouter", "OpenRouter", "openai_compatible", "gateway_platform", ["llm.chat"]),
     provider("perplexity", "Perplexity", "openai_compatible", "model_provider", ["llm.chat"]),
     provider("replicate", "Replicate", "rest_json", "tool_provider", ["media.predict", "media.prediction.read"]),
@@ -2844,8 +2911,8 @@ function demoData() {
   ];
   const connections: ProviderConnection[] = providers.map((item) => ({ providerId: item.id, enabled: !demoDisabledProviderIds.has(item.id) }));
   const upstreamGrants: UpstreamGrant[] = [
-    { key: "oauth/maintainer_models/openai", scope: "policies", scopeId: "maintainer_models", tokenRef: "openai", version: 1, enabled: true, kind: "subscription", provider: "openai", label: "maintainer subscription", tokenType: "Bearer", scopes: ["openid", "profile"], accountId: "acct_demo", subscription: { plan: "plus" }, createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: false, hasAccessToken: true, hasRefreshToken: true, refreshConfigured: true, usable: true },
-    { key: "oauth/tenants/openclaw/anthropic", scope: "tenants", scopeId: "openclaw", tokenRef: "anthropic", version: 1, enabled: true, kind: "api_key", provider: "anthropic", label: "shared Anthropic key", tokenType: "Bearer", scopes: [], createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: true, hasAccessToken: false, hasRefreshToken: false, refreshConfigured: false, usable: true },
+    { key: "oauth/maintainer_models/openai", scope: "policies", scopeId: "maintainer_models", tokenRef: "openai", version: 1, enabled: true, kind: "subscription", provider: "openai", label: "maintainer subscription", tokenType: "Bearer", scopes: ["openid", "profile"], accountId: "acct_demo", subscription: { plan: "plus" }, createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: false, credentialFields: [], hasAccessToken: true, hasRefreshToken: true, refreshConfigured: true, usable: true },
+    { key: "oauth/tenants/openclaw/anthropic", scope: "tenants", scopeId: "openclaw", tokenRef: "anthropic", version: 1, enabled: true, kind: "api_key", provider: "anthropic", label: "shared Anthropic key", tokenType: "Bearer", scopes: [], createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z", hasCredential: true, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, refreshConfigured: false, usable: true },
   ];
   const assignmentRules: AssignmentRule[] = [
     { ruleId: "maintainers", version: 1, enabled: true, kind: "email_domain", subject: "example.com", groups: ["maintainers"], policyIds: ["maintainer_models", "openclaw_tools"], priority: 10, revokeOnLoss: true, provenance: "cloudflare_access", generatedGroup: "assignment.maintainers", createdAt: "2026-06-16T00:00:00.000Z", updatedAt: "2026-06-16T00:00:00.000Z" },
@@ -2931,8 +2998,8 @@ function manifestRoute(provider: string, endpoint: string, route: string, method
   return { provider, endpoint, route, methods, pathParams };
 }
 
-function provider(id: string, display_name: string, providerClass: string, service_kind: string, capabilities: string[]): ProviderRow {
-  return { id, display_name, class: providerClass, service_kind, meter: "request", capabilities: capabilities.map((capability) => ({ id: capability })) };
+function provider(id: string, display_name: string, providerClass: string, service_kind: string, capabilities: string[], authorizationKind?: "oauth" | "subscription"): ProviderRow {
+  return { id, display_name, class: providerClass, service_kind, meter: "request", capabilities: capabilities.map((capability) => ({ id: capability })), auth: authorizationKind ? { authorization: { grantKind: authorizationKind } } : undefined };
 }
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1927,7 +1927,7 @@ function AssignmentRulePanel({ policies, rules, selected, form, setForm, error, 
       <section className="mainPane">
         <div className="overviewStrip">
           <Metric label="active rules" value={String(rules.filter((rule) => rule.enabled).length)} meta={`${rules.length} total`} />
-          <Metric label="email rules" value={String(rules.filter((rule) => rule.kind.startsWith("email") || rule.kind === "exact_email").length)} meta="reconcile on first login" />
+          <Metric label="email rules" value={String(rules.filter((rule) => rule.kind.startsWith("email") || rule.kind === "exact_email").length)} meta="reconcile on login" />
           <Metric label="GitHub rules" value={String(rules.filter((rule) => rule.kind.startsWith("github")).length)} meta="verified evidence only" />
         </div>
         <div className="tableSectionHeader"><div><strong>Automatic assignments</strong><span>Identity evidence to managed group access</span></div><div className="inlineActions"><button type="button" className="buttonSecondary" onClick={onReconcile} disabled={busy}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Reconcile all</span></button><button type="button" onClick={onNew} disabled={busy}><Plus className="buttonIcon" aria-hidden="true" /><span>New rule</span></button></div></div>

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -3089,6 +3089,36 @@ label > span,
   color: var(--success);
 }
 
+.inlineActions {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.checkLabel {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  min-height: 30px;
+  align-self: end;
+  border: 1px solid var(--border);
+  padding: 5px 8px;
+}
+
+.checkLabel input {
+  width: 14px;
+  min-height: 14px;
+  margin: 0;
+}
+
+.checkLabel span {
+  color: var(--foreground-strong);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: none;
+}
+
 .userListHeader {
   display: grid;
   grid-template-columns: minmax(220px, 360px) auto;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,8 +8,8 @@ pub use budget::{BudgetDecision, BudgetLedger, BudgetPolicy, Reservation};
 pub use key::{parse_proxy_key, ProxyKeyParts};
 pub use provider::{
     compile_provider_snapshot, validate_provider_manifest, AuthScheme, Capability,
-    CompiledEndpoint, CompiledModel, CompiledProvider, Endpoint, PathParamStyle, ProviderClass,
-    ProviderManifest, ProviderSnapshot,
+    CompiledEndpoint, CompiledModel, CompiledProvider, Endpoint, GrantTransportConfig,
+    PathParamStyle, ProviderClass, ProviderManifest, ProviderSnapshot,
 };
 pub use routing::{match_model, RouteMatch};
 pub use usage::{UsageEvent, UsageStatus};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,8 +7,8 @@ pub mod usage;
 pub use budget::{BudgetDecision, BudgetLedger, BudgetPolicy, Reservation};
 pub use key::{parse_proxy_key, ProxyKeyParts};
 pub use provider::{
-    compile_provider_snapshot, validate_provider_manifest, AuthScheme, Capability,
-    CompiledEndpoint, CompiledModel, CompiledProvider, Endpoint, GrantTransportConfig,
+    compile_provider_snapshot, validate_provider_manifest, AuthAuthorizationConfig, AuthScheme,
+    Capability, CompiledEndpoint, CompiledModel, CompiledProvider, Endpoint, GrantTransportConfig,
     PathParamStyle, ProviderClass, ProviderManifest, ProviderSnapshot,
 };
 pub use routing::{match_model, RouteMatch};

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -93,6 +93,36 @@ pub struct ServiceBinding {
 pub struct AuthConfig {
     #[serde(default)]
     pub schemes: Vec<AuthScheme>,
+    #[serde(default)]
+    pub refresh: Option<AuthRefreshConfig>,
+    #[serde(rename = "grantTransports", default)]
+    pub grant_transports: BTreeMap<String, GrantTransportConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthRefreshConfig {
+    #[serde(rename = "tokenUrl")]
+    pub token_url: String,
+    #[serde(rename = "clientId", default)]
+    pub client_id: Option<String>,
+    #[serde(rename = "clientIdConfig", default)]
+    pub client_id_config: Option<String>,
+    #[serde(rename = "clientSecretConfig", default)]
+    pub client_secret_config: Option<String>,
+    #[serde(rename = "extraParams", default)]
+    pub extra_params: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrantTransportConfig {
+    #[serde(rename = "baseUrl", default)]
+    pub base_url: Option<String>,
+    #[serde(rename = "endpointPaths", default)]
+    pub endpoint_paths: BTreeMap<String, String>,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -388,6 +418,10 @@ pub enum ProviderError {
         endpoint: String,
         param: String,
     },
+    #[error("provider {provider} has invalid OAuth refresh configuration")]
+    InvalidAuthRefresh { provider: String },
+    #[error("provider {provider} has invalid grant transport {transport}")]
+    InvalidGrantTransport { provider: String, transport: String },
     #[error("provider {provider} capability {capability} references missing endpoint {endpoint}")]
     MissingEndpoint {
         provider: String,
@@ -427,6 +461,49 @@ pub fn validate_provider_manifest(manifest: &ProviderManifest) -> Result<(), Pro
     }
     if manifest.capabilities.is_empty() {
         return Err(ProviderError::MissingCapabilities(manifest.id.clone()));
+    }
+    if manifest.auth.refresh.as_ref().is_some_and(|refresh| {
+        !refresh.token_url.starts_with("https://")
+            || (refresh.client_id.is_none() && refresh.client_id_config.is_none())
+            || refresh
+                .client_id
+                .as_deref()
+                .is_some_and(|value| value.trim().is_empty())
+            || refresh
+                .client_id_config
+                .as_deref()
+                .is_some_and(|value| value.trim().is_empty())
+    }) {
+        return Err(ProviderError::InvalidAuthRefresh {
+            provider: manifest.id.clone(),
+        });
+    }
+    for (kind, transport) in &manifest.auth.grant_transports {
+        if !matches!(kind.as_str(), "api_key" | "oauth" | "subscription")
+            || transport
+                .base_url
+                .as_deref()
+                .is_some_and(|value| !value.starts_with("https://"))
+            || transport.endpoint_paths.iter().any(|(endpoint, path)| {
+                !manifest.endpoints.contains_key(endpoint) || !path.starts_with('/')
+            })
+            || transport.headers.values().any(|value| {
+                template_placeholders(value).iter().any(|placeholder| {
+                    !matches!(
+                        placeholder.as_str(),
+                        "grant.accountId"
+                            | "grant.provider"
+                            | "grant.subscription.plan"
+                            | "grant.subscription.subject"
+                    )
+                })
+            })
+        {
+            return Err(ProviderError::InvalidGrantTransport {
+                provider: manifest.id.clone(),
+                transport: kind.clone(),
+            });
+        }
     }
     for (endpoint_id, endpoint) in &manifest.endpoints {
         if !endpoint.path.starts_with('/') {
@@ -946,6 +1023,77 @@ endpoints:
         .unwrap();
         let error = validate_provider_manifest(&manifest).unwrap_err();
         assert!(matches!(error, ProviderError::MissingPathParam { .. }));
+    }
+
+    #[test]
+    fn rejects_unapproved_refresh_and_grant_transport_contracts() {
+        let invalid_refresh: ProviderManifest = serde_yaml::from_str(
+            r#"
+schema: clawrouter.service-provider.v1
+id: bad-refresh
+displayName: Bad Refresh
+auth:
+  schemes:
+    - type: bearer
+      header: Authorization
+      format: "Bearer ${secret}"
+      secretKind: api_key
+  refresh:
+    tokenUrl: http://example.com/oauth/token
+    clientId: public-client
+baseUrls:
+  default: https://example.com
+capabilities:
+  - id: llm.responses
+    endpoint: responses
+endpoints:
+  responses:
+    path: /v1/responses
+    requestFormat: openai.responses
+    responseFormat: openai.responses
+"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            validate_provider_manifest(&invalid_refresh),
+            Err(ProviderError::InvalidAuthRefresh { .. })
+        ));
+
+        let invalid_transport: ProviderManifest = serde_yaml::from_str(
+            r#"
+schema: clawrouter.service-provider.v1
+id: bad-transport
+displayName: Bad Transport
+auth:
+  schemes:
+    - type: bearer
+      header: Authorization
+      format: "Bearer ${secret}"
+      secretKind: api_key
+  grantTransports:
+    subscription:
+      baseUrl: https://example.com/subscription
+      endpointPaths:
+        unknown: /responses
+      headers:
+        Account-ID: "${grant.unknown}"
+baseUrls:
+  default: https://example.com
+capabilities:
+  - id: llm.responses
+    endpoint: responses
+endpoints:
+  responses:
+    path: /v1/responses
+    requestFormat: openai.responses
+    responseFormat: openai.responses
+"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            validate_provider_manifest(&invalid_transport),
+            Err(ProviderError::InvalidGrantTransport { .. })
+        ));
     }
 
     #[test]

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -531,6 +531,14 @@ pub fn validate_provider_manifest(manifest: &ProviderManifest) -> Result<(), Pro
                     .iter()
                     .any(|scope| scope.trim().is_empty())
                 || authorization
+                    .extra_authorize_params
+                    .keys()
+                    .any(|name| oauth_authorize_reserved_param(name))
+                || authorization
+                    .extra_token_params
+                    .keys()
+                    .any(|name| oauth_token_reserved_param(name))
+                || authorization
                     .account_id_json_pointer
                     .as_deref()
                     .is_some_and(|pointer| !pointer.starts_with('/'))
@@ -769,6 +777,26 @@ fn default_true() -> bool {
 
 fn default_oauth_grant_kind() -> String {
     "oauth".to_string()
+}
+
+fn oauth_authorize_reserved_param(name: &str) -> bool {
+    matches!(
+        name,
+        "response_type"
+            | "client_id"
+            | "redirect_uri"
+            | "scope"
+            | "code_challenge"
+            | "code_challenge_method"
+            | "state"
+    )
+}
+
+fn oauth_token_reserved_param(name: &str) -> bool {
+    matches!(
+        name,
+        "grant_type" | "client_id" | "client_secret" | "code" | "code_verifier" | "redirect_uri"
+    )
 }
 
 fn auth_scheme_id(scheme: &AuthScheme) -> String {
@@ -1127,6 +1155,42 @@ endpoints:
         assert!(matches!(
             validate_provider_manifest(&invalid_refresh),
             Err(ProviderError::InvalidAuthRefresh { .. })
+        ));
+
+        let invalid_authorization: ProviderManifest = serde_yaml::from_str(
+            r#"
+schema: clawrouter.service-provider.v1
+id: bad-authorization
+displayName: Bad Authorization
+auth:
+  schemes:
+    - type: bearer
+      header: Authorization
+      format: "Bearer ${secret}"
+      secretKind: api_key
+  authorization:
+    authorizeUrl: https://example.com/oauth/authorize
+    tokenUrl: https://example.com/oauth/token
+    clientId: public-client
+    scopes: [openid]
+    extraAuthorizeParams:
+      state: attacker-controlled
+baseUrls:
+  default: https://example.com
+capabilities:
+  - id: llm.responses
+    endpoint: responses
+endpoints:
+  responses:
+    path: /v1/responses
+    requestFormat: openai.responses
+    responseFormat: openai.responses
+"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            validate_provider_manifest(&invalid_authorization),
+            Err(ProviderError::InvalidAuthAuthorization { .. })
         ));
 
         let invalid_transport: ProviderManifest = serde_yaml::from_str(

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -199,10 +199,16 @@ pub struct Endpoint {
     pub path: String,
     #[serde(default = "default_post")]
     pub method: String,
+    #[serde(rename = "nativeProxy", default = "default_true")]
+    pub native_proxy: bool,
     #[serde(default)]
     pub auth: Option<String>,
     #[serde(default)]
     pub headers: BTreeMap<String, String>,
+    #[serde(rename = "requestHeaders", default)]
+    pub request_headers: Vec<String>,
+    #[serde(rename = "responseHeaders", default)]
+    pub response_headers: Vec<String>,
     #[serde(default)]
     pub query: BTreeMap<String, String>,
     #[serde(rename = "pathParams", default)]
@@ -323,8 +329,11 @@ pub struct CompiledEndpoint {
     pub method: String,
     pub methods: Vec<String>,
     pub path: String,
+    pub native_proxy: bool,
     pub auth: Option<String>,
     pub headers: BTreeMap<String, String>,
+    pub request_headers: Vec<String>,
+    pub response_headers: Vec<String>,
     pub query: BTreeMap<String, String>,
     pub path_params: Vec<String>,
     pub path_param_styles: BTreeMap<String, PathParamStyle>,
@@ -541,8 +550,11 @@ pub fn compile_provider_snapshot(
                     .filter(|methods: &Vec<String>| !methods.is_empty())
                     .unwrap_or_else(|| vec![endpoint.method.clone()]),
                 path: endpoint.path.clone(),
+                native_proxy: endpoint.native_proxy,
                 auth: endpoint.auth.clone(),
                 headers: endpoint.headers.clone(),
+                request_headers: endpoint.request_headers.clone(),
+                response_headers: endpoint.response_headers.clone(),
                 query: endpoint.query.clone(),
                 path_params: endpoint.path_params.clone(),
                 path_param_styles: endpoint.path_param_styles.clone(),
@@ -606,6 +618,10 @@ pub fn compile_provider_snapshot(
 
 fn default_post() -> String {
     "POST".to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn auth_scheme_id(scheme: &AuthScheme) -> String {
@@ -722,6 +738,7 @@ billing:
             vec!["GET", "POST"]
         );
         assert_eq!(snapshot.providers[0].endpoints[0].timeout_ms, Some(120000));
+        assert!(snapshot.providers[0].endpoints[0].native_proxy);
         assert_eq!(
             snapshot.providers[0].routing.model_prefixes,
             vec!["tavily/"]
@@ -929,5 +946,41 @@ endpoints:
         .unwrap();
         let error = validate_provider_manifest(&manifest).unwrap_err();
         assert!(matches!(error, ProviderError::MissingPathParam { .. }));
+    }
+
+    #[test]
+    fn compiles_native_proxy_header_contract() {
+        let manifest: ProviderManifest = serde_yaml::from_str(
+            r#"
+schema: clawrouter.service-provider.v1
+id: native-contract
+displayName: Native Contract
+auth:
+  schemes:
+    - type: bearer
+      header: Authorization
+      format: "Bearer ${secret}"
+      secretKind: api_key
+baseUrls:
+  default: https://example.com
+capabilities:
+  - id: llm.responses
+    endpoint: responses
+endpoints:
+  responses:
+    path: /v1/responses
+    nativeProxy: false
+    requestHeaders: [OpenAI-Organization]
+    responseHeaders: [request-id]
+    requestFormat: openai.responses
+    responseFormat: openai.responses
+"#,
+        )
+        .unwrap();
+        let snapshot = compile_provider_snapshot(&[manifest]).unwrap();
+        let endpoint = &snapshot.providers[0].endpoints[0];
+        assert!(!endpoint.native_proxy);
+        assert_eq!(endpoint.request_headers, vec!["OpenAI-Organization"]);
+        assert_eq!(endpoint.response_headers, vec!["request-id"]);
     }
 }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -94,9 +94,38 @@ pub struct AuthConfig {
     #[serde(default)]
     pub schemes: Vec<AuthScheme>,
     #[serde(default)]
+    pub authorization: Option<AuthAuthorizationConfig>,
+    #[serde(default)]
     pub refresh: Option<AuthRefreshConfig>,
     #[serde(rename = "grantTransports", default)]
     pub grant_transports: BTreeMap<String, GrantTransportConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthAuthorizationConfig {
+    #[serde(rename = "authorizeUrl")]
+    pub authorize_url: String,
+    #[serde(rename = "tokenUrl")]
+    pub token_url: String,
+    #[serde(rename = "clientId", default)]
+    pub client_id: Option<String>,
+    #[serde(rename = "clientIdConfig", default)]
+    pub client_id_config: Option<String>,
+    #[serde(rename = "clientSecretConfig", default)]
+    pub client_secret_config: Option<String>,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    #[serde(rename = "grantKind", default = "default_oauth_grant_kind")]
+    pub grant_kind: String,
+    #[serde(rename = "extraAuthorizeParams", default)]
+    pub extra_authorize_params: BTreeMap<String, String>,
+    #[serde(rename = "extraTokenParams", default)]
+    pub extra_token_params: BTreeMap<String, String>,
+    #[serde(rename = "accountIdJsonPointer", default)]
+    pub account_id_json_pointer: Option<String>,
+    #[serde(rename = "subscriptionPlanJsonPointer", default)]
+    pub subscription_plan_json_pointer: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -420,6 +449,8 @@ pub enum ProviderError {
     },
     #[error("provider {provider} has invalid OAuth refresh configuration")]
     InvalidAuthRefresh { provider: String },
+    #[error("provider {provider} has invalid OAuth authorization configuration")]
+    InvalidAuthAuthorization { provider: String },
     #[error("provider {provider} has invalid grant transport {transport}")]
     InvalidGrantTransport { provider: String, transport: String },
     #[error("provider {provider} capability {capability} references missing endpoint {endpoint}")]
@@ -475,6 +506,41 @@ pub fn validate_provider_manifest(manifest: &ProviderManifest) -> Result<(), Pro
                 .is_some_and(|value| value.trim().is_empty())
     }) {
         return Err(ProviderError::InvalidAuthRefresh {
+            provider: manifest.id.clone(),
+        });
+    }
+    if manifest
+        .auth
+        .authorization
+        .as_ref()
+        .is_some_and(|authorization| {
+            !authorization.authorize_url.starts_with("https://")
+                || !authorization.token_url.starts_with("https://")
+                || (authorization.client_id.is_none() && authorization.client_id_config.is_none())
+                || authorization
+                    .client_id
+                    .as_deref()
+                    .is_some_and(|value| value.trim().is_empty())
+                || authorization
+                    .client_id_config
+                    .as_deref()
+                    .is_some_and(|value| value.trim().is_empty())
+                || !matches!(authorization.grant_kind.as_str(), "oauth" | "subscription")
+                || authorization
+                    .scopes
+                    .iter()
+                    .any(|scope| scope.trim().is_empty())
+                || authorization
+                    .account_id_json_pointer
+                    .as_deref()
+                    .is_some_and(|pointer| !pointer.starts_with('/'))
+                || authorization
+                    .subscription_plan_json_pointer
+                    .as_deref()
+                    .is_some_and(|pointer| !pointer.starts_with('/'))
+        })
+    {
+        return Err(ProviderError::InvalidAuthAuthorization {
             provider: manifest.id.clone(),
         });
     }
@@ -699,6 +765,10 @@ fn default_post() -> String {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_oauth_grant_kind() -> String {
+    "oauth".to_string()
 }
 
 fn auth_scheme_id(scheme: &AuthScheme) -> String {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -594,22 +594,21 @@ async fn proxy_openai_compatible(
             return audit.failure_response(response).await;
         }
     };
-    let transport_path =
-        match grant_transport_endpoint_path(route.provider, endpoint, grant.as_ref()) {
-            Ok(value) => value,
-            Err(HeaderBuildError::Client {
-                code,
-                message,
-                status,
-            }) => {
-                let response = json_error(code, message, status)?;
-                return audit.failure_response(response).await;
-            }
-            Err(HeaderBuildError::Runtime(error)) => {
-                let response = provider_runtime_error_response(error)?;
-                return audit.failure_response(response).await;
-            }
-        };
+    let (grant, transport_path) = match endpoint_upstream_grant(route.provider, endpoint, grant) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
     let query_auth = match query_api_key_for_grant(route.provider, &env, grant.as_ref()) {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
@@ -910,7 +909,7 @@ async fn proxy_manifest_endpoint(
             return audit.failure_response(response).await;
         }
     };
-    let transport_path = match grant_transport_endpoint_path(provider, endpoint, grant.as_ref()) {
+    let (grant, transport_path) = match endpoint_upstream_grant(provider, endpoint, grant) {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
             code,
@@ -1167,7 +1166,7 @@ async fn proxy_native_provider(
             return audit.failure_response(response).await;
         }
     };
-    let transport_path = match grant_transport_endpoint_path(provider, endpoint, grant.as_ref()) {
+    let (grant, transport_path) = match endpoint_upstream_grant(provider, endpoint, grant) {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
             code,
@@ -1394,10 +1393,6 @@ fn native_upstream_url(
         base.trim_end_matches('/'),
         transport_path.unwrap_or(&native_path)
     );
-    if let Some(query) = incoming_query.filter(|query| !query.is_empty()) {
-        url.push('?');
-        url.push_str(query);
-    }
     let mut injected = resolved_template_map(provider, &endpoint.query, Some(env))?;
     for (name, value) in resolved_template_map(provider, &provider.adapter.inject_query, Some(env))?
     {
@@ -1406,7 +1401,7 @@ fn native_upstream_url(
     if let Some((param, secret)) = query_auth {
         injected.insert(param, secret);
     }
-    append_query(&mut url, injected);
+    append_native_query(&mut url, incoming_query, injected)?;
     Ok(url)
 }
 
@@ -8409,24 +8404,28 @@ fn provider_upstream_base_url<'a>(
         })
 }
 
-fn grant_transport_endpoint_path(
+fn endpoint_upstream_grant(
     provider: &CompiledProvider,
     endpoint: &CompiledEndpoint,
-    grant: Option<&UpstreamGrantRecord>,
-) -> std::result::Result<Option<String>, HeaderBuildError> {
-    let Some(transport) = grant_transport(provider, grant) else {
-        return Ok(None);
+    grant: Option<UpstreamGrantRecord>,
+) -> std::result::Result<(Option<UpstreamGrantRecord>, Option<String>), HeaderBuildError> {
+    let Some(grant) = grant else {
+        return Ok((None, None));
     };
-    transport
-        .endpoint_paths
-        .get(&endpoint.id)
-        .cloned()
-        .map(Some)
-        .ok_or(HeaderBuildError::Client {
+    let Some(transport) = grant_transport(provider, Some(&grant)) else {
+        return Ok((Some(grant), None));
+    };
+    let Some(path) = transport.endpoint_paths.get(&endpoint.id).cloned() else {
+        if !provider_requires_oauth(provider) {
+            return Ok((None, None));
+        }
+        return Err(HeaderBuildError::Client {
             code: "upstream_grant_transport_unsupported",
             message: "upstream grant transport does not support this provider endpoint",
             status: 409,
-        })
+        });
+    };
+    Ok((Some(grant), Some(path)))
 }
 
 fn apply_grant_transport_headers(
@@ -12245,6 +12244,36 @@ fn append_query(url: &mut String, query: BTreeMap<String, String>) {
     url.push_str(&pairs);
 }
 
+fn append_native_query(
+    url: &mut String,
+    incoming_query: Option<&str>,
+    injected: BTreeMap<String, String>,
+) -> Result<()> {
+    if let Some(incoming_query) = incoming_query.filter(|query| !query.is_empty()) {
+        let mut parsed = Url::parse("https://clawrouter.invalid/")
+            .map_err(|error| Error::RustError(format!("failed to parse native query: {error}")))?;
+        parsed.set_query(Some(incoming_query));
+        let forwarded = parsed
+            .query_pairs()
+            .filter(|(name, _)| !injected.contains_key(name.as_ref()))
+            .map(|(name, value)| {
+                format!(
+                    "{}={}",
+                    encode_component(name.as_ref()),
+                    encode_component(value.as_ref())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("&");
+        if !forwarded.is_empty() {
+            url.push(if url.contains('?') { '&' } else { '?' });
+            url.push_str(&forwarded);
+        }
+    }
+    append_query(url, injected);
+    Ok(())
+}
+
 fn template_placeholders(template: &str) -> Vec<String> {
     let mut params = Vec::new();
     let mut rest = template;
@@ -14361,17 +14390,14 @@ mod tests {
             provider_upstream_base_url(provider, Some(&grant)).unwrap(),
             "https://chatgpt.com/backend-api/codex"
         );
-        assert_eq!(
-            grant_transport_endpoint_path(provider, responses, Some(&grant)).unwrap(),
-            Some("/responses".to_string())
-        );
-        assert!(matches!(
-            grant_transport_endpoint_path(provider, chat, Some(&grant)),
-            Err(HeaderBuildError::Client {
-                code: "upstream_grant_transport_unsupported",
-                ..
-            })
-        ));
+        let (responses_grant, responses_path) =
+            endpoint_upstream_grant(provider, responses, Some(grant.clone())).unwrap();
+        assert!(responses_grant.is_some());
+        assert_eq!(responses_path, Some("/responses".to_string()));
+        let (chat_grant, chat_path) =
+            endpoint_upstream_grant(provider, chat, Some(grant.clone())).unwrap();
+        assert!(chat_grant.is_none());
+        assert!(chat_path.is_none());
         assert_eq!(
             resolve_grant_template("${grant.accountId}", &grant).unwrap(),
             "acct_test"
@@ -14603,13 +14629,21 @@ mod tests {
     }
 
     #[test]
-    fn native_query_injection_preserves_the_client_query() {
-        let mut url = "https://example.com/v1/models?alt=sse".to_string();
-        append_query(
+    fn native_query_injection_preserves_unowned_duplicates_and_overrides_controlled_values() {
+        let mut url = "https://example.com/v1/models".to_string();
+        append_native_query(
             &mut url,
-            BTreeMap::from([("key".to_string(), "secret".to_string())]),
+            Some("tag=one&api-version=caller&tag=two"),
+            BTreeMap::from([
+                ("api-version".to_string(), "configured".to_string()),
+                ("key".to_string(), "secret".to_string()),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "https://example.com/v1/models?tag=one&tag=two&api-version=configured&key=secret"
         );
-        assert_eq!(url, "https://example.com/v1/models?alt=sse&key=secret");
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -300,6 +300,7 @@ fn service_index() -> Result<Response> {
             "adminCredentials": "/v1/admin/credentials",
             "adminConnections": "/v1/admin/connections",
             "adminUpstreamGrants": "/v1/admin/upstream-grants",
+            "adminAssignmentRules": "/v1/admin/assignment-rules",
             "apiAliases": {
                 "routes": ["/api/route", "/api/routes"],
                 "session": "/api/session",
@@ -1787,6 +1788,103 @@ struct AdminUpstreamGrantResponse {
     usable: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AssignmentRuleKind {
+    #[default]
+    ExactEmail,
+    EmailDomain,
+    GithubOrg,
+    GithubTeam,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentRuleRecord {
+    #[serde(default = "default_assignment_rule_version")]
+    version: u8,
+    #[serde(default = "default_true")]
+    enabled: bool,
+    #[serde(default)]
+    kind: AssignmentRuleKind,
+    subject: String,
+    #[serde(default)]
+    groups: Vec<String>,
+    #[serde(default)]
+    policy_ids: Vec<String>,
+    #[serde(default = "default_binding_priority")]
+    priority: u16,
+    #[serde(default = "default_true")]
+    revoke_on_loss: bool,
+    provenance: String,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdminAssignmentRuleResponse {
+    rule_id: String,
+    #[serde(flatten)]
+    rule: AssignmentRuleRecord,
+    generated_group: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentEvidence {
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    verified: bool,
+    #[serde(default)]
+    github_orgs: Vec<String>,
+    #[serde(default)]
+    github_teams: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentReconcileRequest {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    all: bool,
+    #[serde(default)]
+    evidence: Option<AssignmentEvidence>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentStateEntry {
+    #[serde(default)]
+    groups: Vec<String>,
+    #[serde(default = "default_true")]
+    revoke_on_loss: bool,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentStateRecord {
+    #[serde(default = "default_assignment_rule_version")]
+    version: u8,
+    #[serde(default)]
+    assignments: BTreeMap<String, AssignmentStateEntry>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignmentReconcileResult {
+    email: String,
+    matched_rule_ids: Vec<String>,
+    retained_rule_ids: Vec<String>,
+    groups: Vec<String>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 enum AccessRole {
@@ -2583,6 +2681,87 @@ async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {
         return json_error("method_not_allowed", "admin method is not allowed", 405);
     }
 
+    if req.method() == Method::Get && path == "/v1/admin/assignment-rules" {
+        let rules = list_assignment_rules(&kv)
+            .await?
+            .into_iter()
+            .map(|(rule_id, rule)| admin_assignment_rule_response(&rule_id, rule))
+            .collect::<Vec<_>>();
+        return Response::from_json(&serde_json::json!({ "rules": rules }));
+    }
+
+    if req.method() == Method::Post && path == "/v1/admin/assignment-rules/reconcile" {
+        let request = match serde_json::from_str::<AssignmentReconcileRequest>(&req.text().await?) {
+            Ok(request) => request,
+            Err(error) => {
+                return json_error(
+                    "invalid_assignment_reconcile_request",
+                    &format!("request body must be assignment reconciliation JSON: {error}"),
+                    400,
+                );
+            }
+        };
+        let results = match reconcile_assignment_request(&env, &kv, request).await {
+            Ok(results) => results,
+            Err(AssignmentReconcileError::Client(message)) => {
+                return json_error("invalid_assignment_reconcile_request", &message, 400);
+            }
+            Err(AssignmentReconcileError::Runtime(error)) => return Err(error),
+        };
+        return Response::from_json(&serde_json::json!({ "results": results }));
+    }
+
+    if let Some(rule_id) = path.strip_prefix("/v1/admin/assignment-rules/") {
+        if req.method() != Method::Put {
+            return json_error("method_not_allowed", "admin method is not allowed", 405);
+        }
+        let rule_id = match validate_assignment_rule_id(rule_id) {
+            Ok(rule_id) => rule_id,
+            Err(message) => return json_error("invalid_assignment_rule", message, 400),
+        };
+        let request = match serde_json::from_str::<AssignmentRuleRecord>(&req.text().await?) {
+            Ok(request) => request,
+            Err(error) => {
+                return json_error(
+                    "invalid_assignment_rule_request",
+                    &format!("request body must be assignment-rule JSON: {error}"),
+                    400,
+                );
+            }
+        };
+        let existing = get_assignment_rule(&kv, &rule_id).await?;
+        let rule = match normalize_assignment_rule(&rule_id, request, existing.as_ref()) {
+            Ok(rule) => rule,
+            Err(message) => return json_error("invalid_assignment_rule", &message, 400),
+        };
+        let policies = authoritative_access_policies(&env, &kv, &rule.policy_ids).await?;
+        let missing_policy_ids = rule
+            .policy_ids
+            .iter()
+            .filter(|policy_id| !policies.contains_key(*policy_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_policy_ids.is_empty() {
+            return json_error(
+                "unknown_policy",
+                &format!(
+                    "assignment-rule policies do not exist: {}",
+                    missing_policy_ids.join(",")
+                ),
+                404,
+            );
+        }
+        put_kv_record(
+            &kv,
+            &assignment_rule_key(&rule_id),
+            &rule,
+            "assignment rule",
+        )
+        .await?;
+        sync_assignment_rule_bindings(&env, &kv, &rule_id, existing.as_ref(), &rule).await?;
+        return Response::from_json(&admin_assignment_rule_response(&rule_id, rule));
+    }
+
     if req.method() == Method::Get && path == "/v1/admin/provider-status" {
         let snapshot = provider_snapshot()?;
         let grants = list_oauth_grants(&kv).await?;
@@ -3302,7 +3481,17 @@ async fn access_control_user_record(
         "access user compatibility record",
     )
     .await;
-    Ok(user.record)
+    match reconcile_access_user_assignments(env, &kv, email, user.record.clone(), None).await {
+        Ok((record, _)) => Ok(record),
+        Err(error) => {
+            console_error!(
+                "first-login assignment reconciliation failed closed for {}: {}",
+                email,
+                error
+            );
+            Ok(user.record)
+        }
+    }
 }
 
 fn default_access_user_record(default_tenant: &str) -> AccessUserRecord {
@@ -5961,6 +6150,468 @@ fn enum_label<T: Serialize>(value: &T) -> String {
         .ok()
         .and_then(|value| value.as_str().map(str::to_string))
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[derive(Debug)]
+enum AssignmentReconcileError {
+    Client(String),
+    Runtime(Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AssignmentMatch {
+    Match,
+    NoMatch,
+    Unknown,
+}
+
+fn default_assignment_rule_version() -> u8 {
+    1
+}
+
+fn validate_assignment_rule_id(value: &str) -> std::result::Result<String, &'static str> {
+    if value.len() < 4
+        || value.len() > 48
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Err("assignment rule id must use 4-48 lowercase letters, numbers, or underscores");
+    }
+    Ok(value.to_string())
+}
+
+fn assignment_rule_key(rule_id: &str) -> String {
+    format!("access/assignment-rules/{rule_id}")
+}
+
+fn assignment_state_key(email: &str) -> String {
+    format!("access/assignment-state/{email}")
+}
+
+fn assignment_rule_group(rule_id: &str) -> String {
+    format!("assignment.{rule_id}")
+}
+
+fn normalize_assignment_domain(value: &str) -> std::result::Result<String, String> {
+    let domain = value.trim().trim_start_matches('@').to_ascii_lowercase();
+    if domain.is_empty()
+        || domain.len() > 253
+        || !domain.contains('.')
+        || domain.starts_with('.')
+        || domain.ends_with('.')
+        || domain.contains("..")
+        || !domain
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+    {
+        return Err("email-domain subjects must be a valid lowercase domain".to_string());
+    }
+    Ok(domain)
+}
+
+fn normalize_github_subject(value: &str, team: bool) -> std::result::Result<String, String> {
+    let value = value.trim().trim_matches('/').to_ascii_lowercase();
+    let valid_segment = |segment: &str| {
+        !segment.is_empty()
+            && segment.len() <= 100
+            && segment
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    };
+    if team {
+        let Some((org, team)) = value.split_once('/') else {
+            return Err("GitHub team subjects must use org/team".to_string());
+        };
+        if value.matches('/').count() != 1 || !valid_segment(org) || !valid_segment(team) {
+            return Err("GitHub team subjects must use a valid org/team slug".to_string());
+        }
+    } else if value.contains('/') || !valid_segment(&value) {
+        return Err("GitHub organization subjects must use a valid organization slug".to_string());
+    }
+    Ok(value)
+}
+
+fn normalize_assignment_rule(
+    rule_id: &str,
+    mut rule: AssignmentRuleRecord,
+    existing: Option<&AssignmentRuleRecord>,
+) -> std::result::Result<AssignmentRuleRecord, String> {
+    validate_assignment_rule_id(rule_id).map_err(str::to_string)?;
+    rule.version = default_assignment_rule_version();
+    rule.subject = match rule.kind {
+        AssignmentRuleKind::ExactEmail => {
+            normalize_access_email(&rule.subject).map_err(str::to_string)?
+        }
+        AssignmentRuleKind::EmailDomain => normalize_assignment_domain(&rule.subject)?,
+        AssignmentRuleKind::GithubOrg => normalize_github_subject(&rule.subject, false)?,
+        AssignmentRuleKind::GithubTeam => normalize_github_subject(&rule.subject, true)?,
+    };
+    rule.groups = normalize_access_groups(rule.groups)?;
+    let mut policy_ids = BTreeSet::new();
+    for policy_id in rule.policy_ids {
+        policy_ids.insert(validate_admin_kid(policy_id.trim()).map_err(str::to_string)?);
+    }
+    if policy_ids.len() > 64 {
+        return Err("an assignment rule can grant at most 64 policies".to_string());
+    }
+    rule.policy_ids = policy_ids.into_iter().collect();
+    rule.provenance = rule.provenance.trim().to_string();
+    if rule.provenance.is_empty()
+        || rule.provenance.len() > 256
+        || rule.provenance.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err("assignment rule provenance must be 1-256 visible characters".to_string());
+    }
+    let now = current_iso_timestamp();
+    rule.created_at = existing
+        .and_then(|record| record.created_at.clone())
+        .or(rule.created_at)
+        .or_else(|| Some(now.clone()));
+    rule.updated_at = Some(now);
+    Ok(rule)
+}
+
+fn admin_assignment_rule_response(
+    rule_id: &str,
+    rule: AssignmentRuleRecord,
+) -> AdminAssignmentRuleResponse {
+    AdminAssignmentRuleResponse {
+        rule_id: rule_id.to_string(),
+        rule,
+        generated_group: assignment_rule_group(rule_id),
+    }
+}
+
+async fn get_assignment_rule(kv: &KvStore, rule_id: &str) -> Result<Option<AssignmentRuleRecord>> {
+    let Some(record) = kv
+        .get(&assignment_rule_key(rule_id))
+        .text()
+        .await
+        .map_err(|error| Error::RustError(format!("failed to read assignment rule: {error}")))?
+    else {
+        return Ok(None);
+    };
+    serde_json::from_str(&record)
+        .map(Some)
+        .map_err(|error| Error::RustError(format!("assignment rule is invalid JSON: {error}")))
+}
+
+async fn list_assignment_rules(kv: &KvStore) -> Result<BTreeMap<String, AssignmentRuleRecord>> {
+    let mut rules = BTreeMap::new();
+    let mut cursor = None;
+    loop {
+        let mut request = kv
+            .list()
+            .prefix("access/assignment-rules/".to_string())
+            .limit(1000);
+        if let Some(next_cursor) = cursor.take() {
+            request = request.cursor(next_cursor);
+        }
+        let list = request.execute().await.map_err(|error| {
+            Error::RustError(format!("failed to list assignment rules: {error}"))
+        })?;
+        for key in list.keys {
+            let Some(rule_id) = key.name.strip_prefix("access/assignment-rules/") else {
+                continue;
+            };
+            validate_assignment_rule_id(rule_id).map_err(str::to_string)?;
+            let Some(record) = kv.get(&key.name).text().await.map_err(|error| {
+                Error::RustError(format!("failed to read assignment rule: {error}"))
+            })?
+            else {
+                continue;
+            };
+            let rule = serde_json::from_str::<AssignmentRuleRecord>(&record).map_err(|error| {
+                Error::RustError(format!("assignment rule is invalid JSON: {error}"))
+            })?;
+            rules.insert(rule_id.to_string(), rule);
+        }
+        if list.list_complete {
+            break;
+        }
+        let Some(next_cursor) = list.cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+    Ok(rules)
+}
+
+fn normalize_assignment_evidence(
+    mut evidence: AssignmentEvidence,
+) -> std::result::Result<AssignmentEvidence, String> {
+    evidence.source = evidence.source.trim().to_ascii_lowercase();
+    if evidence.source != "github" || !evidence.verified {
+        return Err("GitHub assignment evidence must be explicitly verified".to_string());
+    }
+    evidence.github_orgs = evidence
+        .github_orgs
+        .into_iter()
+        .map(|value| normalize_github_subject(&value, false))
+        .collect::<std::result::Result<BTreeSet<_>, _>>()?
+        .into_iter()
+        .collect();
+    evidence.github_teams = evidence
+        .github_teams
+        .into_iter()
+        .map(|value| normalize_github_subject(&value, true))
+        .collect::<std::result::Result<BTreeSet<_>, _>>()?
+        .into_iter()
+        .collect();
+    Ok(evidence)
+}
+
+fn assignment_rule_match(
+    rule: &AssignmentRuleRecord,
+    email: &str,
+    evidence: Option<&AssignmentEvidence>,
+) -> AssignmentMatch {
+    if !rule.enabled {
+        return AssignmentMatch::NoMatch;
+    }
+    match rule.kind {
+        AssignmentRuleKind::ExactEmail => {
+            if rule.subject == email {
+                AssignmentMatch::Match
+            } else {
+                AssignmentMatch::NoMatch
+            }
+        }
+        AssignmentRuleKind::EmailDomain => {
+            if email
+                .split_once('@')
+                .is_some_and(|(_, domain)| domain == rule.subject)
+            {
+                AssignmentMatch::Match
+            } else {
+                AssignmentMatch::NoMatch
+            }
+        }
+        AssignmentRuleKind::GithubOrg => match evidence {
+            Some(evidence) if evidence.github_orgs.contains(&rule.subject) => {
+                AssignmentMatch::Match
+            }
+            Some(_) => AssignmentMatch::NoMatch,
+            None => AssignmentMatch::Unknown,
+        },
+        AssignmentRuleKind::GithubTeam => match evidence {
+            Some(evidence) if evidence.github_teams.contains(&rule.subject) => {
+                AssignmentMatch::Match
+            }
+            Some(_) => AssignmentMatch::NoMatch,
+            None => AssignmentMatch::Unknown,
+        },
+    }
+}
+
+fn assignment_entry_for_rule(rule_id: &str, rule: &AssignmentRuleRecord) -> AssignmentStateEntry {
+    let mut groups = rule.groups.clone();
+    if !rule.policy_ids.is_empty() {
+        groups.push(assignment_rule_group(rule_id));
+    }
+    groups.sort();
+    groups.dedup();
+    AssignmentStateEntry {
+        groups,
+        revoke_on_loss: rule.revoke_on_loss,
+    }
+}
+
+fn reconcile_assignment_state(
+    email: &str,
+    rules: &BTreeMap<String, AssignmentRuleRecord>,
+    evidence: Option<&AssignmentEvidence>,
+    previous: AssignmentStateRecord,
+) -> (AssignmentStateRecord, Vec<String>, Vec<String>) {
+    reconcile_assignment_state_at(email, rules, evidence, previous, current_iso_timestamp())
+}
+
+fn reconcile_assignment_state_at(
+    email: &str,
+    rules: &BTreeMap<String, AssignmentRuleRecord>,
+    evidence: Option<&AssignmentEvidence>,
+    previous: AssignmentStateRecord,
+    updated_at: String,
+) -> (AssignmentStateRecord, Vec<String>, Vec<String>) {
+    let mut assignments = BTreeMap::new();
+    let mut matched = Vec::new();
+    let mut retained = Vec::new();
+    for (rule_id, rule) in rules {
+        match assignment_rule_match(rule, email, evidence) {
+            AssignmentMatch::Match => {
+                assignments.insert(rule_id.clone(), assignment_entry_for_rule(rule_id, rule));
+                matched.push(rule_id.clone());
+            }
+            AssignmentMatch::Unknown => {
+                if let Some(entry) = previous.assignments.get(rule_id) {
+                    assignments.insert(rule_id.clone(), entry.clone());
+                    retained.push(rule_id.clone());
+                }
+            }
+            AssignmentMatch::NoMatch if rule.enabled && !rule.revoke_on_loss => {
+                if let Some(entry) = previous.assignments.get(rule_id) {
+                    assignments.insert(rule_id.clone(), entry.clone());
+                    retained.push(rule_id.clone());
+                }
+            }
+            AssignmentMatch::NoMatch => {}
+        }
+    }
+    (
+        AssignmentStateRecord {
+            version: default_assignment_rule_version(),
+            assignments,
+            updated_at: Some(updated_at),
+        },
+        matched,
+        retained,
+    )
+}
+
+async fn get_assignment_state(kv: &KvStore, email: &str) -> Result<AssignmentStateRecord> {
+    let Some(record) = kv
+        .get(&assignment_state_key(email))
+        .text()
+        .await
+        .map_err(|error| Error::RustError(format!("failed to read assignment state: {error}")))?
+    else {
+        return Ok(AssignmentStateRecord::default());
+    };
+    serde_json::from_str(&record)
+        .map_err(|error| Error::RustError(format!("assignment state is invalid JSON: {error}")))
+}
+
+fn assignment_state_groups(state: &AssignmentStateRecord) -> BTreeSet<String> {
+    state
+        .assignments
+        .values()
+        .flat_map(|entry| entry.groups.iter().cloned())
+        .collect()
+}
+
+async fn reconcile_access_user_assignments(
+    env: &Env,
+    kv: &KvStore,
+    email: &str,
+    mut record: AccessUserRecord,
+    evidence: Option<&AssignmentEvidence>,
+) -> Result<(AccessUserRecord, AssignmentReconcileResult)> {
+    let email = normalize_access_email(email).map_err(str::to_string)?;
+    let rules = list_assignment_rules(kv).await?;
+    let previous = get_assignment_state(kv, &email).await?;
+    let previous_groups = assignment_state_groups(&previous);
+    let (state, matched_rule_ids, retained_rule_ids) =
+        reconcile_assignment_state(&email, &rules, evidence, previous);
+    let managed_groups = assignment_state_groups(&state);
+    let mut groups = record
+        .groups
+        .into_iter()
+        .filter(|group| !previous_groups.contains(group))
+        .collect::<BTreeSet<_>>();
+    groups.extend(managed_groups);
+    record.groups = normalize_access_groups(groups.into_iter().collect())?;
+    record.role = AccessRole::User;
+    let namespace = access_control_namespace(env)?;
+    let user = AccessControlUser {
+        email: email.clone(),
+        record: record.clone(),
+    };
+    put_access_control_user(&namespace, &user).await?;
+    sync_kv_record_best_effort(
+        kv,
+        &format!("access/users/{email}"),
+        &record,
+        "access user compatibility record",
+    )
+    .await;
+    put_kv_record(
+        kv,
+        &assignment_state_key(&email),
+        &state,
+        "assignment state",
+    )
+    .await?;
+    let result = AssignmentReconcileResult {
+        email,
+        matched_rule_ids,
+        retained_rule_ids,
+        groups: record.groups.clone(),
+    };
+    Ok((record, result))
+}
+
+async fn reconcile_assignment_request(
+    env: &Env,
+    kv: &KvStore,
+    request: AssignmentReconcileRequest,
+) -> std::result::Result<Vec<AssignmentReconcileResult>, AssignmentReconcileError> {
+    if request.all && request.email.is_some() {
+        return Err(AssignmentReconcileError::Client(
+            "use either email or all, not both".to_string(),
+        ));
+    }
+    if request.all && request.evidence.is_some() {
+        return Err(AssignmentReconcileError::Client(
+            "verified GitHub evidence can reconcile only one email".to_string(),
+        ));
+    }
+    let evidence = request
+        .evidence
+        .map(normalize_assignment_evidence)
+        .transpose()
+        .map_err(AssignmentReconcileError::Client)?;
+    let emails = if request.all {
+        list_admin_access_users(env, kv)
+            .await
+            .map_err(AssignmentReconcileError::Runtime)?
+            .into_iter()
+            .map(|user| user.email)
+            .collect::<Vec<_>>()
+    } else {
+        vec![
+            normalize_access_email(request.email.as_deref().unwrap_or_default())
+                .map_err(|message| AssignmentReconcileError::Client(message.to_string()))?,
+        ]
+    };
+    let mut results = Vec::new();
+    for email in emails {
+        let record = access_control_user_record(env, &email, &default_access_tenant(env))
+            .await
+            .map_err(AssignmentReconcileError::Runtime)?;
+        let (_, result) =
+            reconcile_access_user_assignments(env, kv, &email, record, evidence.as_ref())
+                .await
+                .map_err(AssignmentReconcileError::Runtime)?;
+        results.push(result);
+    }
+    Ok(results)
+}
+
+async fn sync_assignment_rule_bindings(
+    env: &Env,
+    kv: &KvStore,
+    rule_id: &str,
+    existing: Option<&AssignmentRuleRecord>,
+    rule: &AssignmentRuleRecord,
+) -> Result<()> {
+    let policy_ids = existing
+        .into_iter()
+        .flat_map(|record| record.policy_ids.iter().cloned())
+        .chain(rule.policy_ids.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    for policy_id in policy_ids.iter() {
+        let binding = normalize_policy_binding(PolicyBindingRecord {
+            policy_id: policy_id.clone(),
+            principal_type: PrincipalType::Group,
+            principal_id: assignment_rule_group(rule_id),
+            enabled: rule.enabled && rule.policy_ids.contains(policy_id),
+            priority: rule.priority,
+        })
+        .map_err(str::to_string)?;
+        put_policy_binding_record(env, kv, &binding).await?;
+    }
+    Ok(())
 }
 
 async fn list_admin_access_users(env: &Env, kv: &KvStore) -> Result<Vec<AdminAccessUserResponse>> {
@@ -11124,6 +11775,26 @@ mod tests {
         }
     }
 
+    fn assignment_test_rule(
+        kind: AssignmentRuleKind,
+        subject: &str,
+        revoke_on_loss: bool,
+    ) -> AssignmentRuleRecord {
+        AssignmentRuleRecord {
+            version: 1,
+            enabled: true,
+            kind,
+            subject: subject.to_string(),
+            groups: vec!["maintainers".to_string()],
+            policy_ids: vec!["svc_models".to_string()],
+            priority: 10,
+            revoke_on_loss,
+            provenance: "test".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
     fn entitlement_test_row(
         provider: &str,
         allowed: bool,
@@ -11831,6 +12502,80 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(groups, vec!["docs", "maintainers"]);
+    }
+
+    #[test]
+    fn assignment_rules_match_verified_identity_evidence_only() {
+        let email_rule = assignment_test_rule(AssignmentRuleKind::EmailDomain, "example.com", true);
+        let github_rule =
+            assignment_test_rule(AssignmentRuleKind::GithubTeam, "openclaw/maintainers", true);
+        let evidence = AssignmentEvidence {
+            source: "github".to_string(),
+            verified: true,
+            github_orgs: vec!["openclaw".to_string()],
+            github_teams: vec!["openclaw/maintainers".to_string()],
+        };
+
+        assert_eq!(
+            assignment_rule_match(&email_rule, "user@example.com", None),
+            AssignmentMatch::Match
+        );
+        assert_eq!(
+            assignment_rule_match(&github_rule, "user@example.com", None),
+            AssignmentMatch::Unknown
+        );
+        assert_eq!(
+            assignment_rule_match(&github_rule, "user@example.com", Some(&evidence)),
+            AssignmentMatch::Match
+        );
+    }
+
+    #[test]
+    fn assignment_reconciliation_retains_unknown_and_revokes_verified_loss() {
+        let rule =
+            assignment_test_rule(AssignmentRuleKind::GithubTeam, "openclaw/maintainers", true);
+        let rules = BTreeMap::from([("maintainers".to_string(), rule)]);
+        let previous = AssignmentStateRecord {
+            version: 1,
+            assignments: BTreeMap::from([(
+                "maintainers".to_string(),
+                AssignmentStateEntry {
+                    groups: vec![
+                        "assignment.maintainers".to_string(),
+                        "maintainers".to_string(),
+                    ],
+                    revoke_on_loss: true,
+                },
+            )]),
+            updated_at: None,
+        };
+        let (unknown, matched, retained) = reconcile_assignment_state_at(
+            "user@example.com",
+            &rules,
+            None,
+            previous.clone(),
+            "2026-06-16T00:00:00.000Z".to_string(),
+        );
+        assert!(matched.is_empty());
+        assert_eq!(retained, vec!["maintainers"]);
+        assert!(unknown.assignments.contains_key("maintainers"));
+
+        let evidence = AssignmentEvidence {
+            source: "github".to_string(),
+            verified: true,
+            github_orgs: Vec::new(),
+            github_teams: Vec::new(),
+        };
+        let (lost, matched, retained) = reconcile_assignment_state_at(
+            "user@example.com",
+            &rules,
+            Some(&evidence),
+            previous,
+            "2026-06-16T00:00:00.000Z".to_string(),
+        );
+        assert!(matched.is_empty());
+        assert!(retained.is_empty());
+        assert!(lost.assignments.is_empty());
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,6 +1,6 @@
 use clawrouter_core::{
-    parse_proxy_key, AuthScheme, CompiledEndpoint, CompiledProvider, GrantTransportConfig,
-    PathParamStyle, ProviderClass, ProviderSnapshot, UsageEvent, UsageStatus,
+    parse_proxy_key, AuthAuthorizationConfig, AuthScheme, CompiledEndpoint, CompiledProvider,
+    GrantTransportConfig, PathParamStyle, ProviderClass, ProviderSnapshot, UsageEvent, UsageStatus,
 };
 use futures_util::future::try_join_all;
 use hmac::{Hmac, Mac};
@@ -25,6 +25,7 @@ const BUDGET_RESERVATION_LEASE_MS: u64 = 15 * 60 * 1_000;
 const BUDGET_CHARGE_RETENTION_MS: u64 = 45 * 86_400_000;
 const BUDGET_CLEANUP_INTERVAL_MS: i64 = 86_400_000;
 const PROVIDER_HEALTH_MAX_AGE_MS: f64 = 86_400_000.0;
+const OAUTH_AUTHORIZATION_TTL_MS: u64 = 10 * 60 * 1_000;
 const UPSTREAM_GRANT_REFRESH_WINDOW_MS: f64 = 5.0 * 60.0 * 1_000.0;
 const USAGE_EVENT_LIMIT: usize = 100;
 const USAGE_EVENT_RETENTION_MS: u64 = 30 * 86_400_000;
@@ -146,6 +147,10 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return client_catalog(req.headers(), &env)
             .await
             .and_then(with_cors);
+    }
+
+    if req.method() == Method::Get && api_path == "/v1/oauth/callback" {
+        return oauth_authorization_callback(req, env).await;
     }
 
     if api_path.starts_with("/v1/admin/") {
@@ -300,6 +305,7 @@ fn service_index() -> Result<Response> {
             "adminCredentials": "/v1/admin/credentials",
             "adminConnections": "/v1/admin/connections",
             "adminUpstreamGrants": "/v1/admin/upstream-grants",
+            "oauthCallback": "/v1/oauth/callback",
             "adminAssignmentRules": "/v1/admin/assignment-rules",
             "apiAliases": {
                 "routes": ["/api/route", "/api/routes"],
@@ -1779,6 +1785,7 @@ struct AdminUpstreamGrantResponse {
     updated_at: Option<String>,
     revoked_at: Option<String>,
     has_credential: bool,
+    credential_fields: Vec<String>,
     has_access_token: bool,
     has_refresh_token: bool,
     refresh_configured: bool,
@@ -2167,6 +2174,36 @@ struct AccessControlCredentialListRow {
     credential_json: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OAuthAuthorizationState {
+    state: String,
+    verifier: String,
+    actor_email: String,
+    grant_key: String,
+    provider: String,
+    redirect_uri: String,
+    expires_at_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OAuthAuthorizationStateConsumeRequest {
+    state: String,
+    actor_email: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OAuthAuthorizationStateConsumeResponse {
+    state: Option<OAuthAuthorizationState>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthAuthorizationStateRow {
+    state_json: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum AccessAud {
@@ -2250,6 +2287,8 @@ struct UpstreamGrantRecord {
     label: Option<String>,
     #[serde(default)]
     credential: Option<String>,
+    #[serde(default)]
+    credentials: BTreeMap<String, String>,
     #[serde(default, alias = "access_token")]
     access_token: Option<String>,
     #[serde(default, alias = "refresh_token")]
@@ -2285,6 +2324,12 @@ struct OAuthRefreshResponse {
     expires_in: Option<u64>,
     #[serde(default)]
     scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OAuthAuthorizationStartRequest {
+    provider: String,
 }
 
 struct AuthorizedKey {
@@ -2838,6 +2883,41 @@ async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {
                 Err(HeaderBuildError::Runtime(error)) => return Err(error),
             };
             return Response::from_json(&admin_upstream_grant_response(&route.key, &grant)?);
+        }
+        if req.method() == Method::Post && route.action.as_deref() == Some("authorize") {
+            let Some(session) = verified_access_session(req.headers(), &env).await? else {
+                return json_error(
+                    "access_admin_required",
+                    "browser OAuth authorization requires a verified Cloudflare Access admin session",
+                    403,
+                );
+            };
+            if session.role != AccessRole::Admin {
+                return json_error(
+                    "access_admin_required",
+                    "browser OAuth authorization requires a verified Cloudflare Access admin session",
+                    403,
+                );
+            }
+            let request =
+                match serde_json::from_str::<OAuthAuthorizationStartRequest>(&req.text().await?) {
+                    Ok(request) => request,
+                    Err(_) => {
+                        return json_error(
+                            "invalid_oauth_authorization_request",
+                            "request body must identify a provider",
+                            400,
+                        );
+                    }
+                };
+            return start_oauth_authorization(
+                &env,
+                &url,
+                &route.key,
+                &session.email,
+                request.provider.trim(),
+            )
+            .await;
         }
         return json_error("method_not_allowed", "admin method is not allowed", 405);
     }
@@ -5118,6 +5198,35 @@ async fn list_access_control_credentials(
     })
 }
 
+async fn put_oauth_authorization_state(
+    namespace: &ObjectNamespace,
+    state: &OAuthAuthorizationState,
+) -> Result<()> {
+    access_control_request(namespace, "/oauth-states/put", state)
+        .await
+        .map(|_| ())
+}
+
+async fn consume_oauth_authorization_state(
+    namespace: &ObjectNamespace,
+    state: String,
+    actor_email: String,
+) -> Result<Option<OAuthAuthorizationState>> {
+    let body = access_control_request(
+        namespace,
+        "/oauth-states/consume",
+        &OAuthAuthorizationStateConsumeRequest { state, actor_email },
+    )
+    .await?;
+    serde_json::from_str::<OAuthAuthorizationStateConsumeResponse>(&body)
+        .map(|response| response.state)
+        .map_err(|error| {
+            Error::RustError(format!(
+                "OAuth authorization state response is invalid JSON: {error}"
+            ))
+        })
+}
+
 async fn resolve_access_control_connections(
     namespace: &ObjectNamespace,
     object_name: &str,
@@ -5414,7 +5523,7 @@ fn parse_admin_upstream_grant_route(
     let mut parts = rest.split('/').collect::<Vec<_>>();
     let action = if parts
         .last()
-        .is_some_and(|value| matches!(*value, "revoke" | "refresh"))
+        .is_some_and(|value| matches!(*value, "authorize" | "revoke" | "refresh"))
     {
         parts.pop().map(str::to_string)
     } else {
@@ -5449,6 +5558,283 @@ fn validate_upstream_grant_component(value: &str) -> std::result::Result<String,
         );
     }
     Ok(value.to_string())
+}
+
+async fn start_oauth_authorization(
+    env: &Env,
+    request_url: &Url,
+    grant_key: &str,
+    actor_email: &str,
+    provider_id: &str,
+) -> Result<Response> {
+    let snapshot = provider_snapshot()?;
+    let Some(provider) = snapshot
+        .providers
+        .iter()
+        .find(|provider| provider.id == provider_id)
+    else {
+        return json_error(
+            "unknown_provider",
+            "OAuth authorization provider is not registered",
+            404,
+        );
+    };
+    let Some(authorization) = provider.auth.authorization.as_ref() else {
+        return json_error(
+            "oauth_authorization_unsupported",
+            "provider does not declare a browser OAuth authorization flow",
+            409,
+        );
+    };
+    let client_id = oauth_authorization_client_id(env, authorization).map_err(|_| {
+        Error::RustError("OAuth authorization client configuration is missing".to_string())
+    })?;
+    let state_value = random_hex(32)?;
+    let verifier = random_hex(32)?;
+    let challenge = base64_url_encode(&Sha256::digest(verifier.as_bytes()));
+    let redirect_uri = format!("{}/v1/oauth/callback", request_origin(request_url));
+    let expires_at_ms = Date::now().as_millis() + OAUTH_AUTHORIZATION_TTL_MS;
+    let state = OAuthAuthorizationState {
+        state: state_value.clone(),
+        verifier,
+        actor_email: actor_email.to_string(),
+        grant_key: grant_key.to_string(),
+        provider: provider.id.clone(),
+        redirect_uri: redirect_uri.clone(),
+        expires_at_ms,
+    };
+    put_oauth_authorization_state(&access_control_namespace(env)?, &state).await?;
+
+    let mut authorization_url = Url::parse(&authorization.authorize_url).map_err(|error| {
+        Error::RustError(format!("OAuth authorization URL is invalid: {error}"))
+    })?;
+    {
+        let mut query = authorization_url.query_pairs_mut();
+        for (name, value) in &authorization.extra_authorize_params {
+            query.append_pair(name, value);
+        }
+        query.append_pair("response_type", "code");
+        query.append_pair("client_id", &client_id);
+        query.append_pair("redirect_uri", &redirect_uri);
+        query.append_pair("scope", &authorization.scopes.join(" "));
+        query.append_pair("code_challenge", &challenge);
+        query.append_pair("code_challenge_method", "S256");
+        query.append_pair("state", &state_value);
+    }
+    Response::from_json(&serde_json::json!({
+        "authorizationUrl": authorization_url.as_str(),
+        "expiresAt": timestamp_from_epoch_ms(expires_at_ms),
+        "provider": provider.id,
+    }))
+}
+
+async fn oauth_authorization_callback(req: Request, env: Env) -> Result<Response> {
+    let url = req.url()?;
+    let Some(session) = verified_access_session(req.headers(), &env).await? else {
+        return json_error(
+            "access_admin_required",
+            "OAuth callback requires the initiating Cloudflare Access admin session",
+            403,
+        );
+    };
+    if session.role != AccessRole::Admin {
+        return json_error(
+            "access_admin_required",
+            "OAuth callback requires the initiating Cloudflare Access admin session",
+            403,
+        );
+    }
+    let Some(state_value) = query_param(&url, "state").filter(|value| !value.is_empty()) else {
+        return json_error(
+            "invalid_oauth_callback",
+            "OAuth callback state is missing",
+            400,
+        );
+    };
+    let Some(state) = consume_oauth_authorization_state(
+        &access_control_namespace(&env)?,
+        state_value,
+        session.email,
+    )
+    .await?
+    else {
+        return json_error(
+            "invalid_oauth_callback",
+            "OAuth callback state is invalid, expired, or already used",
+            400,
+        );
+    };
+    if query_param(&url, "error").is_some() {
+        return oauth_authorization_result_redirect("failed", &state.provider);
+    }
+    let Some(code) = query_param(&url, "code").filter(|value| !value.is_empty()) else {
+        return json_error(
+            "invalid_oauth_callback",
+            "OAuth callback authorization code is missing",
+            400,
+        );
+    };
+    complete_oauth_authorization(&env, state.clone(), &code).await?;
+    oauth_authorization_result_redirect("connected", &state.provider)
+}
+
+async fn complete_oauth_authorization(
+    env: &Env,
+    state: OAuthAuthorizationState,
+    code: &str,
+) -> Result<()> {
+    let snapshot = provider_snapshot()?;
+    let provider = snapshot
+        .providers
+        .iter()
+        .find(|provider| provider.id == state.provider)
+        .ok_or_else(|| Error::RustError("OAuth authorization provider is not registered".into()))?;
+    let authorization = provider.auth.authorization.as_ref().ok_or_else(|| {
+        Error::RustError("provider does not declare a browser OAuth authorization flow".into())
+    })?;
+    let client_id = oauth_authorization_client_id(env, authorization)?;
+    let client_secret = authorization
+        .client_secret_config
+        .as_deref()
+        .map(|name| exact_runtime_config_value(env, name))
+        .transpose()?;
+    let mut form = authorization.extra_token_params.clone();
+    form.insert("grant_type".to_string(), "authorization_code".to_string());
+    form.insert("client_id".to_string(), client_id);
+    form.insert("code".to_string(), code.to_string());
+    form.insert("code_verifier".to_string(), state.verifier);
+    form.insert("redirect_uri".to_string(), state.redirect_uri);
+    if let Some(client_secret) = client_secret {
+        form.insert("client_secret".to_string(), client_secret);
+    }
+
+    let headers = Headers::new();
+    headers.set("accept", "application/json")?;
+    headers.set("content-type", "application/x-www-form-urlencoded")?;
+    let mut init = RequestInit::new();
+    init.with_method(Method::Post)
+        .with_headers(headers)
+        .with_body(Some(JsValue::from_str(&form_urlencoded(&form))));
+    let request = Request::new_with_init(&authorization.token_url, &init)?;
+    let mut response = Fetch::Request(request).send().await.map_err(|_| {
+        Error::RustError("upstream OAuth authorization exchange request failed".to_string())
+    })?;
+    if !(200..=299).contains(&response.status_code()) {
+        return Err(Error::RustError(
+            "upstream OAuth authorization exchange was rejected".to_string(),
+        ));
+    }
+    let token = response.json::<OAuthRefreshResponse>().await.map_err(|_| {
+        Error::RustError("upstream OAuth authorization response was invalid".to_string())
+    })?;
+    if token.access_token.trim().is_empty() {
+        return Err(Error::RustError(
+            "upstream OAuth authorization response was invalid".to_string(),
+        ));
+    }
+    let kind = match authorization.grant_kind.as_str() {
+        "oauth" => UpstreamGrantKind::OAuth,
+        "subscription" => UpstreamGrantKind::Subscription,
+        _ => {
+            return Err(Error::RustError(
+                "provider OAuth authorization grant kind is invalid".to_string(),
+            ));
+        }
+    };
+    let account_id = authorization
+        .account_id_json_pointer
+        .as_deref()
+        .and_then(|pointer| jwt_json_pointer_string(&token.access_token, pointer));
+    let plan = authorization
+        .subscription_plan_json_pointer
+        .as_deref()
+        .and_then(|pointer| jwt_json_pointer_string(&token.access_token, pointer));
+    let scopes = token
+        .scope
+        .as_deref()
+        .map(|scope| {
+            scope
+                .split_ascii_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| authorization.scopes.clone());
+    let kv = env.kv("POLICY_KV").map_err(|error| {
+        Error::RustError(format!(
+            "POLICY_KV binding is required for OAuth authorization: {error}"
+        ))
+    })?;
+    let existing = get_upstream_grant(&kv, &state.grant_key).await?;
+    let grant = UpstreamGrantRecord {
+        version: default_upstream_grant_version(),
+        enabled: true,
+        kind,
+        provider: Some(provider.id.clone()),
+        label: existing.as_ref().and_then(|grant| grant.label.clone()),
+        credential: None,
+        credentials: BTreeMap::new(),
+        access_token: Some(token.access_token),
+        refresh_token: token.refresh_token,
+        token_type: token
+            .token_type
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(default_oauth_token_type),
+        expires_at: token.expires_in.map(timestamp_after_seconds),
+        scopes,
+        account_id,
+        subscription: (kind == UpstreamGrantKind::Subscription).then_some(
+            UpstreamGrantSubscription {
+                plan,
+                subject: None,
+            },
+        ),
+        refresh: upstream_grant_refresh_from_manifest(provider),
+        created_at: None,
+        updated_at: None,
+        revoked_at: None,
+    };
+    let grant = normalize_upstream_grant(grant, existing.as_ref()).map_err(Error::RustError)?;
+    put_kv_record(&kv, &state.grant_key, &grant, "authorized upstream grant").await
+}
+
+fn oauth_authorization_client_id(
+    env: &Env,
+    authorization: &AuthAuthorizationConfig,
+) -> Result<String> {
+    if let Some(client_id) = authorization
+        .client_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(client_id.to_string());
+    }
+    exact_runtime_config_value(
+        env,
+        authorization
+            .client_id_config
+            .as_deref()
+            .ok_or_else(|| Error::RustError("OAuth authorization client ID is missing".into()))?,
+    )
+}
+
+fn oauth_authorization_result_redirect(status: &str, provider: &str) -> Result<Response> {
+    redirect_to(&format!(
+        "/dashboard/access?tab=upstream&oauth={}&provider={}",
+        encode_component(status),
+        encode_component(provider)
+    ))
+}
+
+fn jwt_json_pointer_string(token: &str, pointer: &str) -> Option<String> {
+    let (_, payload, _) = split_jwt(token)?;
+    let payload = base64_url_decode(payload).ok()?;
+    let value = serde_json::from_slice::<Value>(&payload).ok()?;
+    value
+        .pointer(pointer)?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 async fn list_admin_upstream_grants(kv: &KvStore) -> Result<Vec<AdminUpstreamGrantResponse>> {
@@ -5549,6 +5935,7 @@ fn normalize_upstream_grant(
         }
     }
     merge_upstream_grant_secrets(&mut grant, existing);
+    grant.credentials = normalize_grant_credentials(grant.credentials)?;
     validate_upstream_grant_secret_shape(&grant)?;
     if grant.refresh.is_none() && grant.refresh_token.is_some() {
         grant.refresh = provider
@@ -5564,9 +5951,11 @@ fn normalize_upstream_grant(
             return Err("provider manifest does not approve refresh configuration".to_string());
         }
     }
-    if grant.enabled && upstream_grant_secret(&grant).is_none() {
+    if grant.enabled && !upstream_grant_has_primary_secret(&grant) {
         return Err(match grant.kind {
-            UpstreamGrantKind::ApiKey => "enabled API-key grant requires credential".to_string(),
+            UpstreamGrantKind::ApiKey => {
+                "enabled API-key grant requires credential or credentials".to_string()
+            }
             UpstreamGrantKind::OAuth | UpstreamGrantKind::Subscription => {
                 "enabled OAuth or subscription grant requires accessToken".to_string()
             }
@@ -5593,13 +5982,12 @@ fn validate_upstream_grant_secret_shape(
         UpstreamGrantKind::ApiKey => {
             if grant.access_token.is_some() || grant.refresh_token.is_some() {
                 return Err(
-                    "API-key grants accept credential only; revoke before changing grant kind"
-                        .to_string(),
+                    "API-key grants accept credential or credentials only; revoke before changing grant kind".to_string(),
                 );
             }
         }
         UpstreamGrantKind::OAuth => {
-            if grant.credential.is_some() {
+            if grant.credential.is_some() || !grant.credentials.is_empty() {
                 return Err(
                     "OAuth grants accept accessToken only; revoke before changing grant kind"
                         .to_string(),
@@ -5607,12 +5995,36 @@ fn validate_upstream_grant_secret_shape(
             }
         }
         UpstreamGrantKind::Subscription => {
-            if grant.credential.is_some() && grant.access_token.is_some() {
+            if !grant.credentials.is_empty()
+                || grant.credential.is_some() && grant.access_token.is_some()
+            {
                 return Err("subscription grants accept exactly one primary credential".to_string());
             }
         }
     }
     Ok(())
+}
+
+fn normalize_grant_credentials(
+    credentials: BTreeMap<String, String>,
+) -> std::result::Result<BTreeMap<String, String>, String> {
+    let mut normalized = BTreeMap::new();
+    for (name, value) in credentials {
+        let name = name.trim();
+        if name.is_empty()
+            || name.len() > 128
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+        {
+            return Err("credentials contains an invalid field name".to_string());
+        }
+        if value.is_empty() || value.len() > 16_384 || value.bytes().any(|byte| byte == 0) {
+            return Err("credentials contains an invalid secret value".to_string());
+        }
+        normalized.insert(name.to_string(), value);
+    }
+    Ok(normalized)
 }
 
 fn normalize_grant_optional_text(
@@ -5714,6 +6126,9 @@ fn merge_upstream_grant_secrets(
     if grant.credential.is_none() {
         grant.credential.clone_from(&existing.credential);
     }
+    if grant.credentials.is_empty() {
+        grant.credentials.clone_from(&existing.credentials);
+    }
     if grant.access_token.is_none() {
         grant.access_token.clone_from(&existing.access_token);
     }
@@ -5726,6 +6141,7 @@ fn revoke_upstream_grant(grant: &mut UpstreamGrantRecord) {
     let now = current_iso_timestamp();
     grant.enabled = false;
     grant.credential = None;
+    grant.credentials.clear();
     grant.access_token = None;
     grant.refresh_token = None;
     grant.updated_at = Some(now.clone());
@@ -5763,6 +6179,7 @@ fn admin_upstream_grant_response(
             .credential
             .as_deref()
             .is_some_and(|value| !value.trim().is_empty()),
+        credential_fields: grant.credentials.keys().cloned().collect(),
         has_access_token: grant
             .access_token
             .as_deref()
@@ -5828,6 +6245,10 @@ fn upstream_grant_secret(grant: &UpstreamGrantRecord) -> Option<&str> {
     preferred.filter(|value| !value.trim().is_empty())
 }
 
+fn upstream_grant_has_primary_secret(grant: &UpstreamGrantRecord) -> bool {
+    upstream_grant_secret(grant).is_some() || !grant.credentials.is_empty()
+}
+
 fn upstream_grant_expired(grant: &UpstreamGrantRecord) -> bool {
     grant
         .expires_at
@@ -5860,8 +6281,32 @@ fn upstream_grant_refreshable(grant: &UpstreamGrantRecord) -> bool {
 
 fn upstream_grant_usable(grant: &UpstreamGrantRecord) -> bool {
     grant.enabled
-        && upstream_grant_secret(grant).is_some()
+        && upstream_grant_has_primary_secret(grant)
         && (!upstream_grant_expired(grant) || upstream_grant_refreshable(grant))
+}
+
+fn upstream_grant_credential_field<'a>(
+    grant: &'a UpstreamGrantRecord,
+    field: &str,
+) -> Option<&'a str> {
+    grant
+        .credentials
+        .get(field)
+        .map(String::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+fn upstream_grant_supports_provider(
+    provider: &CompiledProvider,
+    grant: &UpstreamGrantRecord,
+) -> bool {
+    match provider.auth.schemes.first() {
+        Some(AuthScheme::SigV4 { .. }) => {
+            upstream_grant_credential_field(grant, "accessKeyId").is_some()
+                && upstream_grant_credential_field(grant, "secretAccessKey").is_some()
+        }
+        _ => true,
+    }
 }
 
 fn provider_readiness_rows(
@@ -7076,6 +7521,34 @@ fn base64_url_decode(value: &str) -> Result<Vec<u8>> {
         }
     }
     Ok(out)
+}
+
+fn base64_url_encode(value: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut output = String::with_capacity(value.len().div_ceil(3) * 4);
+    for chunk in value.chunks(3) {
+        let a = chunk[0] as u32;
+        let b = chunk.get(1).copied().unwrap_or_default() as u32;
+        let c = chunk.get(2).copied().unwrap_or_default() as u32;
+        let bits = (a << 16) | (b << 8) | c;
+        output.push(ALPHABET[((bits >> 18) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((bits >> 12) & 0x3f) as usize] as char);
+        if chunk.len() > 1 {
+            output.push(ALPHABET[((bits >> 6) & 0x3f) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            output.push(ALPHABET[(bits & 0x3f) as usize] as char);
+        }
+    }
+    output
+}
+
+fn random_hex(length: u32) -> Result<String> {
+    let crypto = Reflect::get(&js_sys::global(), &JsValue::from_str("crypto")).map_err(js_error)?;
+    let get_random_values = js_function(&crypto, "getRandomValues")?;
+    let bytes = Uint8Array::new_with_length(length);
+    get_random_values.call1(&crypto, &bytes).map_err(js_error)?;
+    Ok(bytes_to_hex(&bytes.to_vec()))
 }
 
 fn default_true() -> bool {
@@ -8481,8 +8954,15 @@ fn apply_auth_headers(
             service,
             region_param,
         } => {
-            let signed = sigv4_headers(env, provider, service, region_param.as_deref(), context)
-                .map_err(HeaderBuildError::Runtime)?;
+            let signed = sigv4_headers(
+                env,
+                provider,
+                grant,
+                service,
+                region_param.as_deref(),
+                context,
+            )
+            .map_err(HeaderBuildError::Runtime)?;
             for (name, value) in signed {
                 headers
                     .set(&name, &value)
@@ -8515,7 +8995,10 @@ async fn upstream_grant_for_request(
             .await
         }
         Some(
-            AuthScheme::Bearer { .. } | AuthScheme::ApiKey { .. } | AuthScheme::QueryApiKey { .. },
+            AuthScheme::Bearer { .. }
+            | AuthScheme::ApiKey { .. }
+            | AuthScheme::QueryApiKey { .. }
+            | AuthScheme::SigV4 { .. },
         ) => selected_upstream_grant(env, provider, auth, None, None, false).await,
         _ => Ok(None),
     }
@@ -8571,7 +9054,7 @@ async fn selected_upstream_grant(
         if upstream_grant_needs_refresh(&grant) {
             grant = refresh_upstream_grant(env, &kv, &key, grant, false).await?;
         }
-        if !upstream_grant_usable(&grant) {
+        if !upstream_grant_usable(&grant) || !upstream_grant_supports_provider(provider, &grant) {
             return Err(HeaderBuildError::Client {
                 code: "upstream_grant_invalid",
                 message: "upstream grant is missing a usable credential",
@@ -8843,6 +9326,11 @@ fn timestamp_after_seconds(seconds: u64) -> String {
     date.to_iso_string().into()
 }
 
+fn timestamp_from_epoch_ms(epoch_ms: u64) -> String {
+    let date = js_sys::Date::new(&JsValue::from_f64(epoch_ms as f64));
+    date.to_iso_string().into()
+}
+
 fn parse_upstream_grant_record(raw: &str) -> Result<UpstreamGrantRecord> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -8856,6 +9344,7 @@ fn parse_upstream_grant_record(raw: &str) -> Result<UpstreamGrantRecord> {
             provider: None,
             label: None,
             credential: None,
+            credentials: BTreeMap::new(),
             access_token: Some(trimmed.to_string()),
             refresh_token: None,
             token_type: default_oauth_token_type(),
@@ -8920,14 +9409,26 @@ fn dedupe_preserving_order(values: &mut Vec<String>) {
 fn sigv4_headers(
     env: &Env,
     provider: &CompiledProvider,
+    grant: Option<&UpstreamGrantRecord>,
     service: &str,
     region_param: Option<&str>,
     context: HeaderRequestContext<'_>,
 ) -> Result<BTreeMap<String, String>> {
-    let access_key_id = provider_config_value(env, provider, "access_key_id")?;
-    let secret_access_key = provider_config_value(env, provider, "secret_access_key")?;
+    let access_key_id = grant
+        .and_then(|grant| upstream_grant_credential_field(grant, "accessKeyId"))
+        .map(str::to_string)
+        .map(Ok)
+        .unwrap_or_else(|| provider_config_value(env, provider, "access_key_id"))?;
+    let secret_access_key = grant
+        .and_then(|grant| upstream_grant_credential_field(grant, "secretAccessKey"))
+        .map(str::to_string)
+        .map(Ok)
+        .unwrap_or_else(|| provider_config_value(env, provider, "secret_access_key"))?;
     let region = provider_config_value(env, provider, region_param.unwrap_or("region"))?;
-    let session_token = optional_provider_config_value(env, provider, "session_token");
+    let session_token = grant
+        .and_then(|grant| upstream_grant_credential_field(grant, "sessionToken"))
+        .map(str::to_string)
+        .or_else(|| optional_provider_config_value(env, provider, "session_token"));
     sigv4_headers_at(
         &access_key_id,
         &secret_access_key,
@@ -9422,6 +9923,28 @@ impl DurableObject for PolicyBindingIndexObject {
             put_access_control_connection_in_object(&self.state, connection)?;
             return Response::ok("updated");
         }
+        if req.method() == Method::Post && url.path() == "/oauth-states/put" {
+            let state = serde_json::from_str::<OAuthAuthorizationState>(&req.text().await?)
+                .map_err(|error| {
+                    Error::RustError(format!(
+                        "OAuth authorization state put request is invalid JSON: {error}"
+                    ))
+                })?;
+            put_oauth_authorization_state_in_object(&self.state, state)?;
+            return Response::ok("updated");
+        }
+        if req.method() == Method::Post && url.path() == "/oauth-states/consume" {
+            let request =
+                serde_json::from_str::<OAuthAuthorizationStateConsumeRequest>(&req.text().await?)
+                    .map_err(|error| {
+                    Error::RustError(format!(
+                        "OAuth authorization state consume request is invalid JSON: {error}"
+                    ))
+                })?;
+            return Response::from_json(&OAuthAuthorizationStateConsumeResponse {
+                state: consume_oauth_authorization_state_in_object(&self.state, request)?,
+            });
+        }
         json_error("route_not_found", "route not found", 404)
     }
 }
@@ -9583,6 +10106,14 @@ fn ensure_access_control_schema(sql: &SqlStorage) -> Result<()> {
         "CREATE TABLE IF NOT EXISTS provider_connections (
             provider_id TEXT PRIMARY KEY,
             connection_json TEXT NOT NULL
+        )",
+        None,
+    )?;
+    sql.exec(
+        "CREATE TABLE IF NOT EXISTS oauth_authorization_states (
+            state TEXT PRIMARY KEY,
+            state_json TEXT NOT NULL,
+            expires_at_ms INTEGER NOT NULL
         )",
         None,
     )?;
@@ -10317,6 +10848,76 @@ fn resolve_access_control_connections_in_object(
         connections,
         missing_provider_ids,
     })
+}
+
+fn put_oauth_authorization_state_in_object(
+    state: &State,
+    authorization: OAuthAuthorizationState,
+) -> Result<()> {
+    if authorization.state.len() < 32
+        || authorization.verifier.len() < 43
+        || authorization.actor_email.is_empty()
+        || authorization.grant_key.is_empty()
+        || authorization.provider.is_empty()
+        || authorization.redirect_uri.is_empty()
+        || authorization.expires_at_ms <= Date::now().as_millis()
+    {
+        return Err(Error::RustError(
+            "OAuth authorization state is invalid".to_string(),
+        ));
+    }
+    let sql = state.storage().sql();
+    ensure_access_control_schema(&sql)?;
+    sql.exec_raw(
+        "DELETE FROM oauth_authorization_states WHERE expires_at_ms <= ?",
+        raw_bindings(vec![JsValue::from_f64(Date::now().as_millis() as f64)]),
+    )?;
+    sql.exec_raw(
+        "INSERT OR REPLACE INTO oauth_authorization_states
+            (state, state_json, expires_at_ms) VALUES (?, ?, ?)",
+        raw_bindings(vec![
+            JsValue::from_str(&authorization.state),
+            JsValue::from_str(&serde_json::to_string(&authorization)?),
+            JsValue::from_f64(authorization.expires_at_ms as f64),
+        ]),
+    )?;
+    Ok(())
+}
+
+fn consume_oauth_authorization_state_in_object(
+    state: &State,
+    request: OAuthAuthorizationStateConsumeRequest,
+) -> Result<Option<OAuthAuthorizationState>> {
+    let sql = state.storage().sql();
+    ensure_access_control_schema(&sql)?;
+    let Some(row) = sql
+        .exec_raw(
+            "SELECT state_json FROM oauth_authorization_states WHERE state = ? LIMIT 1",
+            raw_bindings(vec![JsValue::from_str(&request.state)]),
+        )?
+        .to_array::<OAuthAuthorizationStateRow>()?
+        .into_iter()
+        .next()
+    else {
+        return Ok(None);
+    };
+    let authorization =
+        serde_json::from_str::<OAuthAuthorizationState>(&row.state_json).map_err(|error| {
+            Error::RustError(format!(
+                "stored OAuth authorization state is invalid JSON: {error}"
+            ))
+        })?;
+    if authorization.actor_email != request.actor_email {
+        return Ok(None);
+    }
+    sql.exec_raw(
+        "DELETE FROM oauth_authorization_states WHERE state = ?",
+        raw_bindings(vec![JsValue::from_str(&request.state)]),
+    )?;
+    if authorization.expires_at_ms <= Date::now().as_millis() {
+        return Ok(None);
+    }
+    Ok(Some(authorization))
 }
 
 async fn persist_usage_event(namespace: &ObjectNamespace, event: &UsageEvent) -> Result<()> {
@@ -11758,6 +12359,7 @@ mod tests {
             provider: Some(provider.to_string()),
             label: Some("maintainer subscription".to_string()),
             credential: None,
+            credentials: BTreeMap::new(),
             access_token: Some("test-access-token".to_string()),
             refresh_token: Some("test-refresh-token".to_string()),
             token_type: "Bearer".to_string(),
@@ -13727,6 +14329,98 @@ mod tests {
             resolve_grant_template("${grant.accountId}", &grant).unwrap(),
             "acct_test"
         );
+    }
+
+    #[test]
+    fn openai_manifest_declares_browser_oauth_with_account_metadata() {
+        let snapshot = provider_snapshot().unwrap();
+        let authorization = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "openai")
+            .unwrap()
+            .auth
+            .authorization
+            .as_ref()
+            .unwrap();
+
+        assert_eq!(
+            authorization.authorize_url,
+            "https://auth.openai.com/oauth/authorize"
+        );
+        assert_eq!(authorization.grant_kind, "subscription");
+        assert_eq!(
+            authorization.account_id_json_pointer.as_deref(),
+            Some("/https:~1~1api.openai.com~1auth/chatgpt_account_id")
+        );
+    }
+
+    #[test]
+    fn oauth_callback_metadata_uses_manifest_json_pointers() {
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_test",
+                "chatgpt_plan_type": "plus"
+            }
+        });
+        let token = format!(
+            "{}.{}.{}",
+            base64_url_encode(br#"{"alg":"none"}"#),
+            base64_url_encode(serde_json::to_string(&payload).unwrap().as_bytes()),
+            base64_url_encode(b"signature")
+        );
+
+        assert_eq!(
+            jwt_json_pointer_string(&token, "/https:~1~1api.openai.com~1auth/chatgpt_account_id")
+                .as_deref(),
+            Some("acct_test")
+        );
+        assert_eq!(
+            jwt_json_pointer_string(&token, "/https:~1~1api.openai.com~1auth/chatgpt_plan_type")
+                .as_deref(),
+            Some("plus")
+        );
+    }
+
+    #[test]
+    fn upstream_grant_routes_accept_browser_authorization_action() {
+        let route = parse_admin_upstream_grant_route("policies/svc_docs/openai/authorize").unwrap();
+        assert_eq!(route.key, "oauth/svc_docs/openai");
+        assert_eq!(route.action.as_deref(), Some("authorize"));
+    }
+
+    #[test]
+    fn sigv4_grants_require_and_hide_multi_field_credentials() {
+        let snapshot = provider_snapshot().unwrap();
+        let provider = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "aws-bedrock")
+            .unwrap();
+        let mut grant = subscription_test_grant("aws-bedrock");
+        grant.kind = UpstreamGrantKind::ApiKey;
+        grant.credential = None;
+        grant.access_token = None;
+        grant.refresh_token = None;
+        grant.subscription = None;
+        grant.credentials = BTreeMap::from([
+            ("accessKeyId".to_string(), "AKID_PLACEHOLDER".to_string()),
+            (
+                "secretAccessKey".to_string(),
+                "secret-placeholder".to_string(),
+            ),
+        ]);
+
+        assert!(upstream_grant_usable(&grant));
+        assert!(upstream_grant_supports_provider(provider, &grant));
+        let response = admin_upstream_grant_response("oauth/svc_docs/aws-bedrock", &grant).unwrap();
+        let raw = serde_json::to_string(&response).unwrap();
+        assert_eq!(
+            response.credential_fields,
+            vec!["accessKeyId".to_string(), "secretAccessKey".to_string()]
+        );
+        assert!(!raw.contains("AKID_PLACEHOLDER"));
+        assert!(!raw.contains("secret-placeholder"));
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -3583,42 +3583,47 @@ async fn access_control_user_record(
 ) -> Result<AccessUserRecord> {
     let namespace = access_control_namespace(env)?;
     let mut response = resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
-    if let Some(user) = response.users.pop() {
-        return Ok(user.record);
-    }
     let kv = env.kv("POLICY_KV").map_err(|error| {
         Error::RustError(format!(
             "POLICY_KV binding is required before initializing an access user: {error}"
         ))
     })?;
-    let record = existing_access_user_record(&kv, email)
-        .await?
-        .unwrap_or_else(|| default_access_user_record(default_tenant));
-    let user = AccessControlUser {
-        email: email.to_string(),
-        record,
+    let record = if let Some(user) = response.users.pop() {
+        user.record
+    } else {
+        let record = existing_access_user_record(&kv, email)
+            .await?
+            .unwrap_or_else(|| default_access_user_record(default_tenant));
+        let user = AccessControlUser {
+            email: email.to_string(),
+            record,
+        };
+        initialize_access_control_users(&namespace, std::slice::from_ref(&user)).await?;
+        let mut response =
+            resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
+        let user = response.users.pop().ok_or_else(|| {
+            Error::RustError(
+                "access user authority did not initialize the requested user".to_string(),
+            )
+        })?;
+        sync_kv_record_best_effort(
+            &kv,
+            &format!("access/users/{email}"),
+            &user.record,
+            "access user compatibility record",
+        )
+        .await;
+        user.record
     };
-    initialize_access_control_users(&namespace, std::slice::from_ref(&user)).await?;
-    let mut response = resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
-    let user = response.users.pop().ok_or_else(|| {
-        Error::RustError("access user authority did not initialize the requested user".to_string())
-    })?;
-    sync_kv_record_best_effort(
-        &kv,
-        &format!("access/users/{email}"),
-        &user.record,
-        "access user compatibility record",
-    )
-    .await;
-    match reconcile_access_user_assignments(env, &kv, email, user.record.clone(), None).await {
+    match reconcile_access_user_assignments(env, &kv, email, record.clone(), None).await {
         Ok((record, _)) => Ok(record),
         Err(error) => {
             console_error!(
-                "first-login assignment reconciliation failed closed for {}: {}",
+                "login assignment reconciliation failed for {}: {}",
                 email,
                 error
             );
-            Ok(user.record)
+            Ok(record)
         }
     }
 }
@@ -8731,6 +8736,23 @@ fn sanitize_native_response(response: Response, endpoint: &CompiledEndpoint) -> 
 
 fn native_response_header_allowed(endpoint: &CompiledEndpoint, name: &str) -> bool {
     let name = name.to_ascii_lowercase();
+    if matches!(
+        name.as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "proxy-connection"
+            | "set-cookie"
+            | "set-cookie2"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    ) || name.starts_with("cf-")
+    {
+        return false;
+    }
     matches!(
         name.as_str(),
         "accept-ranges"
@@ -14839,6 +14861,26 @@ mod tests {
             "x-ratelimit-limit"
         ));
         assert!(!native_response_header_allowed(endpoint, "set-cookie"));
+        let mut manifest_allowed = endpoint.clone();
+        manifest_allowed.response_headers.extend([
+            "connection".to_string(),
+            "cf-ray".to_string(),
+            "set-cookie".to_string(),
+            "x-provider-trace".to_string(),
+        ]);
+        assert!(!native_response_header_allowed(
+            &manifest_allowed,
+            "connection"
+        ));
+        assert!(!native_response_header_allowed(&manifest_allowed, "cf-ray"));
+        assert!(!native_response_header_allowed(
+            &manifest_allowed,
+            "set-cookie"
+        ));
+        assert!(native_response_header_allowed(
+            &manifest_allowed,
+            "x-provider-trace"
+        ));
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -137,6 +137,16 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return user_usage(req.headers(), &env).await.and_then(with_cors);
     }
 
+    if req.method() == Method::Get && api_path == "/v1/models" {
+        return client_models(req.headers(), &env).await.and_then(with_cors);
+    }
+
+    if req.method() == Method::Get && api_path == "/v1/catalog" {
+        return client_catalog(req.headers(), &env)
+            .await
+            .and_then(with_cors);
+    }
+
     if api_path.starts_with("/v1/admin/") {
         return admin_api(req, env, &api_path).await.and_then(with_cors);
     }
@@ -276,6 +286,8 @@ fn service_index() -> Result<Response> {
             "entitlements": "/v1/entitlements",
             "me": "/v1/me",
             "usage": "/v1/usage",
+            "models": "/v1/models",
+            "catalog": "/v1/catalog",
             "keyInspect": "/v1/key/inspect",
             "adminOverview": "/v1/admin/overview",
             "adminUsers": "/v1/admin/users",
@@ -1983,8 +1995,35 @@ async fn access_entitlement_rows_for_session(
             ));
         }
     };
-    let snapshot = provider_snapshot()?;
     let entries = list_session_policy_entries(&kv, env, session).await?;
+    entitlement_rows_for_entries(&entries, env, &kv).await
+}
+
+async fn entitlement_rows_for_policy(
+    policy_id: &str,
+    policy: &AccessPolicy,
+    env: &Env,
+) -> Result<Vec<EntitlementProviderRow>> {
+    let kv = env.kv("POLICY_KV").map_err(|_| {
+        Error::RustError("POLICY_KV binding is required for client discovery".to_string())
+    })?;
+    entitlement_rows_for_entries(
+        &[AccessPolicyEntry {
+            policy_id: policy_id.to_string(),
+            policy: policy.clone(),
+        }],
+        env,
+        &kv,
+    )
+    .await
+}
+
+async fn entitlement_rows_for_entries(
+    entries: &[AccessPolicyEntry],
+    env: &Env,
+    kv: &KvStore,
+) -> Result<Vec<EntitlementProviderRow>> {
+    let snapshot = provider_snapshot()?;
     let grants = list_oauth_grants(&kv).await?;
     let connections = list_provider_connections(env, &kv, &snapshot).await?;
     let health = list_provider_health(&kv).await?;
@@ -2018,6 +2057,170 @@ async fn access_entitlement_rows_for_session(
             }
         })
         .collect())
+}
+
+async fn client_entitlement_rows(
+    headers: &Headers,
+    env: &Env,
+) -> std::result::Result<Vec<EntitlementProviderRow>, Response> {
+    if proxy_key_header_present(headers).map_err(internal_error_response)? {
+        let auth = match authorize_proxy_key_identity(headers, env)
+            .await
+            .map_err(internal_error_response)?
+        {
+            AuthOutcome::Allowed(auth) => auth,
+            AuthOutcome::Denied(response) => return Err(response),
+        };
+        return entitlement_rows_for_policy(&auth.policy_id, &auth.policy, env)
+            .await
+            .map_err(internal_error_response);
+    }
+    let session = verified_access_session(headers, env)
+        .await
+        .map_err(internal_error_response)?
+        .ok_or_else(|| {
+            json_error(
+                "client_auth_required",
+                "a valid ClawRouter proxy key or Cloudflare Access session is required",
+                401,
+            )
+            .unwrap_or_else(|_| Response::error("client authentication required", 401).unwrap())
+        })?;
+    access_entitlement_rows_for_session(&session, env)
+        .await
+        .map_err(internal_error_response)
+}
+
+async fn client_models(headers: &Headers, env: &Env) -> Result<Response> {
+    let rows = match client_entitlement_rows(headers, env).await {
+        Ok(rows) => rows,
+        Err(response) => return Ok(response),
+    };
+    let snapshot = provider_snapshot()?;
+    private_json_response(&client_models_value(&snapshot, &rows))
+}
+
+fn client_models_value(snapshot: &ProviderSnapshot, rows: &[EntitlementProviderRow]) -> Value {
+    let allowed = rows
+        .iter()
+        .filter(|row| row.allowed && row.readiness.executable)
+        .map(|row| row.provider.as_str())
+        .collect::<BTreeSet<_>>();
+    let data = snapshot
+        .providers
+        .iter()
+        .filter(|provider| allowed.contains(provider.id.as_str()))
+        .flat_map(|provider| {
+            provider.models.iter().map(|model| {
+                serde_json::json!({
+                    "id": model.id,
+                    "object": "model",
+                    "owned_by": provider.id,
+                    "capabilities": model.capabilities
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "object": "list",
+        "data": data
+    })
+}
+
+async fn client_catalog(headers: &Headers, env: &Env) -> Result<Response> {
+    let rows = match client_entitlement_rows(headers, env).await {
+        Ok(rows) => rows,
+        Err(response) => return Ok(response),
+    };
+    let snapshot = provider_snapshot()?;
+    private_json_response(&client_catalog_value(&snapshot, rows))
+}
+
+fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProviderRow>) -> Value {
+    let providers = rows
+        .into_iter()
+        .filter(|row| row.allowed)
+        .filter_map(|row| {
+            let provider = snapshot
+                .providers
+                .iter()
+                .find(|provider| provider.id == row.provider)?;
+            Some(serde_json::json!({
+                "id": provider.id,
+                "displayName": provider.display_name,
+                "allowed": true,
+                "executable": row.readiness.executable,
+                "nativeBaseUrl": format!("/v1/native/{}", provider.id),
+                "policies": row.policies,
+                "readiness": row.readiness,
+                "connectionTypes": provider_connection_types(provider),
+                "routes": provider.endpoints.iter().filter(|endpoint| endpoint.native_proxy).map(|endpoint| {
+                    serde_json::json!({
+                        "endpoint": endpoint.id,
+                        "methods": endpoint.methods,
+                        "path": endpoint.path,
+                        "streaming": endpoint.streaming
+                    })
+                }).collect::<Vec<_>>(),
+                "models": provider.models
+            }))
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "version": "clawrouter.client-catalog.v1",
+        "providers": providers
+    })
+}
+
+fn provider_connection_types(provider: &CompiledProvider) -> Vec<&'static str> {
+    let mut types = BTreeSet::new();
+    for scheme in &provider.auth.schemes {
+        match scheme {
+            AuthScheme::OAuth { .. } => {
+                types.insert("oauth");
+                types.insert("subscription");
+            }
+            AuthScheme::Bearer { .. }
+            | AuthScheme::ApiKey { .. }
+            | AuthScheme::QueryApiKey { .. } => {
+                types.insert("api_key");
+            }
+            AuthScheme::SigV4 { .. } => {
+                types.insert("sigv4");
+            }
+            AuthScheme::CloudflareBinding => {
+                types.insert("cloudflare_binding");
+            }
+        }
+    }
+    types.into_iter().collect()
+}
+
+fn private_json_response(value: &Value) -> Result<Response> {
+    let raw = serde_json::to_vec(value)?;
+    let etag = format!("\"{}\"", sha256_hex_bytes(&raw));
+    let mut response = Response::from_bytes(raw)?;
+    response
+        .headers_mut()
+        .set("content-type", "application/json")?;
+    response
+        .headers_mut()
+        .set("cache-control", "private, max-age=60")?;
+    response
+        .headers_mut()
+        .set("vary", "authorization, cf-access-jwt-assertion")?;
+    response.headers_mut().set("etag", &etag)?;
+    Ok(response)
+}
+
+fn internal_error_response(error: Error) -> Response {
+    console_error!("client discovery failed: {}", error);
+    json_error(
+        "client_discovery_unavailable",
+        "client discovery is temporarily unavailable",
+        503,
+    )
+    .unwrap_or_else(|_| Response::error("client discovery unavailable", 503).unwrap())
 }
 
 fn provider_runtime_error_summary(error: &Error) -> String {
@@ -9616,6 +9819,8 @@ fn cors_enabled_path(path: &str) -> bool {
             | "/v1/entitlements"
             | "/v1/me"
             | "/v1/usage"
+            | "/v1/models"
+            | "/v1/catalog"
             | "/v1/key/inspect"
     ) || path.starts_with("/v1/admin/")
 }
@@ -9682,6 +9887,49 @@ mod tests {
         provider
     }
 
+    fn entitlement_test_row(
+        provider: &str,
+        allowed: bool,
+        executable: bool,
+    ) -> EntitlementProviderRow {
+        EntitlementProviderRow {
+            provider: provider.to_string(),
+            display_name: provider.to_string(),
+            service_kind: "model_provider".to_string(),
+            allowed,
+            policies: allowed
+                .then(|| vec!["maintainers".to_string()])
+                .unwrap_or_default(),
+            readiness: ProviderReadinessRow {
+                id: provider.to_string(),
+                display_name: provider.to_string(),
+                class: "openai_compatible".to_string(),
+                service_kind: "model_provider".to_string(),
+                required_config: Vec::new(),
+                optional_config: Vec::new(),
+                missing_config: Vec::new(),
+                config_present: true,
+                connection_enabled: true,
+                oauth_grant_required: false,
+                oauth_grant_count: 0,
+                openai_compatible: true,
+                manifest_routes: 1,
+                model_count: 1,
+                executable,
+                verified: false,
+                last_checked_at: None,
+                latency_ms: None,
+                status: if executable {
+                    "unverified"
+                } else {
+                    "unsupported"
+                }
+                .to_string(),
+                reasons: Vec::new(),
+            },
+        }
+    }
+
     #[test]
     fn prefix_models_keep_requested_upstream_model() {
         let snapshot = provider_snapshot().unwrap();
@@ -9700,6 +9948,39 @@ mod tests {
         let route = select_model_route(&snapshot, "openai/gpt-4.1-mini").unwrap();
         assert_eq!(route.provider.id, "openai");
         assert_eq!(route.upstream_model, "gpt-4.1-mini");
+    }
+
+    #[test]
+    fn client_catalog_and_models_filter_by_effective_entitlement() {
+        let snapshot = provider_snapshot().unwrap();
+        let rows = vec![
+            entitlement_test_row("openai", true, true),
+            entitlement_test_row("anthropic", false, true),
+            entitlement_test_row("xai", true, false),
+        ];
+        let models = client_models_value(&snapshot, &rows);
+        let ids = models["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|model| model["id"].as_str())
+            .collect::<Vec<_>>();
+        assert!(ids.contains(&"openai/gpt-4.1-mini"));
+        assert!(!ids.contains(&"anthropic/default"));
+        assert!(!ids.contains(&"xai/default"));
+
+        let catalog = client_catalog_value(&snapshot, rows);
+        let providers = catalog["providers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|provider| provider["id"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(providers, vec!["openai", "xai"]);
+        assert_eq!(
+            catalog["providers"][0]["nativeBaseUrl"],
+            "/v1/native/openai"
+        );
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2321,6 +2321,8 @@ struct UpstreamGrantRecord {
 struct OAuthRefreshResponse {
     access_token: String,
     #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
     refresh_token: Option<String>,
     #[serde(default)]
     token_type: Option<String>,
@@ -5748,11 +5750,11 @@ async fn complete_oauth_authorization(
     let account_id = authorization
         .account_id_json_pointer
         .as_deref()
-        .and_then(|pointer| jwt_json_pointer_string(&token.access_token, pointer));
+        .and_then(|pointer| oauth_token_json_pointer_string(&token, pointer));
     let plan = authorization
         .subscription_plan_json_pointer
         .as_deref()
-        .and_then(|pointer| jwt_json_pointer_string(&token.access_token, pointer));
+        .and_then(|pointer| oauth_token_json_pointer_string(&token, pointer));
     let scopes = token
         .scope
         .as_deref()
@@ -5839,6 +5841,14 @@ fn jwt_json_pointer_string(token: &str, pointer: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn oauth_token_json_pointer_string(token: &OAuthRefreshResponse, pointer: &str) -> Option<String> {
+    token
+        .id_token
+        .as_deref()
+        .and_then(|id_token| jwt_json_pointer_string(id_token, pointer))
+        .or_else(|| jwt_json_pointer_string(&token.access_token, pointer))
 }
 
 async fn list_admin_upstream_grants(kv: &KvStore) -> Result<Vec<AdminUpstreamGrantResponse>> {
@@ -7001,6 +7011,7 @@ async fn reconcile_access_user_assignments(
         .collect::<BTreeSet<_>>();
     groups.extend(managed_groups);
     record.groups = normalize_access_groups(groups.into_iter().collect())?;
+    // Access admins are derived from the runtime allowlist, never from a persisted user role.
     record.role = AccessRole::User;
     let namespace = access_control_namespace(env)?;
     let user = AccessControlUser {
@@ -14443,28 +14454,53 @@ mod tests {
     }
 
     #[test]
-    fn oauth_callback_metadata_uses_manifest_json_pointers() {
-        let payload = serde_json::json!({
+    fn oauth_callback_metadata_prefers_id_token_with_access_token_fallback() {
+        let access_payload = serde_json::json!({
             "https://api.openai.com/auth": {
-                "chatgpt_account_id": "acct_test",
+                "chatgpt_account_id": "acct_access",
                 "chatgpt_plan_type": "plus"
             }
         });
-        let token = format!(
+        let id_payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_id"
+            }
+        });
+        let access_token = format!(
             "{}.{}.{}",
             base64_url_encode(br#"{"alg":"none"}"#),
-            base64_url_encode(serde_json::to_string(&payload).unwrap().as_bytes()),
+            base64_url_encode(serde_json::to_string(&access_payload).unwrap().as_bytes()),
             base64_url_encode(b"signature")
         );
+        let id_token = format!(
+            "{}.{}.{}",
+            base64_url_encode(br#"{"alg":"none"}"#),
+            base64_url_encode(serde_json::to_string(&id_payload).unwrap().as_bytes()),
+            base64_url_encode(b"signature")
+        );
+        let token = OAuthRefreshResponse {
+            access_token,
+            id_token: Some(id_token),
+            refresh_token: None,
+            token_type: None,
+            expires_in: None,
+            scope: None,
+        };
 
         assert_eq!(
-            jwt_json_pointer_string(&token, "/https:~1~1api.openai.com~1auth/chatgpt_account_id")
-                .as_deref(),
-            Some("acct_test")
+            oauth_token_json_pointer_string(
+                &token,
+                "/https:~1~1api.openai.com~1auth/chatgpt_account_id"
+            )
+            .as_deref(),
+            Some("acct_id")
         );
         assert_eq!(
-            jwt_json_pointer_string(&token, "/https:~1~1api.openai.com~1auth/chatgpt_plan_type")
-                .as_deref(),
+            oauth_token_json_pointer_string(
+                &token,
+                "/https:~1~1api.openai.com~1auth/chatgpt_plan_type"
+            )
+            .as_deref(),
             Some("plus")
         );
     }

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2648,7 +2648,7 @@ fn provider_connection_types(provider: &CompiledProvider) -> Vec<&'static str> {
                 types.insert("subscription");
             }
             AuthScheme::SigV4 { .. } => {
-                types.insert("sigv4");
+                types.insert("api_key");
             }
             AuthScheme::CloudflareBinding => {
                 types.insert("cloudflare_binding");
@@ -14677,6 +14677,7 @@ mod tests {
 
         assert!(upstream_grant_usable(&grant));
         assert!(upstream_grant_supports_provider(provider, &grant));
+        assert_eq!(provider_connection_types(provider), vec!["api_key"]);
         let response = admin_upstream_grant_response("oauth/svc_docs/aws-bedrock", &grant).unwrap();
         let raw = serde_json::to_string(&response).unwrap();
         assert_eq!(

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -8541,6 +8541,7 @@ fn endpoint_upstream_grant(
     };
     let Some(path) = transport.endpoint_paths.get(&endpoint.id).cloned() else {
         if !provider_requires_oauth(provider) {
+            // Provider policy grants shared fallback access; endpoint transports augment it.
             return Ok((None, None));
         }
         return Err(HeaderBuildError::Client {
@@ -14517,7 +14518,7 @@ mod tests {
     }
 
     #[test]
-    fn openai_subscription_grants_use_the_manifest_codex_transport() {
+    fn openai_subscription_grants_augment_responses_and_fallback_for_chat() {
         let snapshot = provider_snapshot().unwrap();
         let provider = snapshot
             .providers

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1324,16 +1324,22 @@ fn select_native_endpoint<'a>(
 }
 
 fn native_endpoint_path_matches(endpoint: &CompiledEndpoint, path: &str) -> bool {
+    native_endpoint_path(endpoint, path).is_some()
+}
+
+fn native_endpoint_path(endpoint: &CompiledEndpoint, path: &str) -> Option<String> {
     let mut template_rest = endpoint.path.as_str();
     let mut path_rest = path;
+    let mut normalized = String::with_capacity(path.len());
     while let Some(start) = template_rest.find("${") {
         let literal = &template_rest[..start];
         let Some(after_literal) = path_rest.strip_prefix(literal) else {
-            return false;
+            return None;
         };
+        normalized.push_str(literal);
         let after_start = &template_rest[start + 2..];
         let Some(end) = after_start.find('}') else {
-            return false;
+            return None;
         };
         let param = &after_start[..end];
         let next_template = &after_start[end + 1..];
@@ -1343,18 +1349,22 @@ fn native_endpoint_path_matches(endpoint: &CompiledEndpoint, path: &str) -> bool
             after_literal.len()
         } else {
             let Some(index) = after_literal.find(next_literal) else {
-                return false;
+                return None;
             };
             index
         };
         let capture = &after_literal[..capture_end];
-        if path_param_value(endpoint, param, capture).is_err() {
-            return false;
-        }
+        let decoded = percent_decode_path_segment(capture)?;
+        let encoded = path_param_value(endpoint, param, &decoded).ok()?;
+        normalized.push_str(&encoded);
         path_rest = &after_literal[capture_end..];
         template_rest = next_template;
     }
-    path_rest == template_rest
+    if path_rest != template_rest {
+        return None;
+    }
+    normalized.push_str(template_rest);
+    Some(normalized)
 }
 
 fn supports_native_proxy(provider: &CompiledProvider, endpoint: &CompiledEndpoint) -> bool {
@@ -1371,18 +1381,18 @@ fn native_upstream_url(
     grant: Option<&UpstreamGrantRecord>,
     transport_path: Option<&str>,
 ) -> Result<String> {
-    if !native_endpoint_path_matches(endpoint, native_path) {
-        return Err(Error::RustError(format!(
+    let native_path = native_endpoint_path(endpoint, native_path).ok_or_else(|| {
+        Error::RustError(format!(
             "provider-native path is not allowed for endpoint `{}`",
             endpoint.id
-        )));
-    }
+        ))
+    })?;
     let base = provider_upstream_base_url(provider, grant)?;
     let base = resolve_template_value(provider, base, Some(env))?;
     let mut url = format!(
         "{}{}",
         base.trim_end_matches('/'),
-        transport_path.unwrap_or(native_path)
+        transport_path.unwrap_or(&native_path)
     );
     if let Some(query) = incoming_query.filter(|query| !query.is_empty()) {
         url.push('?');
@@ -14302,6 +14312,14 @@ mod tests {
             generate,
             "/v1beta/models/gemini-2.5-pro:streamGenerateContent"
         ));
+        assert!(!native_endpoint_path_matches(
+            generate,
+            "/v1beta/models/gemini%2F2.5-pro:generateContent"
+        ));
+        assert!(!native_endpoint_path_matches(
+            generate,
+            "/v1beta/models/%2e%2e:generateContent"
+        ));
         assert_eq!(
             select_native_endpoint(
                 google,
@@ -14541,6 +14559,11 @@ mod tests {
             endpoint,
             "/v1/repos/../secrets"
         ));
+        assert_eq!(
+            native_endpoint_path(endpoint, "/v1/repos/openclaw%2Fclawrouter").as_deref(),
+            Some("/v1/repos/openclaw/clawrouter")
+        );
+        assert!(native_endpoint_path(endpoint, "/v1/repos/openclaw%2F..%2Fsecrets").is_none());
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2222,6 +2222,7 @@ struct AccessJwtPayload {
     aud: Option<AccessAud>,
     email: Option<String>,
     exp: Option<u64>,
+    iat: Option<u64>,
     iss: Option<String>,
     nbf: Option<u64>,
     sub: Option<String>,
@@ -3395,7 +3396,7 @@ async fn verified_access_session(headers: &Headers, env: &Env) -> Result<Option<
         return Ok(None);
     };
     let normalized_email = email.to_ascii_lowercase();
-    let Some(identity) = access_role_for_email(env, &normalized_email).await? else {
+    let Some(identity) = access_role_for_email(env, &normalized_email, payload.iat).await? else {
         return Ok(None);
     };
     Ok(Some(AccessSession {
@@ -3553,9 +3554,16 @@ fn access_audiences(payload: &AccessJwtPayload) -> Vec<&str> {
     }
 }
 
-async fn access_role_for_email(env: &Env, email: &str) -> Result<Option<AccessUserIdentity>> {
+async fn access_role_for_email(
+    env: &Env,
+    email: &str,
+    access_issued_at: Option<u64>,
+) -> Result<Option<AccessUserIdentity>> {
     let default_tenant = default_access_tenant(env);
     let user = access_control_user_record(env, email, &default_tenant).await?;
+    let user =
+        reconcile_access_user_assignments_for_access_session(env, email, user, access_issued_at)
+            .await;
     if !user.enabled.unwrap_or(true) {
         return Ok(None);
     }
@@ -3583,38 +3591,35 @@ async fn access_control_user_record(
 ) -> Result<AccessUserRecord> {
     let namespace = access_control_namespace(env)?;
     let mut response = resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
+    if let Some(user) = response.users.pop() {
+        // Existing users reconcile only through the Access JWT issued-at gate or an admin request.
+        return Ok(user.record);
+    }
     let kv = env.kv("POLICY_KV").map_err(|error| {
         Error::RustError(format!(
             "POLICY_KV binding is required before initializing an access user: {error}"
         ))
     })?;
-    let record = if let Some(user) = response.users.pop() {
-        user.record
-    } else {
-        let record = existing_access_user_record(&kv, email)
-            .await?
-            .unwrap_or_else(|| default_access_user_record(default_tenant));
-        let user = AccessControlUser {
-            email: email.to_string(),
-            record,
-        };
-        initialize_access_control_users(&namespace, std::slice::from_ref(&user)).await?;
-        let mut response =
-            resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
-        let user = response.users.pop().ok_or_else(|| {
-            Error::RustError(
-                "access user authority did not initialize the requested user".to_string(),
-            )
-        })?;
-        sync_kv_record_best_effort(
-            &kv,
-            &format!("access/users/{email}"),
-            &user.record,
-            "access user compatibility record",
-        )
-        .await;
-        user.record
+    let record = existing_access_user_record(&kv, email)
+        .await?
+        .unwrap_or_else(|| default_access_user_record(default_tenant));
+    let user = AccessControlUser {
+        email: email.to_string(),
+        record,
     };
+    initialize_access_control_users(&namespace, std::slice::from_ref(&user)).await?;
+    let mut response = resolve_access_control_users(&namespace, vec![email.to_string()]).await?;
+    let user = response.users.pop().ok_or_else(|| {
+        Error::RustError("access user authority did not initialize the requested user".to_string())
+    })?;
+    sync_kv_record_best_effort(
+        &kv,
+        &format!("access/users/{email}"),
+        &user.record,
+        "access user compatibility record",
+    )
+    .await;
+    let record = user.record;
     match reconcile_access_user_assignments(env, &kv, email, record.clone(), None).await {
         Ok((record, _)) => Ok(record),
         Err(error) => {
@@ -3626,6 +3631,63 @@ async fn access_control_user_record(
             Ok(record)
         }
     }
+}
+
+async fn reconcile_access_user_assignments_for_access_session(
+    env: &Env,
+    email: &str,
+    record: AccessUserRecord,
+    access_issued_at: Option<u64>,
+) -> AccessUserRecord {
+    let Some(issued_at) = access_issued_at
+        .and_then(|issued_at| issued_at.checked_mul(1_000))
+        .map(timestamp_from_epoch_ms)
+    else {
+        return record;
+    };
+    let kv = match env.kv("POLICY_KV") {
+        Ok(kv) => kv,
+        Err(error) => {
+            console_error!(
+                "login assignment state lookup failed for {}: {}",
+                email,
+                error
+            );
+            return record;
+        }
+    };
+    let state = match get_assignment_state(&kv, email).await {
+        Ok(state) => state,
+        Err(error) => {
+            console_error!(
+                "login assignment state lookup failed for {}: {}",
+                email,
+                error
+            );
+            return record;
+        }
+    };
+    if !assignment_state_predates_issued_at(&state, &issued_at) {
+        return record;
+    }
+    match reconcile_access_user_assignments(env, &kv, email, record.clone(), None).await {
+        Ok((record, _)) => record,
+        Err(error) => {
+            console_error!(
+                "login assignment reconciliation failed for {}: {}",
+                email,
+                error
+            );
+            record
+        }
+    }
+}
+
+fn assignment_state_predates_issued_at(state: &AssignmentStateRecord, issued_at: &str) -> bool {
+    state
+        .updated_at
+        .as_deref()
+        .is_none_or(|updated_at| updated_at < issued_at)
 }
 
 fn default_access_user_record(default_tenant: &str) -> AccessUserRecord {
@@ -13416,6 +13478,36 @@ mod tests {
     }
 
     #[test]
+    fn assignment_reconciliation_runs_once_per_access_session() {
+        let issued_at = "2026-06-16T00:00:00.000Z";
+        assert!(assignment_state_predates_issued_at(
+            &AssignmentStateRecord::default(),
+            issued_at
+        ));
+        assert!(assignment_state_predates_issued_at(
+            &AssignmentStateRecord {
+                updated_at: Some("2026-06-15T23:59:59.999Z".to_string()),
+                ..AssignmentStateRecord::default()
+            },
+            issued_at
+        ));
+        assert!(!assignment_state_predates_issued_at(
+            &AssignmentStateRecord {
+                updated_at: Some(issued_at.to_string()),
+                ..AssignmentStateRecord::default()
+            },
+            issued_at
+        ));
+        assert!(!assignment_state_predates_issued_at(
+            &AssignmentStateRecord {
+                updated_at: Some("2026-06-16T00:00:00.001Z".to_string()),
+                ..AssignmentStateRecord::default()
+            },
+            issued_at
+        ));
+    }
+
+    #[test]
     fn user_grant_mutations_reconcile_direct_bindings_as_one_authority_request() {
         let request = serde_json::from_str::<AdminAccessUserGrantsRequest>(
             r#"{"tenantId":"openclaw","enabled":true,"groups":["maintainers"],"policyIds":["svc_tools","svc_tools"]}"#,
@@ -14044,6 +14136,7 @@ mod tests {
             ])),
             email: None,
             exp: None,
+            iat: None,
             iss: None,
             nbf: None,
             sub: None,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -192,6 +192,10 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return proxy_manifest_endpoint(req, env, url.path(), ProxyAuthMode::ProxyKey).await;
     }
 
+    if url.path().starts_with("/v1/native/") {
+        return proxy_native_provider(req, env, url.path(), ProxyAuthMode::Client).await;
+    }
+
     Response::from_json(&serde_json::json!({
         "error": {
             "code": "route_not_found",
@@ -295,6 +299,7 @@ fn service_index() -> Result<Response> {
                 "/v1/embeddings"
             ],
             "manifestProxy": "/v1/proxy/{provider}/{endpoint}"
+            ,"nativeProxy": "/v1/native/{provider}/{provider-native-path}"
         }
     }))
 }
@@ -424,11 +429,32 @@ fn route_catalog(snapshot: &ProviderSnapshot) -> Value {
             })
         })
         .collect::<Vec<_>>();
+    let native_proxy = snapshot
+        .providers
+        .iter()
+        .flat_map(|provider| {
+            provider
+                .endpoints
+                .iter()
+                .filter(|endpoint| endpoint.native_proxy)
+                .map(move |endpoint| {
+                    serde_json::json!({
+                        "provider": provider.id,
+                        "endpoint": endpoint.id,
+                        "route": format!("/v1/native/{}{}", provider.id, endpoint.path),
+                        "methods": &endpoint.methods,
+                        "path": &endpoint.path,
+                        "streaming": &endpoint.streaming
+                    })
+                })
+        })
+        .collect::<Vec<_>>();
 
     serde_json::json!({
         "version": "clawrouter.route-catalog.v1",
         "openaiCompatible": openai_compatible,
-        "manifestProxy": manifest_proxy
+        "manifestProxy": manifest_proxy,
+        "nativeProxy": native_proxy
     })
 }
 
@@ -446,6 +472,7 @@ fn openai_compatible_endpoint_paths(
 enum ProxyAuthMode {
     ProxyKey,
     AccessSession,
+    Client,
 }
 
 async fn proxy_openai_compatible(
@@ -556,7 +583,7 @@ async fn proxy_openai_compatible(
     let header_context = HeaderRequestContext {
         method: "POST",
         url: &upstream_url,
-        body: Some(&upstream_body),
+        body: Some(upstream_body.as_bytes()),
     };
     let headers = match provider_headers(
         req.headers(),
@@ -811,7 +838,7 @@ async fn proxy_manifest_endpoint(
     let header_context = HeaderRequestContext {
         method: &upstream_method,
         url: &upstream_url,
-        body: upstream_body.as_deref(),
+        body: upstream_body.as_deref().map(str::as_bytes),
     };
     let headers = match provider_headers(
         req.headers(),
@@ -898,6 +925,297 @@ async fn proxy_manifest_endpoint(
     )
     .await;
     Ok(response)
+}
+
+async fn proxy_native_provider(
+    mut req: Request,
+    env: Env,
+    path: &str,
+    auth_mode: ProxyAuthMode,
+) -> Result<Response> {
+    let snapshot = provider_snapshot()?;
+    let Some(rest) = path.strip_prefix("/v1/native/") else {
+        return json_error("route_not_found", "route not found", 404);
+    };
+    let Some((provider_id, native_rest)) = rest.split_once('/') else {
+        return json_error(
+            "invalid_native_route",
+            "expected /v1/native/<provider>/<provider-native-path>",
+            400,
+        );
+    };
+    let native_path = format!("/{native_rest}");
+    let Some(provider) = snapshot
+        .providers
+        .iter()
+        .find(|provider| provider.id == provider_id)
+    else {
+        return json_error("provider_not_found", "provider is not registered", 404);
+    };
+    let method = req.method().to_string().to_ascii_uppercase();
+    let Some(endpoint) = select_native_endpoint(provider, &method, &native_path) else {
+        return json_error(
+            "native_route_not_allowed",
+            "provider-native path or method is not declared by the provider manifest",
+            404,
+        );
+    };
+    if !supports_native_proxy(provider, endpoint) {
+        return json_error(
+            "provider_endpoint_not_supported",
+            "provider-native endpoint requires edge support that is not configured yet",
+            501,
+        );
+    }
+    let capability = provider
+        .capabilities
+        .iter()
+        .find(|candidate| {
+            candidate.endpoint == endpoint.id
+                && candidate
+                    .methods
+                    .iter()
+                    .any(|candidate| candidate == &method)
+        })
+        .or_else(|| {
+            provider
+                .capabilities
+                .iter()
+                .find(|candidate| candidate.endpoint == endpoint.id)
+        })
+        .map(|capability| capability.id.as_str())
+        .unwrap_or("tool.invoke");
+    let auth = match authorize_request(req.headers(), &env, &provider.id, auth_mode).await? {
+        AuthOutcome::Allowed(auth) => auth,
+        AuthOutcome::Denied(response) => return Ok(response),
+    };
+    let request_id = request_id(req.headers(), endpoint.id.as_str());
+    let audit = ProxyAuditContext {
+        env: &env,
+        auth: &auth,
+        provider: &provider.id,
+        capability,
+        model: None,
+        request_id: &request_id,
+    };
+    if let Some(response) = disabled_provider_connection_response(&env, &provider.id).await? {
+        enqueue_denied_usage(
+            &env,
+            &auth,
+            &provider.id,
+            capability,
+            None,
+            &request_id,
+            response.status_code(),
+        )
+        .await;
+        return Ok(response);
+    }
+    if let Some(response) = preflight_static_budget(&auth.policy)? {
+        enqueue_denied_usage(
+            &env,
+            &auth,
+            &provider.id,
+            capability,
+            None,
+            &request_id,
+            response.status_code(),
+        )
+        .await;
+        return Ok(response);
+    }
+    let incoming_url = req.url()?;
+    let upstream_url =
+        match native_upstream_url(provider, endpoint, &env, &native_path, incoming_url.query()) {
+            Ok(url) => url,
+            Err(error) => {
+                return audit
+                    .failure_response(provider_runtime_error_response(error)?)
+                    .await
+            }
+        };
+    let body = if method_allows_body(&method) {
+        Some(req.bytes().await?)
+    } else {
+        None
+    };
+    let header_context = HeaderRequestContext {
+        method: &method,
+        url: &upstream_url,
+        body: body.as_deref(),
+    };
+    let headers = match native_provider_headers(
+        req.headers(),
+        &env,
+        provider,
+        endpoint,
+        &auth,
+        header_context,
+    )
+    .await
+    {
+        Ok(headers) => headers,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let mut init = RequestInit::new();
+    init.with_method(method_from_str(&method)?)
+        .with_headers(headers);
+    if let Some(body) = body {
+        init.with_body(Some(Uint8Array::from(body.as_slice()).into()));
+    }
+    let upstream_req = match Request::new_with_init(&upstream_url, &init) {
+        Ok(request) => request,
+        Err(error) => {
+            console_error!(
+                "failed to build native upstream request for provider {}: {}",
+                provider.id,
+                error
+            );
+            let response = json_error(
+                "proxy_request_build_failed",
+                "failed to build upstream provider request",
+                500,
+            )?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let budget = match preflight_budget(&env, &auth, capability).await? {
+        BudgetPreflight::Allowed(budget) => budget,
+        BudgetPreflight::Denied(response) => {
+            enqueue_denied_usage(
+                &env,
+                &auth,
+                &provider.id,
+                capability,
+                None,
+                &request_id,
+                response.status_code(),
+            )
+            .await;
+            return Ok(response);
+        }
+    };
+    let started_at_ms = Date::now().as_millis();
+    let mut response = send_upstream_request(upstream_req, &provider.id).await?;
+    let status_code = response.status_code();
+    let tokens = response_usage_tokens(&mut response, capability).await;
+    let response = sanitize_native_response(response, endpoint)?;
+    let budget = settle_budget_after_response(&env, &auth, budget, status_code).await;
+    enqueue_usage(
+        &env,
+        UsageRecord {
+            auth: &auth,
+            provider: &provider.id,
+            capability,
+            model: None,
+            request_id: &request_id,
+            budget,
+            tokens,
+            status: usage_status(status_code),
+            status_code,
+            duration_ms: Date::now().as_millis().saturating_sub(started_at_ms),
+        },
+    )
+    .await;
+    Ok(response)
+}
+
+fn select_native_endpoint<'a>(
+    provider: &'a CompiledProvider,
+    method: &str,
+    path: &str,
+) -> Option<&'a CompiledEndpoint> {
+    provider.endpoints.iter().find(|endpoint| {
+        endpoint.native_proxy
+            && endpoint.methods.iter().any(|candidate| candidate == method)
+            && native_endpoint_path_matches(endpoint, path)
+    })
+}
+
+fn native_endpoint_path_matches(endpoint: &CompiledEndpoint, path: &str) -> bool {
+    let mut template_rest = endpoint.path.as_str();
+    let mut path_rest = path;
+    while let Some(start) = template_rest.find("${") {
+        let literal = &template_rest[..start];
+        let Some(after_literal) = path_rest.strip_prefix(literal) else {
+            return false;
+        };
+        let after_start = &template_rest[start + 2..];
+        let Some(end) = after_start.find('}') else {
+            return false;
+        };
+        let param = &after_start[..end];
+        let next_template = &after_start[end + 1..];
+        let next_literal_end = next_template.find("${").unwrap_or(next_template.len());
+        let next_literal = &next_template[..next_literal_end];
+        let capture_end = if next_literal.is_empty() {
+            after_literal.len()
+        } else {
+            let Some(index) = after_literal.find(next_literal) else {
+                return false;
+            };
+            index
+        };
+        let capture = &after_literal[..capture_end];
+        if path_param_value(endpoint, param, capture).is_err() {
+            return false;
+        }
+        path_rest = &after_literal[capture_end..];
+        template_rest = next_template;
+    }
+    path_rest == template_rest
+}
+
+fn supports_native_proxy(provider: &CompiledProvider, endpoint: &CompiledEndpoint) -> bool {
+    endpoint.native_proxy && supports_manifest_proxy(provider, endpoint)
+}
+
+fn native_upstream_url(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    env: &Env,
+    native_path: &str,
+    incoming_query: Option<&str>,
+) -> Result<String> {
+    if !native_endpoint_path_matches(endpoint, native_path) {
+        return Err(Error::RustError(format!(
+            "provider-native path is not allowed for endpoint `{}`",
+            endpoint.id
+        )));
+    }
+    let base = provider.base_urls.get("default").ok_or_else(|| {
+        Error::RustError(format!(
+            "provider `{}` has no default base URL",
+            provider.id
+        ))
+    })?;
+    let base = resolve_template_value(provider, base, Some(env))?;
+    let mut url = format!("{}{}", base.trim_end_matches('/'), native_path);
+    if let Some(query) = incoming_query.filter(|query| !query.is_empty()) {
+        url.push('?');
+        url.push_str(query);
+    }
+    let mut injected = resolved_template_map(provider, &endpoint.query, Some(env))?;
+    for (name, value) in resolved_template_map(provider, &provider.adapter.inject_query, Some(env))?
+    {
+        injected.insert(name, value);
+    }
+    if let Some((param, secret)) = query_api_key(provider, Some(env))? {
+        injected.insert(param, secret);
+    }
+    append_query(&mut url, injected);
+    Ok(url)
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
@@ -5207,7 +5525,20 @@ async fn authorize_request(
     match mode {
         ProxyAuthMode::ProxyKey => authorize_proxy_key(headers, env, provider_id).await,
         ProxyAuthMode::AccessSession => authorize_access_session(headers, env, provider_id).await,
+        ProxyAuthMode::Client => {
+            if proxy_key_header_present(headers)? {
+                authorize_proxy_key(headers, env, provider_id).await
+            } else {
+                authorize_access_session(headers, env, provider_id).await
+            }
+        }
     }
+}
+
+fn proxy_key_header_present(headers: &Headers) -> Result<bool> {
+    let auth = headers.get("authorization")?.unwrap_or_default();
+    let token = auth.strip_prefix("Bearer ").unwrap_or("");
+    Ok(parse_proxy_key(token).is_ok())
 }
 
 async fn disabled_provider_connection_response(
@@ -5881,7 +6212,7 @@ enum HeaderBuildError {
 struct HeaderRequestContext<'a> {
     method: &'a str,
     url: &'a str,
-    body: Option<&'a str>,
+    body: Option<&'a [u8]>,
 }
 
 async fn provider_headers(
@@ -5920,6 +6251,123 @@ async fn provider_headers(
     }
     apply_auth_headers(&headers, env, provider, auth, context).await?;
     Ok(headers)
+}
+
+async fn native_provider_headers(
+    incoming: &Headers,
+    env: &Env,
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    auth: &AuthorizedKey,
+    context: HeaderRequestContext<'_>,
+) -> std::result::Result<Headers, HeaderBuildError> {
+    let headers = Headers::new();
+    for (name, value) in incoming.entries() {
+        if native_request_header_allowed(provider, endpoint, &name) {
+            headers
+                .set(&name, &value)
+                .map_err(HeaderBuildError::Runtime)?;
+        }
+    }
+    for (name, value) in
+        resolved_template_map(provider, &provider.adapter.inject_headers, Some(env))
+            .map_err(HeaderBuildError::Runtime)?
+    {
+        headers
+            .set(&name, &value)
+            .map_err(HeaderBuildError::Runtime)?;
+    }
+    for (name, value) in resolved_template_map(provider, &endpoint.headers, Some(env))
+        .map_err(HeaderBuildError::Runtime)?
+    {
+        headers
+            .set(&name, &value)
+            .map_err(HeaderBuildError::Runtime)?;
+    }
+    apply_auth_headers(&headers, env, provider, auth, context).await?;
+    Ok(headers)
+}
+
+fn native_request_header_allowed(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    name: &str,
+) -> bool {
+    let name = name.to_ascii_lowercase();
+    if matches!(
+        name.as_str(),
+        "authorization"
+            | "cookie"
+            | "host"
+            | "connection"
+            | "content-length"
+            | "proxy-authorization"
+            | "proxy-connection"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    ) || name.starts_with("cf-")
+    {
+        return false;
+    }
+    matches!(
+        name.as_str(),
+        "accept" | "accept-encoding" | "content-encoding" | "content-type" | "x-request-id"
+    ) || provider
+        .adapter
+        .passthrough_headers
+        .iter()
+        .chain(endpoint.request_headers.iter())
+        .any(|candidate| candidate.eq_ignore_ascii_case(&name))
+}
+
+fn sanitize_native_response(response: Response, endpoint: &CompiledEndpoint) -> Result<Response> {
+    let status = response.status_code();
+    let body = response.body().clone();
+    let headers = Headers::new();
+    for (name, value) in response.headers().entries() {
+        if native_response_header_allowed(endpoint, &name) {
+            headers.set(&name, &value)?;
+        }
+    }
+    headers.set(
+        UPSTREAM_PROVIDER_HEADER,
+        &response
+            .headers()
+            .get(UPSTREAM_PROVIDER_HEADER)?
+            .unwrap_or_default(),
+    )?;
+    Ok(Response::from_body(body)?
+        .with_status(status)
+        .with_headers(headers))
+}
+
+fn native_response_header_allowed(endpoint: &CompiledEndpoint, name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "accept-ranges"
+            | "cache-control"
+            | "content-disposition"
+            | "content-encoding"
+            | "content-language"
+            | "content-length"
+            | "content-range"
+            | "content-type"
+            | "etag"
+            | "expires"
+            | "last-modified"
+            | "location"
+            | "retry-after"
+            | "request-id"
+            | "x-request-id"
+    ) || name.starts_with("ratelimit-")
+        || name.starts_with("x-ratelimit-")
+        || endpoint
+            .response_headers
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(&name))
 }
 
 fn path_param_value(
@@ -6440,7 +6888,7 @@ fn sigv4_headers_at(
     let date_stamp = amz_date
         .get(0..8)
         .ok_or_else(|| Error::RustError("invalid SigV4 date".to_string()))?;
-    let payload_hash = sha256_hex(context.body.unwrap_or(""));
+    let payload_hash = sha256_hex_bytes(context.body.unwrap_or_default());
     let mut canonical_headers = BTreeMap::from([
         ("host".to_string(), host.clone()),
         ("x-amz-content-sha256".to_string(), payload_hash.clone()),
@@ -9094,7 +9542,7 @@ fn append_query(url: &mut String, query: BTreeMap<String, String>) {
         .map(|(name, value)| format!("{}={}", encode_component(name), encode_component(value)))
         .collect::<Vec<_>>()
         .join("&");
-    url.push('?');
+    url.push(if url.contains('?') { '&' } else { '?' });
     url.push_str(&pairs);
 }
 
@@ -9128,7 +9576,11 @@ fn encode_component(value: &str) -> String {
 }
 
 fn sha256_hex(input: &str) -> String {
-    let digest = Sha256::digest(input.as_bytes());
+    sha256_hex_bytes(input.as_bytes())
+}
+
+fn sha256_hex_bytes(input: &[u8]) -> String {
+    let digest = Sha256::digest(input);
     bytes_to_hex(&digest)
 }
 
@@ -9465,6 +9917,10 @@ mod tests {
             .get("manifestProxy")
             .and_then(Value::as_array)
             .unwrap();
+        let native_routes = catalog
+            .get("nativeProxy")
+            .and_then(Value::as_array)
+            .unwrap();
 
         assert!(openai_routes
             .iter()
@@ -9473,6 +9929,12 @@ mod tests {
             route.get("provider").and_then(Value::as_str) == Some("tavily")
                 && route.get("endpoint").and_then(Value::as_str) == Some("search")
                 && route.get("route").and_then(Value::as_str) == Some("/v1/proxy/tavily/search")
+        }));
+        assert!(native_routes.iter().any(|route| {
+            route.get("provider").and_then(Value::as_str) == Some("anthropic")
+                && route.get("endpoint").and_then(Value::as_str) == Some("messages")
+                && route.get("route").and_then(Value::as_str)
+                    == Some("/v1/native/anthropic/v1/messages")
         }));
         assert!(manifest_routes.iter().any(|route| {
             route.get("provider").and_then(Value::as_str) == Some("replicate")
@@ -10924,6 +11386,108 @@ mod tests {
     }
 
     #[test]
+    fn native_proxy_matches_only_manifest_declared_paths_and_methods() {
+        let snapshot = provider_snapshot().unwrap();
+        let google = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "google-gemini")
+            .unwrap();
+        let generate = google
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "generate_content")
+            .unwrap();
+        assert!(native_endpoint_path_matches(
+            generate,
+            "/v1beta/models/gemini-2.5-pro:generateContent"
+        ));
+        assert!(!native_endpoint_path_matches(
+            generate,
+            "/v1beta/models/gemini-2.5-pro:streamGenerateContent"
+        ));
+        assert_eq!(
+            select_native_endpoint(
+                google,
+                "POST",
+                "/v1beta/models/gemini-2.5-pro:generateContent"
+            )
+            .map(|endpoint| endpoint.id.as_str()),
+            Some("generate_content")
+        );
+        assert!(select_native_endpoint(
+            google,
+            "DELETE",
+            "/v1beta/models/gemini-2.5-pro:generateContent"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn native_proxy_relative_paths_still_reject_traversal() {
+        let provider = relative_path_test_provider();
+        let endpoint = provider
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "search")
+            .unwrap();
+        assert!(native_endpoint_path_matches(
+            endpoint,
+            "/v1/repos/openclaw/clawrouter"
+        ));
+        assert!(!native_endpoint_path_matches(
+            endpoint,
+            "/v1/repos/../secrets"
+        ));
+    }
+
+    #[test]
+    fn native_proxy_header_filters_strip_client_credentials_and_cookies() {
+        let snapshot = provider_snapshot().unwrap();
+        let openai = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "openai")
+            .unwrap();
+        let endpoint = openai
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "responses")
+            .unwrap();
+        assert!(native_request_header_allowed(
+            openai,
+            endpoint,
+            "content-type"
+        ));
+        assert!(native_request_header_allowed(
+            openai,
+            endpoint,
+            "openai-organization"
+        ));
+        assert!(!native_request_header_allowed(
+            openai,
+            endpoint,
+            "authorization"
+        ));
+        assert!(!native_request_header_allowed(openai, endpoint, "cookie"));
+        assert!(native_response_header_allowed(
+            endpoint,
+            "x-ratelimit-limit"
+        ));
+        assert!(!native_response_header_allowed(endpoint, "set-cookie"));
+    }
+
+    #[test]
+    fn native_query_injection_preserves_the_client_query() {
+        let mut url = "https://example.com/v1/models?alt=sse".to_string();
+        append_query(
+            &mut url,
+            BTreeMap::from([("key".to_string(), "secret".to_string())]),
+        );
+        assert_eq!(url, "https://example.com/v1/models?alt=sse&key=secret");
+    }
+
+    #[test]
     fn manifest_proxy_encodes_safe_path_params() {
         let snapshot = provider_snapshot().unwrap();
         let provider = snapshot
@@ -11062,7 +11626,7 @@ mod tests {
         let context = HeaderRequestContext {
             method: "POST",
             url: "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude/invoke",
-            body: Some(r#"{"inputText":"ok"}"#),
+            body: Some(br#"{"inputText":"ok"}"#),
         };
         let headers = sigv4_headers_at(
             "AKIDEXAMPLE",

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1766,6 +1766,7 @@ struct EntitlementProviderRow {
 struct OAuthGrantRecord {
     key: String,
     kind: UpstreamGrantKind,
+    provider: Option<String>,
     enabled: bool,
     usable: bool,
 }
@@ -5613,6 +5614,7 @@ async fn list_oauth_grants(kv: &KvStore) -> Result<Vec<OAuthGrantRecord>> {
             grants.push(OAuthGrantRecord {
                 key: key.name,
                 kind: token.kind,
+                provider: token.provider.clone(),
                 enabled: token.enabled,
                 usable: upstream_grant_usable_by_declared_provider(&token),
             });
@@ -6756,6 +6758,10 @@ fn provider_endpoint_has_upstream_grant(
 fn provider_upstream_grant_matches(provider: &CompiledProvider, grant: &OAuthGrantRecord) -> bool {
     grant.enabled
         && grant.usable
+        && grant
+            .provider
+            .as_deref()
+            .is_none_or(|grant_provider| grant_provider == provider.id)
         && provider_upstream_grant_refs(provider)
             .iter()
             .any(|token_ref| grant.key.ends_with(token_ref))
@@ -14453,20 +14459,30 @@ mod tests {
             OAuthGrantRecord {
                 key: "oauth/svc_docs/oauth.acme.access_token".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/default/acme-oauth".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: false,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: true,
                 usable: false,
+            },
+            OAuthGrantRecord {
+                key: "oauth/svc_docs/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
+                provider: Some("other-provider".to_string()),
+                enabled: true,
+                usable: true,
             },
         ];
 
@@ -14479,18 +14495,21 @@ mod tests {
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/research/acme-oauth".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_other/acme-oauth".to_string(),
                 kind: UpstreamGrantKind::OAuth,
+                provider: None,
                 enabled: true,
                 usable: true,
             },
@@ -14553,6 +14572,7 @@ mod tests {
         let grants = vec![OAuthGrantRecord {
             key: "oauth/svc_research/acme-oauth".to_string(),
             kind: UpstreamGrantKind::OAuth,
+            provider: None,
             enabled: true,
             usable: true,
         }];
@@ -14655,6 +14675,7 @@ mod tests {
         let discovery_grants = vec![OAuthGrantRecord {
             key: "oauth/svc_models/openai".to_string(),
             kind: UpstreamGrantKind::Subscription,
+            provider: Some("openai".to_string()),
             enabled: true,
             usable: true,
         }];

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -579,7 +579,7 @@ async fn proxy_openai_compatible(
         };
         return audit.failure_response(response).await;
     }
-    let grant = match upstream_grant_for_request(&env, route.provider, &auth).await {
+    let grant = match upstream_grant_for_request(&env, route.provider, endpoint, &auth).await {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
             code,
@@ -894,7 +894,7 @@ async fn proxy_manifest_endpoint(
         let response = json_error("invalid_proxy_request", &message, 400)?;
         return audit.failure_response(response).await;
     }
-    let grant = match upstream_grant_for_request(&env, provider, &auth).await {
+    let grant = match upstream_grant_for_request(&env, provider, endpoint, &auth).await {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
             code,
@@ -1151,7 +1151,7 @@ async fn proxy_native_provider(
         return Ok(response);
     }
     let incoming_url = req.url()?;
-    let grant = match upstream_grant_for_request(&env, provider, &auth).await {
+    let grant = match upstream_grant_for_request(&env, provider, endpoint, &auth).await {
         Ok(value) => value,
         Err(HeaderBuildError::Client {
             code,
@@ -6747,12 +6747,20 @@ fn provider_endpoint_has_upstream_grant(
 ) -> bool {
     grants.iter().any(|grant| {
         provider_upstream_grant_matches(provider, grant)
-            && provider
-                .auth
-                .grant_transports
-                .get(&enum_label(&grant.kind))
-                .is_none_or(|transport| transport.endpoint_paths.contains_key(&endpoint.id))
+            && grant_kind_supports_endpoint(provider, endpoint, grant.kind)
     })
+}
+
+fn grant_kind_supports_endpoint(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    kind: UpstreamGrantKind,
+) -> bool {
+    provider
+        .auth
+        .grant_transports
+        .get(&enum_label(&kind))
+        .is_none_or(|transport| transport.endpoint_paths.contains_key(&endpoint.id))
 }
 
 fn provider_upstream_grant_matches(provider: &CompiledProvider, grant: &OAuthGrantRecord) -> bool {
@@ -9221,6 +9229,7 @@ fn apply_auth_headers(
 async fn upstream_grant_for_request(
     env: &Env,
     provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
     auth: &AuthorizedKey,
 ) -> std::result::Result<Option<UpstreamGrantRecord>, HeaderBuildError> {
     match provider.auth.schemes.first() {
@@ -9232,6 +9241,7 @@ async fn upstream_grant_for_request(
             selected_upstream_grant(
                 env,
                 provider,
+                endpoint,
                 auth,
                 oauth_provider.as_deref(),
                 token_ref.as_deref(),
@@ -9244,7 +9254,7 @@ async fn upstream_grant_for_request(
             | AuthScheme::ApiKey { .. }
             | AuthScheme::QueryApiKey { .. }
             | AuthScheme::SigV4 { .. },
-        ) => selected_upstream_grant(env, provider, auth, None, None, false).await,
+        ) => selected_upstream_grant(env, provider, endpoint, auth, None, None, false).await,
         _ => Ok(None),
     }
 }
@@ -9252,6 +9262,7 @@ async fn upstream_grant_for_request(
 async fn selected_upstream_grant(
     env: &Env,
     provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
     auth: &AuthorizedKey,
     oauth_provider: Option<&str>,
     token_ref: Option<&str>,
@@ -9275,6 +9286,11 @@ async fn selected_upstream_grant(
         else {
             continue;
         };
+        if !provider_requires_oauth(provider)
+            && !grant_kind_supports_endpoint(provider, endpoint, grant.kind)
+        {
+            continue;
+        }
         if grant.refresh.is_none() && grant.refresh_token.is_some() {
             grant.refresh = upstream_grant_refresh_from_manifest(provider);
         }
@@ -14687,6 +14703,16 @@ mod tests {
             provider,
             chat,
             &discovery_grants
+        ));
+        assert!(grant_kind_supports_endpoint(
+            provider,
+            responses,
+            UpstreamGrantKind::Subscription
+        ));
+        assert!(!grant_kind_supports_endpoint(
+            provider,
+            chat,
+            UpstreamGrantKind::Subscription
         ));
         let (responses_grant, responses_path) =
             endpoint_upstream_grant(provider, responses, Some(grant.clone())).unwrap();

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,6 +1,7 @@
 use clawrouter_core::{
-    parse_proxy_key, AuthAuthorizationConfig, AuthScheme, CompiledEndpoint, CompiledProvider,
-    GrantTransportConfig, PathParamStyle, ProviderClass, ProviderSnapshot, UsageEvent, UsageStatus,
+    parse_proxy_key, AuthAuthorizationConfig, AuthScheme, CompiledEndpoint, CompiledModel,
+    CompiledProvider, GrantTransportConfig, PathParamStyle, ProviderClass, ProviderSnapshot,
+    UsageEvent, UsageStatus,
 };
 use futures_util::future::try_join_all;
 use hmac::{Hmac, Mac};
@@ -1717,6 +1718,7 @@ struct ProviderReadinessRow {
     upstream_grant_count: usize,
     openai_compatible: bool,
     manifest_routes: usize,
+    executable_endpoints: Vec<String>,
     model_count: usize,
     executable: bool,
     verified: bool,
@@ -1764,6 +1766,7 @@ struct EntitlementProviderRow {
 #[derive(Clone, Debug)]
 struct OAuthGrantRecord {
     key: String,
+    kind: UpstreamGrantKind,
     enabled: bool,
     usable: bool,
 }
@@ -2520,19 +2523,27 @@ fn client_models_value(snapshot: &ProviderSnapshot, rows: &[EntitlementProviderR
     let allowed = rows
         .iter()
         .filter(|row| row.allowed && row.readiness.executable)
-        .map(|row| row.provider.as_str())
-        .collect::<BTreeSet<_>>();
+        .map(|row| (row.provider.as_str(), &row.readiness.executable_endpoints))
+        .collect::<BTreeMap<_, _>>();
     let data = snapshot
         .providers
         .iter()
-        .filter(|provider| allowed.contains(provider.id.as_str()))
+        .filter_map(|provider| {
+            allowed
+                .get(provider.id.as_str())
+                .map(|endpoints| (provider, *endpoints))
+        })
         .flat_map(|provider| {
-            provider.models.iter().map(|model| {
-                serde_json::json!({
-                    "id": model.id,
-                    "object": "model",
-                    "owned_by": provider.id,
-                    "capabilities": model.capabilities
+            let (provider, endpoints) = provider;
+            provider.models.iter().filter_map(|model| {
+                let capabilities = executable_model_capabilities(provider, model, endpoints);
+                (!capabilities.is_empty()).then(|| {
+                    serde_json::json!({
+                        "id": model.id,
+                        "object": "model",
+                        "owned_by": provider.id,
+                        "capabilities": capabilities
+                    })
                 })
             })
         })
@@ -2561,6 +2572,7 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                 .providers
                 .iter()
                 .find(|provider| provider.id == row.provider)?;
+            let executable_endpoints = &row.readiness.executable_endpoints;
             Some(serde_json::json!({
                 "id": provider.id,
                 "displayName": provider.display_name,
@@ -2570,7 +2582,9 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                 "policies": row.policies,
                 "readiness": row.readiness,
                 "connectionTypes": provider_connection_types(provider),
-                "routes": provider.endpoints.iter().filter(|endpoint| endpoint.native_proxy).map(|endpoint| {
+                "routes": provider.endpoints.iter().filter(|endpoint| {
+                    endpoint.native_proxy && executable_endpoints.contains(&endpoint.id)
+                }).map(|endpoint| {
                     serde_json::json!({
                         "endpoint": endpoint.id,
                         "methods": endpoint.methods,
@@ -2578,7 +2592,18 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                         "streaming": endpoint.streaming
                     })
                 }).collect::<Vec<_>>(),
-                "models": provider.models
+                "models": provider.models.iter().filter_map(|model| {
+                    let capabilities =
+                        executable_model_capabilities(provider, model, executable_endpoints);
+                    (!capabilities.is_empty()).then(|| {
+                        serde_json::json!({
+                            "id": model.id,
+                            "upstream": model.upstream,
+                            "capabilities": capabilities,
+                            "pricing_ref": model.pricing_ref
+                        })
+                    })
+                }).collect::<Vec<_>>()
             }))
         })
         .collect::<Vec<_>>();
@@ -2586,6 +2611,25 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
         "version": "clawrouter.client-catalog.v1",
         "providers": providers
     })
+}
+
+fn executable_model_capabilities(
+    provider: &CompiledProvider,
+    model: &CompiledModel,
+    executable_endpoints: &[String],
+) -> Vec<String> {
+    model
+        .capabilities
+        .iter()
+        .filter(|capability| {
+            provider
+                .capabilities
+                .iter()
+                .find(|candidate| candidate.id == **capability)
+                .is_some_and(|candidate| executable_endpoints.contains(&candidate.endpoint))
+        })
+        .cloned()
+        .collect()
 }
 
 fn provider_connection_types(provider: &CompiledProvider) -> Vec<&'static str> {
@@ -5502,6 +5546,7 @@ async fn list_oauth_grants(kv: &KvStore) -> Result<Vec<OAuthGrantRecord>> {
             let token = parse_upstream_grant_record(&record)?;
             grants.push(OAuthGrantRecord {
                 key: key.name,
+                kind: token.kind,
                 enabled: token.enabled,
                 usable: upstream_grant_usable_by_declared_provider(&token),
             });
@@ -6389,11 +6434,20 @@ fn provider_readiness_row(
         .collect::<Vec<_>>();
     let upstream_grant_count = provider_upstream_grant_count(provider, grants);
     let auth_secret_config = provider_auth_secret_config_keys(provider);
+    let routable_endpoints = provider
+        .endpoints
+        .iter()
+        .filter(|endpoint| supports_manifest_proxy(provider, endpoint))
+        .collect::<Vec<_>>();
     let missing_config = required_config
         .iter()
         .filter(|key| {
             !runtime_binding_present(env, key)
-                && !(upstream_grant_count > 0 && auth_secret_config.contains(*key))
+                && !(auth_secret_config.contains(*key)
+                    && !routable_endpoints.is_empty()
+                    && routable_endpoints.iter().all(|endpoint| {
+                        provider_endpoint_has_upstream_grant(provider, endpoint, grants)
+                    }))
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -6405,16 +6459,24 @@ fn provider_readiness_row(
         0
     };
     let openai_compatible = supports_openai_compatible_proxy(provider);
-    let manifest_routes = provider
-        .endpoints
-        .iter()
-        .filter(|endpoint| supports_manifest_proxy(provider, endpoint))
-        .count();
+    let manifest_routes = routable_endpoints.len();
     let has_route = openai_compatible || manifest_routes > 0;
-    let executable = connection_enabled
-        && has_route
-        && config_present
-        && (!oauth_grant_required || oauth_grant_count > 0);
+    let executable_endpoints = routable_endpoints
+        .iter()
+        .filter(|endpoint| {
+            provider_endpoint_executable(
+                provider,
+                endpoint,
+                env,
+                grants,
+                &required_config,
+                &auth_secret_config,
+                connection_enabled,
+            )
+        })
+        .map(|endpoint| endpoint.id.clone())
+        .collect::<Vec<_>>();
+    let executable = !executable_endpoints.is_empty();
     let health_fresh = health.is_some_and(provider_health_is_fresh);
     let verified = health_fresh && health.is_some_and(|health| health.status == "verified");
     let health_failed = health.is_some_and(|health| health.status == "failed");
@@ -6473,6 +6535,7 @@ fn provider_readiness_row(
         upstream_grant_count,
         openai_compatible,
         manifest_routes,
+        executable_endpoints,
         model_count: provider.models.len(),
         executable,
         verified,
@@ -6481,6 +6544,24 @@ fn provider_readiness_row(
         status: status.to_string(),
         reasons,
     }
+}
+
+fn provider_endpoint_executable(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    env: &Env,
+    grants: &[OAuthGrantRecord],
+    required_config: &[String],
+    auth_secret_config: &BTreeSet<String>,
+    connection_enabled: bool,
+) -> bool {
+    if !connection_enabled || !supports_manifest_proxy(provider, endpoint) {
+        return false;
+    }
+    let has_grant = provider_endpoint_has_upstream_grant(provider, endpoint, grants);
+    required_config.iter().all(|key| {
+        runtime_binding_present(env, key) || (auth_secret_config.contains(key) && has_grant)
+    }) && (!provider_requires_oauth(provider) || has_grant)
 }
 
 fn provider_health_is_fresh(health: &ProviderHealthRecord) -> bool {
@@ -6585,12 +6666,33 @@ fn provider_upstream_grant_count(
     provider: &CompiledProvider,
     grants: &[OAuthGrantRecord],
 ) -> usize {
-    let refs = provider_upstream_grant_refs(provider);
     grants
         .iter()
-        .filter(|grant| grant.enabled && grant.usable)
-        .filter(|grant| refs.iter().any(|token_ref| grant.key.ends_with(token_ref)))
+        .filter(|grant| provider_upstream_grant_matches(provider, grant))
         .count()
+}
+
+fn provider_endpoint_has_upstream_grant(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    grants: &[OAuthGrantRecord],
+) -> bool {
+    grants.iter().any(|grant| {
+        provider_upstream_grant_matches(provider, grant)
+            && provider
+                .auth
+                .grant_transports
+                .get(&enum_label(&grant.kind))
+                .is_none_or(|transport| transport.endpoint_paths.contains_key(&endpoint.id))
+    })
+}
+
+fn provider_upstream_grant_matches(provider: &CompiledProvider, grant: &OAuthGrantRecord) -> bool {
+    grant.enabled
+        && grant.usable
+        && provider_upstream_grant_refs(provider)
+            .iter()
+            .any(|token_ref| grant.key.ends_with(token_ref))
 }
 
 fn provider_upstream_grant_refs(provider: &CompiledProvider) -> Vec<String> {
@@ -12511,6 +12613,7 @@ mod tests {
                 upstream_grant_count: 0,
                 openai_compatible: true,
                 manifest_routes: 1,
+                executable_endpoints: Vec::new(),
                 model_count: 1,
                 executable,
                 verified: false,
@@ -12550,8 +12653,10 @@ mod tests {
     #[test]
     fn client_catalog_and_models_filter_by_effective_entitlement() {
         let snapshot = provider_snapshot().unwrap();
+        let mut openai = entitlement_test_row("openai", true, true);
+        openai.readiness.executable_endpoints = vec!["responses".to_string()];
         let rows = vec![
-            entitlement_test_row("openai", true, true),
+            openai,
             entitlement_test_row("anthropic", false, true),
             entitlement_test_row("xai", true, false),
         ];
@@ -12563,8 +12668,13 @@ mod tests {
             .filter_map(|model| model["id"].as_str())
             .collect::<Vec<_>>();
         assert!(ids.contains(&"openai/gpt-4.1-mini"));
+        assert!(!ids.contains(&"openai/text-embedding-3-large"));
         assert!(!ids.contains(&"anthropic/default"));
         assert!(!ids.contains(&"xai/default"));
+        assert_eq!(
+            models["data"][0]["capabilities"],
+            serde_json::json!(["llm.responses"])
+        );
 
         let catalog = client_catalog_value(&snapshot, rows);
         let providers = catalog["providers"]
@@ -12577,6 +12687,14 @@ mod tests {
         assert_eq!(
             catalog["providers"][0]["nativeBaseUrl"],
             "/v1/native/openai"
+        );
+        assert_eq!(
+            catalog["providers"][0]["routes"][0]["endpoint"],
+            "responses"
+        );
+        assert_eq!(
+            catalog["providers"][0]["models"][0]["capabilities"],
+            serde_json::json!(["llm.responses"])
         );
     }
 
@@ -14217,16 +14335,19 @@ mod tests {
         let grants = vec![
             OAuthGrantRecord {
                 key: "oauth/svc_docs/oauth.acme.access_token".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/default/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: false,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: true,
                 usable: false,
             },
@@ -14240,16 +14361,19 @@ mod tests {
         let grants = vec![
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/research/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: true,
                 usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_other/acme-oauth".to_string(),
+                kind: UpstreamGrantKind::OAuth,
                 enabled: true,
                 usable: true,
             },
@@ -14311,6 +14435,7 @@ mod tests {
         };
         let grants = vec![OAuthGrantRecord {
             key: "oauth/svc_research/acme-oauth".to_string(),
+            kind: UpstreamGrantKind::OAuth,
             enabled: true,
             usable: true,
         }];
@@ -14410,11 +14535,27 @@ mod tests {
             .iter()
             .find(|endpoint| endpoint.id == "chat_completions")
             .unwrap();
+        let discovery_grants = vec![OAuthGrantRecord {
+            key: "oauth/svc_models/openai".to_string(),
+            kind: UpstreamGrantKind::Subscription,
+            enabled: true,
+            usable: true,
+        }];
 
         assert_eq!(
             provider_upstream_base_url(provider, Some(&grant)).unwrap(),
             "https://chatgpt.com/backend-api/codex"
         );
+        assert!(provider_endpoint_has_upstream_grant(
+            provider,
+            responses,
+            &discovery_grants
+        ));
+        assert!(!provider_endpoint_has_upstream_grant(
+            provider,
+            chat,
+            &discovery_grants
+        ));
         let (responses_grant, responses_path) =
             endpoint_upstream_grant(provider, responses, Some(grant.clone())).unwrap();
         assert!(responses_grant.is_some());

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -209,7 +209,7 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     }
 
     if url.path().starts_with("/v1/native/") {
-        return proxy_native_provider(req, env, url.path(), ProxyAuthMode::Client).await;
+        return proxy_native_provider(req, env, url.path(), ProxyAuthMode::ProxyKey).await;
     }
 
     Response::from_json(&serde_json::json!({
@@ -493,7 +493,6 @@ fn openai_compatible_endpoint_paths(
 enum ProxyAuthMode {
     ProxyKey,
     AccessSession,
-    Client,
 }
 
 async fn proxy_openai_compatible(
@@ -7715,13 +7714,6 @@ async fn authorize_request(
     match mode {
         ProxyAuthMode::ProxyKey => authorize_proxy_key(headers, env, provider_id).await,
         ProxyAuthMode::AccessSession => authorize_access_session(headers, env, provider_id).await,
-        ProxyAuthMode::Client => {
-            if proxy_key_header_present(headers)? {
-                authorize_proxy_key(headers, env, provider_id).await
-            } else {
-                authorize_access_session(headers, env, provider_id).await
-            }
-        }
     }
 }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -9627,17 +9627,11 @@ fn upstream_grant_keys(
         .iter()
         .map(|token_ref| format!("oauth/{}/{token_ref}", auth.policy_id))
         .collect::<Vec<_>>();
-    if let Some(tenant) = auth
-        .policy
-        .tenant_id
-        .as_deref()
-        .filter(|value| !value.is_empty())
-    {
-        keys.extend(
-            refs.iter()
-                .map(|token_ref| format!("oauth/tenants/{tenant}/{token_ref}")),
-        );
-    }
+    let tenant = tenant_id(auth);
+    keys.extend(
+        refs.iter()
+            .map(|token_ref| format!("oauth/tenants/{tenant}/{token_ref}")),
+    );
     keys
 }
 
@@ -15103,7 +15097,7 @@ mod tests {
     #[test]
     fn upstream_grant_keys_prefer_policy_scope_before_tenant_fallbacks() {
         let provider = oauth_test_provider();
-        let auth = AuthorizedKey {
+        let mut auth = AuthorizedKey {
             credential_id: Some("cred_docs".to_string()),
             principal_id: None,
             auth_type: "proxy_key",
@@ -15133,6 +15127,14 @@ mod tests {
                 "oauth/tenants/team_docs/oauth.acme.access_token",
                 "oauth/tenants/team_docs/acme-oauth",
                 "oauth/tenants/team_docs/oauth-test",
+            ]
+        );
+        auth.policy.tenant_id = None;
+        assert_eq!(
+            upstream_grant_keys(&provider, &auth, None, None),
+            vec![
+                "oauth/svc_docs/oauth-test",
+                "oauth/tenants/default/oauth-test",
             ]
         );
     }

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -5502,7 +5502,7 @@ async fn list_oauth_grants(kv: &KvStore) -> Result<Vec<OAuthGrantRecord>> {
             grants.push(OAuthGrantRecord {
                 key: key.name,
                 enabled: token.enabled,
-                usable: upstream_grant_usable(&token),
+                usable: upstream_grant_usable_by_declared_provider(&token),
             });
         }
         if list.list_complete {
@@ -6215,7 +6215,7 @@ fn admin_upstream_grant_response(
             .refresh
             .as_ref()
             .and_then(|refresh| refresh.client_secret_config.clone()),
-        usable: upstream_grant_usable(grant),
+        usable: upstream_grant_usable_by_declared_provider(grant),
     })
 }
 
@@ -6299,6 +6299,25 @@ fn upstream_grant_usable(grant: &UpstreamGrantRecord) -> bool {
         && (!upstream_grant_expired(grant) || upstream_grant_refreshable(grant))
 }
 
+fn upstream_grant_usable_by_declared_provider(grant: &UpstreamGrantRecord) -> bool {
+    let usable = upstream_grant_usable(grant);
+    if !usable || grant.credentials.is_empty() {
+        return usable;
+    }
+    let Some(provider_id) = grant.provider.as_deref() else {
+        return false;
+    };
+    provider_snapshot()
+        .ok()
+        .and_then(|snapshot| {
+            snapshot
+                .providers
+                .into_iter()
+                .find(|provider| provider.id == provider_id)
+        })
+        .is_some_and(|provider| upstream_grant_supports_provider(&provider, grant))
+}
+
 fn upstream_grant_credential_field<'a>(
     grant: &'a UpstreamGrantRecord,
     field: &str,
@@ -6319,7 +6338,7 @@ fn upstream_grant_supports_provider(
             upstream_grant_credential_field(grant, "accessKeyId").is_some()
                 && upstream_grant_credential_field(grant, "secretAccessKey").is_some()
         }
-        _ => true,
+        _ => grant.credentials.is_empty(),
     }
 }
 
@@ -12250,21 +12269,18 @@ fn append_native_query(
     injected: BTreeMap<String, String>,
 ) -> Result<()> {
     if let Some(incoming_query) = incoming_query.filter(|query| !query.is_empty()) {
-        let mut parsed = Url::parse("https://clawrouter.invalid/")
-            .map_err(|error| Error::RustError(format!("failed to parse native query: {error}")))?;
-        parsed.set_query(Some(incoming_query));
-        let forwarded = parsed
-            .query_pairs()
-            .filter(|(name, _)| !injected.contains_key(name.as_ref()))
-            .map(|(name, value)| {
-                format!(
-                    "{}={}",
-                    encode_component(name.as_ref()),
-                    encode_component(value.as_ref())
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("&");
+        let forwarded = if incoming_query
+            .split('&')
+            .any(|pair| raw_query_pair_is_controlled(pair, &injected))
+        {
+            incoming_query
+                .split('&')
+                .filter(|pair| !raw_query_pair_is_controlled(pair, &injected))
+                .collect::<Vec<_>>()
+                .join("&")
+        } else {
+            incoming_query.to_string()
+        };
         if !forwarded.is_empty() {
             url.push(if url.contains('?') { '&' } else { '?' });
             url.push_str(&forwarded);
@@ -12272,6 +12288,12 @@ fn append_native_query(
     }
     append_query(url, injected);
     Ok(())
+}
+
+fn raw_query_pair_is_controlled(pair: &str, injected: &BTreeMap<String, String>) -> bool {
+    let raw_name = pair.split_once('=').map(|(name, _)| name).unwrap_or(pair);
+    let query_name = raw_name.replace('+', " ");
+    percent_decode_path_segment(&query_name).is_some_and(|name| injected.contains_key(&name))
 }
 
 fn template_placeholders(template: &str) -> Vec<String> {
@@ -14514,6 +14536,25 @@ mod tests {
     }
 
     #[test]
+    fn named_credential_bundles_require_a_provider_auth_consumer() {
+        let mut grant = subscription_test_grant("anthropic");
+        grant.kind = UpstreamGrantKind::ApiKey;
+        grant.credential = None;
+        grant.access_token = None;
+        grant.refresh_token = None;
+        grant.subscription = None;
+        grant.credentials =
+            BTreeMap::from([("apiKey".to_string(), "secret-placeholder".to_string())]);
+
+        assert!(upstream_grant_usable(&grant));
+        assert!(!upstream_grant_usable_by_declared_provider(&grant));
+        assert_eq!(
+            normalize_upstream_grant(grant, None).unwrap_err(),
+            "upstream grant credentials do not satisfy the provider auth contract"
+        );
+    }
+
+    #[test]
     fn upstream_grant_admin_metadata_never_serializes_secrets() {
         let grant = subscription_test_grant("openai");
         let value = serde_json::to_value(
@@ -14633,7 +14674,7 @@ mod tests {
         let mut url = "https://example.com/v1/models".to_string();
         append_native_query(
             &mut url,
-            Some("tag=one&api-version=caller&tag=two"),
+            Some("tag=one+two&%61pi-version=caller&flag&tag=%2Fraw"),
             BTreeMap::from([
                 ("api-version".to_string(), "configured".to_string()),
                 ("key".to_string(), "secret".to_string()),
@@ -14642,7 +14683,19 @@ mod tests {
         .unwrap();
         assert_eq!(
             url,
-            "https://example.com/v1/models?tag=one&tag=two&api-version=configured&key=secret"
+            "https://example.com/v1/models?tag=one+two&flag&tag=%2Fraw&api-version=configured&key=secret"
+        );
+
+        let mut passthrough = "https://example.com/v1/models".to_string();
+        append_native_query(
+            &mut passthrough,
+            Some("tag=one+two&&flag&empty=&encoded=%2f"),
+            BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            passthrough,
+            "https://example.com/v1/models?tag=one+two&&flag&empty=&encoded=%2f"
         );
     }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1200,11 +1200,13 @@ async fn proxy_native_provider(
         provider,
         endpoint,
         &env,
-        &native_path,
-        incoming_url.query(),
-        query_auth,
-        grant.as_ref(),
-        transport_path.as_deref(),
+        NativeUpstreamContext {
+            native_path: &native_path,
+            incoming_query: incoming_url.query(),
+            query_auth,
+            grant: grant.as_ref(),
+            transport_path: transport_path.as_deref(),
+        },
     ) {
         Ok(url) => url,
         Err(error) => {
@@ -1332,14 +1334,10 @@ fn native_endpoint_path(endpoint: &CompiledEndpoint, path: &str) -> Option<Strin
     let mut normalized = String::with_capacity(path.len());
     while let Some(start) = template_rest.find("${") {
         let literal = &template_rest[..start];
-        let Some(after_literal) = path_rest.strip_prefix(literal) else {
-            return None;
-        };
+        let after_literal = path_rest.strip_prefix(literal)?;
         normalized.push_str(literal);
         let after_start = &template_rest[start + 2..];
-        let Some(end) = after_start.find('}') else {
-            return None;
-        };
+        let end = after_start.find('}')?;
         let param = &after_start[..end];
         let next_template = &after_start[end + 1..];
         let next_literal_end = next_template.find("${").unwrap_or(next_template.len());
@@ -1347,10 +1345,7 @@ fn native_endpoint_path(endpoint: &CompiledEndpoint, path: &str) -> Option<Strin
         let capture_end = if next_literal.is_empty() {
             after_literal.len()
         } else {
-            let Some(index) = after_literal.find(next_literal) else {
-                return None;
-            };
-            index
+            after_literal.find(next_literal)?
         };
         let capture = &after_literal[..capture_end];
         let decoded = percent_decode_path_segment(capture)?;
@@ -1370,38 +1365,42 @@ fn supports_native_proxy(provider: &CompiledProvider, endpoint: &CompiledEndpoin
     endpoint.native_proxy && supports_manifest_proxy(provider, endpoint)
 }
 
+struct NativeUpstreamContext<'a> {
+    native_path: &'a str,
+    incoming_query: Option<&'a str>,
+    query_auth: Option<(String, String)>,
+    grant: Option<&'a UpstreamGrantRecord>,
+    transport_path: Option<&'a str>,
+}
+
 fn native_upstream_url(
     provider: &CompiledProvider,
     endpoint: &CompiledEndpoint,
     env: &Env,
-    native_path: &str,
-    incoming_query: Option<&str>,
-    query_auth: Option<(String, String)>,
-    grant: Option<&UpstreamGrantRecord>,
-    transport_path: Option<&str>,
+    context: NativeUpstreamContext<'_>,
 ) -> Result<String> {
-    let native_path = native_endpoint_path(endpoint, native_path).ok_or_else(|| {
+    let native_path = native_endpoint_path(endpoint, context.native_path).ok_or_else(|| {
         Error::RustError(format!(
             "provider-native path is not allowed for endpoint `{}`",
             endpoint.id
         ))
     })?;
-    let base = provider_upstream_base_url(provider, grant)?;
+    let base = provider_upstream_base_url(provider, context.grant)?;
     let base = resolve_template_value(provider, base, Some(env))?;
     let mut url = format!(
         "{}{}",
         base.trim_end_matches('/'),
-        transport_path.unwrap_or(&native_path)
+        context.transport_path.unwrap_or(&native_path)
     );
     let mut injected = resolved_template_map(provider, &endpoint.query, Some(env))?;
     for (name, value) in resolved_template_map(provider, &provider.adapter.inject_query, Some(env))?
     {
         injected.insert(name, value);
     }
-    if let Some((param, secret)) = query_auth {
+    if let Some((param, secret)) = context.query_auth {
         injected.insert(param, secret);
     }
-    append_native_query(&mut url, incoming_query, injected)?;
+    append_native_query(&mut url, context.incoming_query, injected)?;
     Ok(url)
 }
 
@@ -2443,9 +2442,9 @@ async fn entitlement_rows_for_entries(
     kv: &KvStore,
 ) -> Result<Vec<EntitlementProviderRow>> {
     let snapshot = provider_snapshot()?;
-    let grants = list_oauth_grants(&kv).await?;
-    let connections = list_provider_connections(env, &kv, &snapshot).await?;
-    let health = list_provider_health(&kv).await?;
+    let grants = list_oauth_grants(kv).await?;
+    let connections = list_provider_connections(env, kv, &snapshot).await?;
+    let health = list_provider_health(kv).await?;
     Ok(snapshot
         .providers
         .iter()
@@ -6008,7 +6007,7 @@ fn normalize_upstream_grant(
     if grant.refresh.is_none() && grant.refresh_token.is_some() {
         grant.refresh = provider
             .as_ref()
-            .and_then(|provider| upstream_grant_refresh_from_manifest(provider));
+            .and_then(upstream_grant_refresh_from_manifest);
     }
     if let Some(refresh) = grant.refresh.as_ref() {
         validate_upstream_grant_refresh(refresh)?;
@@ -6442,12 +6441,12 @@ fn provider_readiness_row(
     let missing_config = required_config
         .iter()
         .filter(|key| {
-            !runtime_binding_present(env, key)
-                && !(auth_secret_config.contains(*key)
-                    && !routable_endpoints.is_empty()
-                    && routable_endpoints.iter().all(|endpoint| {
-                        provider_endpoint_has_upstream_grant(provider, endpoint, grants)
-                    }))
+            let covered_by_grants = auth_secret_config.contains(*key)
+                && !routable_endpoints.is_empty()
+                && routable_endpoints.iter().all(|endpoint| {
+                    provider_endpoint_has_upstream_grant(provider, endpoint, grants)
+                });
+            !runtime_binding_present(env, key) && !covered_by_grants
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -9100,7 +9099,7 @@ fn apply_auth_headers(
                     &format!(
                         "{} {}",
                         token.token_type,
-                        upstream_grant_secret(&token).unwrap_or_default()
+                        upstream_grant_secret(token).unwrap_or_default()
                     ),
                 )
                 .map_err(HeaderBuildError::Runtime)?;
@@ -12596,9 +12595,11 @@ mod tests {
             display_name: provider.to_string(),
             service_kind: "model_provider".to_string(),
             allowed,
-            policies: allowed
-                .then(|| vec!["maintainers".to_string()])
-                .unwrap_or_default(),
+            policies: if allowed {
+                vec!["maintainers".to_string()]
+            } else {
+                Vec::new()
+            },
             readiness: ProviderReadinessRow {
                 id: provider.to_string(),
                 display_name: provider.to_string(),

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,6 +1,6 @@
 use clawrouter_core::{
-    parse_proxy_key, AuthScheme, CompiledEndpoint, CompiledProvider, PathParamStyle, ProviderClass,
-    ProviderSnapshot, UsageEvent, UsageStatus,
+    parse_proxy_key, AuthScheme, CompiledEndpoint, CompiledProvider, GrantTransportConfig,
+    PathParamStyle, ProviderClass, ProviderSnapshot, UsageEvent, UsageStatus,
 };
 use futures_util::future::try_join_all;
 use hmac::{Hmac, Mac};
@@ -25,6 +25,7 @@ const BUDGET_RESERVATION_LEASE_MS: u64 = 15 * 60 * 1_000;
 const BUDGET_CHARGE_RETENTION_MS: u64 = 45 * 86_400_000;
 const BUDGET_CLEANUP_INTERVAL_MS: i64 = 86_400_000;
 const PROVIDER_HEALTH_MAX_AGE_MS: f64 = 86_400_000.0;
+const UPSTREAM_GRANT_REFRESH_WINDOW_MS: f64 = 5.0 * 60.0 * 1_000.0;
 const USAGE_EVENT_LIMIT: usize = 100;
 const USAGE_EVENT_RETENTION_MS: u64 = 30 * 86_400_000;
 const USAGE_CLEANUP_INTERVAL_MS: i64 = 86_400_000;
@@ -298,6 +299,7 @@ fn service_index() -> Result<Response> {
             "adminPolicies": "/v1/admin/policies",
             "adminCredentials": "/v1/admin/credentials",
             "adminConnections": "/v1/admin/connections",
+            "adminUpstreamGrants": "/v1/admin/upstream-grants",
             "apiAliases": {
                 "routes": ["/api/route", "/api/routes"],
                 "session": "/api/session",
@@ -570,18 +572,71 @@ async fn proxy_openai_compatible(
         };
         return audit.failure_response(response).await;
     }
-    let upstream_url =
-        match openai_upstream_url(route.provider, endpoint, &env, &route.upstream_model) {
-            Ok(url) => url,
-            Err(OpenAiProxyUrlError::Client(message)) => {
-                let response = json_error("invalid_model", &message, 400)?;
+    let grant = match upstream_grant_for_request(&env, route.provider, &auth).await {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let transport_path =
+        match grant_transport_endpoint_path(route.provider, endpoint, grant.as_ref()) {
+            Ok(value) => value,
+            Err(HeaderBuildError::Client {
+                code,
+                message,
+                status,
+            }) => {
+                let response = json_error(code, message, status)?;
                 return audit.failure_response(response).await;
             }
-            Err(OpenAiProxyUrlError::Runtime(error)) => {
+            Err(HeaderBuildError::Runtime(error)) => {
                 let response = provider_runtime_error_response(error)?;
                 return audit.failure_response(response).await;
             }
         };
+    let query_auth = match query_api_key_for_grant(route.provider, &env, grant.as_ref()) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let upstream_url = match openai_upstream_url(
+        route.provider,
+        endpoint,
+        &env,
+        &route.upstream_model,
+        query_auth,
+        grant.as_ref(),
+        transport_path.as_deref(),
+    ) {
+        Ok(url) => url,
+        Err(OpenAiProxyUrlError::Client(message)) => {
+            let response = json_error("invalid_model", &message, 400)?;
+            return audit.failure_response(response).await;
+        }
+        Err(OpenAiProxyUrlError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
     body["model"] = Value::String(route.upstream_model.clone());
     normalize_openai_proxy_body(
         route.provider,
@@ -602,7 +657,7 @@ async fn proxy_openai_compatible(
         &env,
         route.provider,
         endpoint,
-        &auth,
+        grant.as_ref(),
         header_context,
     )
     .await
@@ -833,7 +888,60 @@ async fn proxy_manifest_endpoint(
         let response = json_error("invalid_proxy_request", &message, 400)?;
         return audit.failure_response(response).await;
     }
-    let upstream_url = match manifest_upstream_url(provider, endpoint, &proxy, Some(&env)) {
+    let grant = match upstream_grant_for_request(&env, provider, &auth).await {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let transport_path = match grant_transport_endpoint_path(provider, endpoint, grant.as_ref()) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let query_auth = match query_api_key_for_grant(provider, &env, grant.as_ref()) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let upstream_url = match manifest_upstream_url(
+        provider,
+        endpoint,
+        &proxy,
+        Some(&env),
+        query_auth,
+        grant.as_ref(),
+        transport_path.as_deref(),
+    ) {
         Ok(url) => url,
         Err(ManifestProxyError::Client(message)) => {
             let response = json_error("invalid_proxy_request", &message, 400)?;
@@ -857,7 +965,7 @@ async fn proxy_manifest_endpoint(
         &env,
         provider,
         endpoint,
-        &auth,
+        grant.as_ref(),
         header_context,
     )
     .await
@@ -1037,15 +1145,68 @@ async fn proxy_native_provider(
         return Ok(response);
     }
     let incoming_url = req.url()?;
-    let upstream_url =
-        match native_upstream_url(provider, endpoint, &env, &native_path, incoming_url.query()) {
-            Ok(url) => url,
-            Err(error) => {
-                return audit
-                    .failure_response(provider_runtime_error_response(error)?)
-                    .await
-            }
-        };
+    let grant = match upstream_grant_for_request(&env, provider, &auth).await {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let transport_path = match grant_transport_endpoint_path(provider, endpoint, grant.as_ref()) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let query_auth = match query_api_key_for_grant(provider, &env, grant.as_ref()) {
+        Ok(value) => value,
+        Err(HeaderBuildError::Client {
+            code,
+            message,
+            status,
+        }) => {
+            let response = json_error(code, message, status)?;
+            return audit.failure_response(response).await;
+        }
+        Err(HeaderBuildError::Runtime(error)) => {
+            let response = provider_runtime_error_response(error)?;
+            return audit.failure_response(response).await;
+        }
+    };
+    let upstream_url = match native_upstream_url(
+        provider,
+        endpoint,
+        &env,
+        &native_path,
+        incoming_url.query(),
+        query_auth,
+        grant.as_ref(),
+        transport_path.as_deref(),
+    ) {
+        Ok(url) => url,
+        Err(error) => {
+            return audit
+                .failure_response(provider_runtime_error_response(error)?)
+                .await
+        }
+    };
     let body = if method_allows_body(&method) {
         Some(req.bytes().await?)
     } else {
@@ -1061,7 +1222,7 @@ async fn proxy_native_provider(
         &env,
         provider,
         endpoint,
-        &auth,
+        grant.as_ref(),
         header_context,
     )
     .await
@@ -1199,6 +1360,9 @@ fn native_upstream_url(
     env: &Env,
     native_path: &str,
     incoming_query: Option<&str>,
+    query_auth: Option<(String, String)>,
+    grant: Option<&UpstreamGrantRecord>,
+    transport_path: Option<&str>,
 ) -> Result<String> {
     if !native_endpoint_path_matches(endpoint, native_path) {
         return Err(Error::RustError(format!(
@@ -1206,14 +1370,13 @@ fn native_upstream_url(
             endpoint.id
         )));
     }
-    let base = provider.base_urls.get("default").ok_or_else(|| {
-        Error::RustError(format!(
-            "provider `{}` has no default base URL",
-            provider.id
-        ))
-    })?;
+    let base = provider_upstream_base_url(provider, grant)?;
     let base = resolve_template_value(provider, base, Some(env))?;
-    let mut url = format!("{}{}", base.trim_end_matches('/'), native_path);
+    let mut url = format!(
+        "{}{}",
+        base.trim_end_matches('/'),
+        transport_path.unwrap_or(native_path)
+    );
     if let Some(query) = incoming_query.filter(|query| !query.is_empty()) {
         url.push('?');
         url.push_str(query);
@@ -1223,7 +1386,7 @@ fn native_upstream_url(
     {
         injected.insert(name, value);
     }
-    if let Some((param, secret)) = query_api_key(provider, Some(env))? {
+    if let Some((param, secret)) = query_auth {
         injected.insert(param, secret);
     }
     append_query(&mut url, injected);
@@ -1540,6 +1703,7 @@ struct ProviderReadinessRow {
     connection_enabled: bool,
     oauth_grant_required: bool,
     oauth_grant_count: usize,
+    upstream_grant_count: usize,
     openai_compatible: bool,
     manifest_routes: usize,
     model_count: usize,
@@ -1590,7 +1754,37 @@ struct EntitlementProviderRow {
 struct OAuthGrantRecord {
     key: String,
     enabled: bool,
+    usable: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdminUpstreamGrantResponse {
+    key: String,
+    scope: String,
+    scope_id: String,
+    token_ref: String,
+    version: u8,
+    enabled: bool,
+    kind: UpstreamGrantKind,
+    provider: Option<String>,
+    label: Option<String>,
+    token_type: String,
+    expires_at: Option<String>,
+    scopes: Vec<String>,
+    account_id: Option<String>,
+    subscription: Option<UpstreamGrantSubscription>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    revoked_at: Option<String>,
+    has_credential: bool,
     has_access_token: bool,
+    has_refresh_token: bool,
+    refresh_configured: bool,
+    refresh_token_url: Option<String>,
+    client_id_config: Option<String>,
+    client_secret_config: Option<String>,
+    usable: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1911,15 +2105,88 @@ struct AccessPublicJwk {
     e: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UpstreamGrantKind {
+    ApiKey,
+    #[default]
+    OAuth,
+    Subscription,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct OAuthTokenRecord {
+struct UpstreamGrantSubscription {
+    #[serde(default)]
+    plan: Option<String>,
+    #[serde(default)]
+    subject: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpstreamGrantRefresh {
+    token_url: String,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    client_id_config: Option<String>,
+    #[serde(default)]
+    client_secret_config: Option<String>,
+    #[serde(default)]
+    extra_params: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpstreamGrantRecord {
+    #[serde(default = "default_upstream_grant_version")]
+    version: u8,
     #[serde(default = "default_true")]
     enabled: bool,
+    #[serde(default)]
+    kind: UpstreamGrantKind,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    credential: Option<String>,
     #[serde(default, alias = "access_token")]
     access_token: Option<String>,
+    #[serde(default, alias = "refresh_token")]
+    refresh_token: Option<String>,
     #[serde(default = "default_oauth_token_type", alias = "token_type")]
     token_type: String,
+    #[serde(default, alias = "expires_at")]
+    expires_at: Option<String>,
+    #[serde(default)]
+    scopes: Vec<String>,
+    #[serde(default, alias = "account_id")]
+    account_id: Option<String>,
+    #[serde(default)]
+    subscription: Option<UpstreamGrantSubscription>,
+    #[serde(default)]
+    refresh: Option<UpstreamGrantRefresh>,
+    #[serde(default, alias = "created_at")]
+    created_at: Option<String>,
+    #[serde(default, alias = "updated_at")]
+    updated_at: Option<String>,
+    #[serde(default, alias = "revoked_at")]
+    revoked_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthRefreshResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    expires_in: Option<u64>,
+    #[serde(default)]
+    scope: Option<String>,
 }
 
 struct AuthorizedKey {
@@ -2184,6 +2451,8 @@ fn provider_connection_types(provider: &CompiledProvider) -> Vec<&'static str> {
             | AuthScheme::ApiKey { .. }
             | AuthScheme::QueryApiKey { .. } => {
                 types.insert("api_key");
+                types.insert("oauth");
+                types.insert("subscription");
             }
             AuthScheme::SigV4 { .. } => {
                 types.insert("sigv4");
@@ -2329,6 +2598,69 @@ async fn admin_api(mut req: Request, env: Env, path: &str) -> Result<Response> {
         return Response::from_json(&serde_json::json!({
             "providers": health.into_values().collect::<Vec<_>>()
         }));
+    }
+
+    if req.method() == Method::Get && path == "/v1/admin/upstream-grants" {
+        let grants = list_admin_upstream_grants(&kv).await?;
+        return Response::from_json(&serde_json::json!({ "grants": grants }));
+    }
+
+    if let Some(rest) = path.strip_prefix("/v1/admin/upstream-grants/") {
+        let route = match parse_admin_upstream_grant_route(rest) {
+            Ok(route) => route,
+            Err(message) => return json_error("invalid_upstream_grant_route", message, 400),
+        };
+        if req.method() == Method::Put && route.action.is_none() {
+            let request = match serde_json::from_str::<UpstreamGrantRecord>(&req.text().await?) {
+                Ok(request) => request,
+                Err(_) => {
+                    return json_error(
+                        "invalid_upstream_grant_request",
+                        "request body must be a JSON upstream grant record",
+                        400,
+                    );
+                }
+            };
+            let existing = get_upstream_grant(&kv, &route.key).await?;
+            let grant = match normalize_upstream_grant(request, existing.as_ref()) {
+                Ok(grant) => grant,
+                Err(message) => return json_error("invalid_upstream_grant", &message, 400),
+            };
+            put_kv_record(&kv, &route.key, &grant, "upstream grant").await?;
+            return Response::from_json(&admin_upstream_grant_response(&route.key, &grant)?);
+        }
+        if req.method() == Method::Post && route.action.as_deref() == Some("revoke") {
+            let Some(mut grant) = get_upstream_grant(&kv, &route.key).await? else {
+                return json_error(
+                    "unknown_upstream_grant",
+                    "upstream grant is not registered",
+                    404,
+                );
+            };
+            revoke_upstream_grant(&mut grant);
+            put_kv_record(&kv, &route.key, &grant, "upstream grant tombstone").await?;
+            return Response::from_json(&admin_upstream_grant_response(&route.key, &grant)?);
+        }
+        if req.method() == Method::Post && route.action.as_deref() == Some("refresh") {
+            let Some(grant) = get_upstream_grant(&kv, &route.key).await? else {
+                return json_error(
+                    "unknown_upstream_grant",
+                    "upstream grant is not registered",
+                    404,
+                );
+            };
+            let grant = match refresh_upstream_grant(&env, &kv, &route.key, grant, true).await {
+                Ok(grant) => grant,
+                Err(HeaderBuildError::Client {
+                    code,
+                    message,
+                    status,
+                }) => return json_error(code, message, status),
+                Err(HeaderBuildError::Runtime(error)) => return Err(error),
+            };
+            return Response::from_json(&admin_upstream_grant_response(&route.key, &grant)?);
+        }
+        return json_error("method_not_allowed", "admin method is not allowed", 405);
     }
 
     if req.method() == Method::Get && path == "/v1/admin/policies" {
@@ -4863,14 +5195,11 @@ async fn list_oauth_grants(kv: &KvStore) -> Result<Vec<OAuthGrantRecord>> {
             else {
                 continue;
             };
-            let token = parse_oauth_token_record(&record)?;
+            let token = parse_upstream_grant_record(&record)?;
             grants.push(OAuthGrantRecord {
                 key: key.name,
                 enabled: token.enabled,
-                has_access_token: token
-                    .access_token
-                    .as_deref()
-                    .is_some_and(|value| !value.trim().is_empty()),
+                usable: upstream_grant_usable(&token),
             });
         }
         if list.list_complete {
@@ -4882,6 +5211,468 @@ async fn list_oauth_grants(kv: &KvStore) -> Result<Vec<OAuthGrantRecord>> {
         cursor = Some(next_cursor);
     }
     Ok(grants)
+}
+
+#[derive(Debug)]
+struct AdminUpstreamGrantRoute {
+    key: String,
+    action: Option<String>,
+}
+
+fn parse_admin_upstream_grant_route(
+    rest: &str,
+) -> std::result::Result<AdminUpstreamGrantRoute, &'static str> {
+    let mut parts = rest.split('/').collect::<Vec<_>>();
+    let action = if parts
+        .last()
+        .is_some_and(|value| matches!(*value, "revoke" | "refresh"))
+    {
+        parts.pop().map(str::to_string)
+    } else {
+        None
+    };
+    if parts.len() != 3 {
+        return Err("expected /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>");
+    }
+    let scope = parts[0];
+    if !matches!(scope, "policies" | "tenants") {
+        return Err("upstream grant scope must be `policies` or `tenants`");
+    }
+    let scope_id = validate_upstream_grant_component(parts[1])?;
+    let token_ref = validate_upstream_grant_component(parts[2])?;
+    let key = if scope == "tenants" {
+        format!("oauth/tenants/{scope_id}/{token_ref}")
+    } else {
+        format!("oauth/{scope_id}/{token_ref}")
+    };
+    Ok(AdminUpstreamGrantRoute { key, action })
+}
+
+fn validate_upstream_grant_component(value: &str) -> std::result::Result<String, &'static str> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        return Err(
+            "upstream grant identifiers must be 1-128 ASCII letters, numbers, underscores, hyphens, or dots",
+        );
+    }
+    Ok(value.to_string())
+}
+
+async fn list_admin_upstream_grants(kv: &KvStore) -> Result<Vec<AdminUpstreamGrantResponse>> {
+    let mut grants = Vec::new();
+    let mut cursor = None;
+    loop {
+        let mut request = kv.list().prefix("oauth/".to_string()).limit(1000);
+        if let Some(next_cursor) = cursor.take() {
+            request = request.cursor(next_cursor);
+        }
+        let list = request.execute().await.map_err(|error| {
+            Error::RustError(format!("failed to list upstream grants: {error}"))
+        })?;
+        for key in list.keys {
+            let Some(record) = kv.get(&key.name).text().await.map_err(|error| {
+                Error::RustError(format!("failed to read upstream grant: {error}"))
+            })?
+            else {
+                continue;
+            };
+            let grant = parse_upstream_grant_record(&record)?;
+            grants.push(admin_upstream_grant_response(&key.name, &grant)?);
+        }
+        if list.list_complete {
+            break;
+        }
+        let Some(next_cursor) = list.cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+    grants.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(grants)
+}
+
+async fn get_upstream_grant(kv: &KvStore, key: &str) -> Result<Option<UpstreamGrantRecord>> {
+    let Some(record) = kv
+        .get(key)
+        .text()
+        .await
+        .map_err(|error| Error::RustError(format!("failed to read upstream grant: {error}")))?
+    else {
+        return Ok(None);
+    };
+    parse_upstream_grant_record(&record).map(Some)
+}
+
+fn normalize_upstream_grant(
+    mut grant: UpstreamGrantRecord,
+    existing: Option<&UpstreamGrantRecord>,
+) -> std::result::Result<UpstreamGrantRecord, String> {
+    if let Some(existing) = existing.filter(|record| record.enabled) {
+        if existing.kind != grant.kind {
+            return Err("revoke an enabled grant before changing its kind".to_string());
+        }
+        if existing
+            .provider
+            .as_deref()
+            .zip(grant.provider.as_deref())
+            .is_some_and(|(current, requested)| current != requested)
+        {
+            return Err("revoke an enabled grant before changing its provider".to_string());
+        }
+    }
+    grant.version = default_upstream_grant_version();
+    grant.provider = normalize_grant_optional_text(grant.provider, "provider", 128)?;
+    grant.label = normalize_optional_label(grant.label).map_err(str::to_string)?;
+    grant.account_id = normalize_grant_optional_text(grant.account_id, "accountId", 256)?;
+    if let Some(subscription) = grant.subscription.as_mut() {
+        subscription.plan =
+            normalize_grant_optional_text(subscription.plan.take(), "subscription.plan", 128)?;
+        subscription.subject = normalize_grant_optional_text(
+            subscription.subject.take(),
+            "subscription.subject",
+            256,
+        )?;
+    }
+    grant.scopes = normalize_grant_scopes(grant.scopes)?;
+    grant.token_type = grant.token_type.trim().to_string();
+    if grant.token_type.is_empty() || grant.token_type.len() > 32 {
+        return Err("tokenType must be 1-32 characters".to_string());
+    }
+    let provider = if let Some(provider_id) = grant.provider.as_deref() {
+        let snapshot = provider_snapshot().map_err(|error| error.to_string())?;
+        let provider = snapshot
+            .providers
+            .iter()
+            .find(|candidate| candidate.id == provider_id)
+            .cloned()
+            .ok_or_else(|| format!("provider `{provider_id}` is not registered"))?;
+        Some(provider)
+    } else {
+        None
+    };
+    if let Some(expires_at) = grant.expires_at.as_deref() {
+        if !js_sys::Date::parse(expires_at).is_finite() {
+            return Err("expiresAt must be an ISO-8601 timestamp".to_string());
+        }
+    }
+    merge_upstream_grant_secrets(&mut grant, existing);
+    validate_upstream_grant_secret_shape(&grant)?;
+    if grant.refresh.is_none() && grant.refresh_token.is_some() {
+        grant.refresh = provider
+            .as_ref()
+            .and_then(|provider| upstream_grant_refresh_from_manifest(provider));
+    }
+    if let Some(refresh) = grant.refresh.as_ref() {
+        validate_upstream_grant_refresh(refresh)?;
+        if provider
+            .as_ref()
+            .is_none_or(|provider| !provider_approves_refresh(provider, refresh))
+        {
+            return Err("provider manifest does not approve refresh configuration".to_string());
+        }
+    }
+    if grant.enabled && upstream_grant_secret(&grant).is_none() {
+        return Err(match grant.kind {
+            UpstreamGrantKind::ApiKey => "enabled API-key grant requires credential".to_string(),
+            UpstreamGrantKind::OAuth | UpstreamGrantKind::Subscription => {
+                "enabled OAuth or subscription grant requires accessToken".to_string()
+            }
+        });
+    }
+    let now = current_iso_timestamp();
+    grant.created_at = existing
+        .and_then(|record| record.created_at.clone())
+        .or(grant.created_at)
+        .or_else(|| Some(now.clone()));
+    grant.updated_at = Some(now);
+    if grant.enabled {
+        grant.revoked_at = None;
+    } else {
+        revoke_upstream_grant(&mut grant);
+    }
+    Ok(grant)
+}
+
+fn validate_upstream_grant_secret_shape(
+    grant: &UpstreamGrantRecord,
+) -> std::result::Result<(), String> {
+    match grant.kind {
+        UpstreamGrantKind::ApiKey => {
+            if grant.access_token.is_some() || grant.refresh_token.is_some() {
+                return Err(
+                    "API-key grants accept credential only; revoke before changing grant kind"
+                        .to_string(),
+                );
+            }
+        }
+        UpstreamGrantKind::OAuth => {
+            if grant.credential.is_some() {
+                return Err(
+                    "OAuth grants accept accessToken only; revoke before changing grant kind"
+                        .to_string(),
+                );
+            }
+        }
+        UpstreamGrantKind::Subscription => {
+            if grant.credential.is_some() && grant.access_token.is_some() {
+                return Err("subscription grants accept exactly one primary credential".to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn normalize_grant_optional_text(
+    value: Option<String>,
+    field: &str,
+    max_len: usize,
+) -> std::result::Result<Option<String>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.len() > max_len || value.bytes().any(|byte| byte.is_ascii_control()) {
+        return Err(format!(
+            "{field} must be {max_len} or fewer characters without control characters"
+        ));
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn normalize_grant_scopes(scopes: Vec<String>) -> std::result::Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for scope in scopes {
+        let Some(scope) = normalize_grant_optional_text(Some(scope), "scope", 256)? else {
+            continue;
+        };
+        if !normalized.iter().any(|value| value == &scope) {
+            normalized.push(scope);
+        }
+    }
+    normalized.sort();
+    Ok(normalized)
+}
+
+fn validate_upstream_grant_refresh(
+    refresh: &UpstreamGrantRefresh,
+) -> std::result::Result<(), String> {
+    if !refresh.token_url.starts_with("https://")
+        || refresh.token_url.contains('@')
+        || refresh.token_url.contains('#')
+    {
+        return Err("refresh.tokenUrl must be a trusted HTTPS URL".to_string());
+    }
+    if refresh
+        .client_id
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+        && refresh.client_id_config.is_none()
+    {
+        return Err("refresh requires clientId or clientIdConfig".to_string());
+    }
+    if let Some(value) = refresh.client_id.as_deref() {
+        if value.len() > 256 || value.bytes().any(|byte| byte.is_ascii_control()) {
+            return Err("refresh.clientId is invalid".to_string());
+        }
+    }
+    if let Some(value) = refresh.client_id_config.as_deref() {
+        validate_runtime_config_name(value, "refresh.clientIdConfig")?;
+    }
+    if let Some(value) = refresh.client_secret_config.as_deref() {
+        validate_runtime_config_name(value, "refresh.clientSecretConfig")?;
+    }
+    for (name, value) in &refresh.extra_params {
+        if name.is_empty()
+            || name.len() > 128
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+            || value.len() > 1024
+            || value.bytes().any(|byte| byte.is_ascii_control())
+        {
+            return Err("refresh.extraParams contains an invalid entry".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn validate_runtime_config_name(value: &str, field: &str) -> std::result::Result<(), String> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Err(format!("{field} must be an uppercase runtime binding name"));
+    }
+    Ok(())
+}
+
+fn merge_upstream_grant_secrets(
+    grant: &mut UpstreamGrantRecord,
+    existing: Option<&UpstreamGrantRecord>,
+) {
+    let Some(existing) = existing else {
+        return;
+    };
+    if grant.credential.is_none() {
+        grant.credential.clone_from(&existing.credential);
+    }
+    if grant.access_token.is_none() {
+        grant.access_token.clone_from(&existing.access_token);
+    }
+    if grant.refresh_token.is_none() {
+        grant.refresh_token.clone_from(&existing.refresh_token);
+    }
+}
+
+fn revoke_upstream_grant(grant: &mut UpstreamGrantRecord) {
+    let now = current_iso_timestamp();
+    grant.enabled = false;
+    grant.credential = None;
+    grant.access_token = None;
+    grant.refresh_token = None;
+    grant.updated_at = Some(now.clone());
+    grant.revoked_at = Some(now);
+}
+
+fn current_iso_timestamp() -> String {
+    js_sys::Date::new_0().to_iso_string().into()
+}
+
+fn admin_upstream_grant_response(
+    key: &str,
+    grant: &UpstreamGrantRecord,
+) -> Result<AdminUpstreamGrantResponse> {
+    let (scope, scope_id, token_ref) = parse_upstream_grant_key(key)?;
+    Ok(AdminUpstreamGrantResponse {
+        key: key.to_string(),
+        scope,
+        scope_id,
+        token_ref,
+        version: grant.version,
+        enabled: grant.enabled,
+        kind: grant.kind,
+        provider: grant.provider.clone(),
+        label: grant.label.clone(),
+        token_type: grant.token_type.clone(),
+        expires_at: grant.expires_at.clone(),
+        scopes: grant.scopes.clone(),
+        account_id: grant.account_id.clone(),
+        subscription: grant.subscription.clone(),
+        created_at: grant.created_at.clone(),
+        updated_at: grant.updated_at.clone(),
+        revoked_at: grant.revoked_at.clone(),
+        has_credential: grant
+            .credential
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
+        has_access_token: grant
+            .access_token
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
+        has_refresh_token: grant
+            .refresh_token
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
+        refresh_configured: grant.refresh.is_some(),
+        refresh_token_url: grant
+            .refresh
+            .as_ref()
+            .map(|refresh| refresh.token_url.clone()),
+        client_id_config: grant
+            .refresh
+            .as_ref()
+            .and_then(|refresh| refresh.client_id_config.clone()),
+        client_secret_config: grant
+            .refresh
+            .as_ref()
+            .and_then(|refresh| refresh.client_secret_config.clone()),
+        usable: upstream_grant_usable(grant),
+    })
+}
+
+fn parse_upstream_grant_key(key: &str) -> Result<(String, String, String)> {
+    let Some(rest) = key.strip_prefix("oauth/") else {
+        return Err(Error::RustError(
+            "upstream grant key has invalid prefix".to_string(),
+        ));
+    };
+    let (scope, scope_id, token_ref) = if let Some(rest) = rest.strip_prefix("tenants/") {
+        let Some((scope_id, token_ref)) = rest.split_once('/') else {
+            return Err(Error::RustError(
+                "tenant upstream grant key is invalid".to_string(),
+            ));
+        };
+        ("tenants", scope_id, token_ref)
+    } else {
+        let Some((scope_id, token_ref)) = rest.split_once('/') else {
+            return Err(Error::RustError(
+                "policy upstream grant key is invalid".to_string(),
+            ));
+        };
+        ("policies", scope_id, token_ref)
+    };
+    Ok((
+        scope.to_string(),
+        scope_id.to_string(),
+        token_ref.to_string(),
+    ))
+}
+
+fn upstream_grant_secret(grant: &UpstreamGrantRecord) -> Option<&str> {
+    let preferred = match grant.kind {
+        UpstreamGrantKind::ApiKey => grant.credential.as_deref(),
+        UpstreamGrantKind::OAuth => grant.access_token.as_deref(),
+        UpstreamGrantKind::Subscription => grant
+            .access_token
+            .as_deref()
+            .or(grant.credential.as_deref()),
+    };
+    preferred.filter(|value| !value.trim().is_empty())
+}
+
+fn upstream_grant_expired(grant: &UpstreamGrantRecord) -> bool {
+    grant
+        .expires_at
+        .as_deref()
+        .map(js_sys::Date::parse)
+        .is_some_and(|expires_at| expires_at.is_finite() && expires_at <= js_sys::Date::now())
+}
+
+fn upstream_grant_needs_refresh(grant: &UpstreamGrantRecord) -> bool {
+    grant
+        .expires_at
+        .as_deref()
+        .map(js_sys::Date::parse)
+        .is_some_and(|expires_at| {
+            expires_at.is_finite()
+                && expires_at <= js_sys::Date::now() + UPSTREAM_GRANT_REFRESH_WINDOW_MS
+        })
+}
+
+fn upstream_grant_refreshable(grant: &UpstreamGrantRecord) -> bool {
+    matches!(
+        grant.kind,
+        UpstreamGrantKind::OAuth | UpstreamGrantKind::Subscription
+    ) && grant
+        .refresh_token
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+        && grant.refresh.is_some()
+}
+
+fn upstream_grant_usable(grant: &UpstreamGrantRecord) -> bool {
+    grant.enabled
+        && upstream_grant_secret(grant).is_some()
+        && (!upstream_grant_expired(grant) || upstream_grant_refreshable(grant))
 }
 
 fn provider_readiness_rows(
@@ -4920,15 +5711,20 @@ fn provider_readiness_row(
         .filter(|key| !optional_config.iter().any(|optional| optional == *key))
         .cloned()
         .collect::<Vec<_>>();
+    let upstream_grant_count = provider_upstream_grant_count(provider, grants);
+    let auth_secret_config = provider_auth_secret_config_keys(provider);
     let missing_config = required_config
         .iter()
-        .filter(|key| !runtime_binding_present(env, key))
+        .filter(|key| {
+            !runtime_binding_present(env, key)
+                && !(upstream_grant_count > 0 && auth_secret_config.contains(*key))
+        })
         .cloned()
         .collect::<Vec<_>>();
     let config_present = missing_config.is_empty();
     let oauth_grant_required = provider_requires_oauth(provider);
     let oauth_grant_count = if oauth_grant_required {
-        provider_oauth_grant_count(provider, grants)
+        upstream_grant_count
     } else {
         0
     };
@@ -4998,6 +5794,7 @@ fn provider_readiness_row(
         connection_enabled,
         oauth_grant_required,
         oauth_grant_count,
+        upstream_grant_count,
         openai_compatible,
         manifest_routes,
         model_count: provider.models.len(),
@@ -5083,15 +5880,13 @@ fn select_access_policy_for_provider<'a>(
     grants: &[OAuthGrantRecord],
 ) -> Option<&'a AccessPolicyEntry> {
     let first_entry = entries.first().copied()?;
-    if provider.is_some_and(provider_requires_oauth) {
-        if let Some(grant_entry) = provider.and_then(|provider| {
-            entries.iter().copied().find(|entry| {
-                let scoped_grants = entitlement_oauth_grants(grants, &[*entry]);
-                provider_oauth_grant_count(provider, &scoped_grants) > 0
-            })
-        }) {
-            return Some(grant_entry);
-        }
+    if let Some(grant_entry) = provider.and_then(|provider| {
+        entries.iter().copied().find(|entry| {
+            let scoped_grants = entitlement_oauth_grants(grants, &[*entry]);
+            provider_upstream_grant_count(provider, &scoped_grants) > 0
+        })
+    }) {
+        return Some(grant_entry);
     }
     Some(first_entry)
 }
@@ -5110,16 +5905,19 @@ fn runtime_binding_present(env: &Env, name: &str) -> bool {
     false
 }
 
-fn provider_oauth_grant_count(provider: &CompiledProvider, grants: &[OAuthGrantRecord]) -> usize {
-    let refs = provider_oauth_refs(provider);
+fn provider_upstream_grant_count(
+    provider: &CompiledProvider,
+    grants: &[OAuthGrantRecord],
+) -> usize {
+    let refs = provider_upstream_grant_refs(provider);
     grants
         .iter()
-        .filter(|grant| grant.enabled && grant.has_access_token)
+        .filter(|grant| grant.enabled && grant.usable)
         .filter(|grant| refs.iter().any(|token_ref| grant.key.ends_with(token_ref)))
         .count()
 }
 
-fn provider_oauth_refs(provider: &CompiledProvider) -> Vec<String> {
+fn provider_upstream_grant_refs(provider: &CompiledProvider) -> Vec<String> {
     let mut refs = Vec::new();
     for scheme in &provider.auth.schemes {
         if let AuthScheme::OAuth {
@@ -5141,6 +5939,21 @@ fn provider_oauth_refs(provider: &CompiledProvider) -> Vec<String> {
     refs.push(format!("/{}", provider.id));
     dedupe_preserving_order(&mut refs);
     refs
+}
+
+fn provider_auth_secret_config_keys(provider: &CompiledProvider) -> BTreeSet<String> {
+    provider
+        .auth
+        .schemes
+        .iter()
+        .filter_map(|scheme| match scheme {
+            AuthScheme::Bearer { secret_kind, .. }
+            | AuthScheme::ApiKey { secret_kind, .. }
+            | AuthScheme::QueryApiKey { secret_kind, .. } => Some(secret_kind),
+            _ => None,
+        })
+        .flat_map(|secret_kind| secret_binding_candidates(provider, secret_kind))
+        .collect()
 }
 
 fn enum_label<T: Serialize>(value: &T) -> String {
@@ -5683,6 +6496,10 @@ fn default_oauth_token_type() -> String {
     "Bearer".to_string()
 }
 
+fn default_upstream_grant_version() -> u8 {
+    1
+}
+
 fn inspect_policy_for_response<'a>(
     verification: &str,
     policy: &'a AccessPolicy,
@@ -5981,12 +6798,7 @@ async fn authorize_access_session(
         .providers
         .iter()
         .find(|provider| provider.id == provider_id);
-    let grants = if provider.is_some_and(provider_requires_oauth) {
-        let grants = list_oauth_grants(&kv).await?;
-        grants
-    } else {
-        Vec::new()
-    };
+    let grants = list_oauth_grants(&kv).await?;
     let selected_entry = select_access_policy_for_provider(provider, &matching_entries, &grants)
         .unwrap_or(first_entry);
     Ok(AuthOutcome::Allowed(AuthorizedKey {
@@ -6200,19 +7012,23 @@ fn openai_upstream_url(
     endpoint: &CompiledEndpoint,
     env: &Env,
     upstream_model: &str,
+    query_auth: Option<(String, String)>,
+    grant: Option<&UpstreamGrantRecord>,
+    transport_path: Option<&str>,
 ) -> std::result::Result<String, OpenAiProxyUrlError> {
-    let base = provider.base_urls.get("default").ok_or_else(|| {
-        OpenAiProxyUrlError::Runtime(Error::RustError(format!(
-            "provider `{}` has no default base URL",
-            provider.id
-        )))
-    })?;
+    let base = provider_upstream_base_url(provider, grant).map_err(OpenAiProxyUrlError::Runtime)?;
     let base =
         resolve_template_value(provider, base, Some(env)).map_err(OpenAiProxyUrlError::Runtime)?;
-    let path = openai_endpoint_path(endpoint, upstream_model)?;
+    let path = match transport_path {
+        Some(path) => path.to_string(),
+        None => openai_endpoint_path(endpoint, upstream_model)?,
+    };
     let mut url = format!("{}{}", base.trim_end_matches('/'), path);
-    let query = resolved_template_map(provider, &provider.adapter.inject_query, Some(env))
+    let mut query = resolved_template_map(provider, &provider.adapter.inject_query, Some(env))
         .map_err(OpenAiProxyUrlError::Runtime)?;
+    if let Some((param, secret)) = query_auth {
+        query.insert(param, secret);
+    }
     append_query(&mut url, query);
     Ok(url)
 }
@@ -6344,14 +7160,12 @@ fn manifest_upstream_url(
     endpoint: &CompiledEndpoint,
     proxy: &ManifestProxyRequest,
     env: Option<&Env>,
+    query_auth: Option<(String, String)>,
+    grant: Option<&UpstreamGrantRecord>,
+    transport_path: Option<&str>,
 ) -> std::result::Result<String, ManifestProxyError> {
-    let base = provider.base_urls.get("default").ok_or_else(|| {
-        ManifestProxyError::Runtime(Error::RustError(format!(
-            "provider `{}` has no default base URL",
-            provider.id
-        )))
-    })?;
-    let mut path = endpoint.path.clone();
+    let base = provider_upstream_base_url(provider, grant).map_err(ManifestProxyError::Runtime)?;
+    let mut path = transport_path.unwrap_or(&endpoint.path).to_string();
     for param in &endpoint.path_params {
         let Some(value) = proxy.path_params.get(param).and_then(Value::as_str) else {
             return Err(ManifestProxyError::Client(format!(
@@ -6376,9 +7190,7 @@ fn manifest_upstream_url(
     {
         query.insert(name, value);
     }
-    if let Some((param, secret)) =
-        query_api_key(provider, env).map_err(ManifestProxyError::Runtime)?
-    {
+    if let Some((param, secret)) = query_auth {
         query.insert(param, secret);
     }
     append_query(&mut url, query);
@@ -6418,12 +7230,102 @@ struct HeaderRequestContext<'a> {
     body: Option<&'a [u8]>,
 }
 
+fn grant_transport<'a>(
+    provider: &'a CompiledProvider,
+    grant: Option<&UpstreamGrantRecord>,
+) -> Option<&'a GrantTransportConfig> {
+    let grant = grant?;
+    provider.auth.grant_transports.get(&enum_label(&grant.kind))
+}
+
+fn provider_upstream_base_url<'a>(
+    provider: &'a CompiledProvider,
+    grant: Option<&UpstreamGrantRecord>,
+) -> Result<&'a str> {
+    grant_transport(provider, grant)
+        .and_then(|transport| transport.base_url.as_deref())
+        .or_else(|| provider.base_urls.get("default").map(String::as_str))
+        .ok_or_else(|| {
+            Error::RustError(format!(
+                "provider `{}` has no default base URL",
+                provider.id
+            ))
+        })
+}
+
+fn grant_transport_endpoint_path(
+    provider: &CompiledProvider,
+    endpoint: &CompiledEndpoint,
+    grant: Option<&UpstreamGrantRecord>,
+) -> std::result::Result<Option<String>, HeaderBuildError> {
+    let Some(transport) = grant_transport(provider, grant) else {
+        return Ok(None);
+    };
+    transport
+        .endpoint_paths
+        .get(&endpoint.id)
+        .cloned()
+        .map(Some)
+        .ok_or(HeaderBuildError::Client {
+            code: "upstream_grant_transport_unsupported",
+            message: "upstream grant transport does not support this provider endpoint",
+            status: 409,
+        })
+}
+
+fn apply_grant_transport_headers(
+    headers: &Headers,
+    provider: &CompiledProvider,
+    grant: Option<&UpstreamGrantRecord>,
+) -> std::result::Result<(), HeaderBuildError> {
+    let Some(transport) = grant_transport(provider, grant) else {
+        return Ok(());
+    };
+    let grant = grant.expect("grant transport requires a grant");
+    for (name, value) in &transport.headers {
+        headers
+            .set(name, &resolve_grant_template(value, grant)?)
+            .map_err(HeaderBuildError::Runtime)?;
+    }
+    Ok(())
+}
+
+fn resolve_grant_template(
+    value: &str,
+    grant: &UpstreamGrantRecord,
+) -> std::result::Result<String, HeaderBuildError> {
+    let mut resolved = value.to_string();
+    for placeholder in template_placeholders(value) {
+        let replacement = match placeholder.as_str() {
+            "grant.accountId" => grant.account_id.as_deref(),
+            "grant.provider" => grant.provider.as_deref(),
+            "grant.subscription.plan" => grant
+                .subscription
+                .as_ref()
+                .and_then(|subscription| subscription.plan.as_deref()),
+            "grant.subscription.subject" => grant
+                .subscription
+                .as_ref()
+                .and_then(|subscription| subscription.subject.as_deref()),
+            _ => None,
+        }
+        .filter(|replacement| !replacement.trim().is_empty())
+        .ok_or(HeaderBuildError::Client {
+            code: "upstream_grant_invalid",
+            message: "upstream grant is missing transport metadata",
+            status: 409,
+        })?;
+        resolved = resolved.replace(&format!("${{{placeholder}}}"), replacement);
+    }
+    Ok(resolved)
+}
+
 async fn provider_headers(
     incoming: &Headers,
     env: &Env,
     provider: &CompiledProvider,
     endpoint: &CompiledEndpoint,
-    auth: &AuthorizedKey,
+    grant: Option<&UpstreamGrantRecord>,
     context: HeaderRequestContext<'_>,
 ) -> std::result::Result<Headers, HeaderBuildError> {
     let headers = Headers::new();
@@ -6452,7 +7354,8 @@ async fn provider_headers(
                 .map_err(HeaderBuildError::Runtime)?;
         }
     }
-    apply_auth_headers(&headers, env, provider, auth, context).await?;
+    apply_grant_transport_headers(&headers, provider, grant)?;
+    apply_auth_headers(&headers, env, provider, grant, context)?;
     Ok(headers)
 }
 
@@ -6461,7 +7364,7 @@ async fn native_provider_headers(
     env: &Env,
     provider: &CompiledProvider,
     endpoint: &CompiledEndpoint,
-    auth: &AuthorizedKey,
+    grant: Option<&UpstreamGrantRecord>,
     context: HeaderRequestContext<'_>,
 ) -> std::result::Result<Headers, HeaderBuildError> {
     let headers = Headers::new();
@@ -6487,7 +7390,8 @@ async fn native_provider_headers(
             .set(&name, &value)
             .map_err(HeaderBuildError::Runtime)?;
     }
-    apply_auth_headers(&headers, env, provider, auth, context).await?;
+    apply_grant_transport_headers(&headers, provider, grant)?;
+    apply_auth_headers(&headers, env, provider, grant, context)?;
     Ok(headers)
 }
 
@@ -6863,11 +7767,11 @@ fn provider_has_secret_candidate(provider: &CompiledProvider, secret_kind: &str)
         .any(|candidate| provider.config_keys.iter().any(|key| key == candidate))
 }
 
-async fn apply_auth_headers(
+fn apply_auth_headers(
     headers: &Headers,
     env: &Env,
     provider: &CompiledProvider,
-    auth: &AuthorizedKey,
+    grant: Option<&UpstreamGrantRecord>,
     context: HeaderRequestContext<'_>,
 ) -> std::result::Result<(), HeaderBuildError> {
     let Some(scheme) = provider.auth.schemes.first() else {
@@ -6879,8 +7783,13 @@ async fn apply_auth_headers(
             format,
             secret_kind,
         } => {
-            let secret =
-                provider_secret(env, provider, secret_kind).map_err(HeaderBuildError::Runtime)?;
+            let secret = grant
+                .and_then(upstream_grant_secret)
+                .map(str::to_string)
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    provider_secret(env, provider, secret_kind).map_err(HeaderBuildError::Runtime)
+                })?;
             headers
                 .set(header, &format.replace("${secret}", &secret))
                 .map_err(HeaderBuildError::Runtime)?;
@@ -6890,34 +7799,28 @@ async fn apply_auth_headers(
             header,
             secret_kind,
         } => {
-            let secret =
-                provider_secret(env, provider, secret_kind).map_err(HeaderBuildError::Runtime)?;
+            let secret = grant
+                .and_then(upstream_grant_secret)
+                .map(str::to_string)
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    provider_secret(env, provider, secret_kind).map_err(HeaderBuildError::Runtime)
+                })?;
             headers
                 .set(header, &secret)
                 .map_err(HeaderBuildError::Runtime)?;
             Ok(())
         }
         AuthScheme::QueryApiKey { .. } | AuthScheme::CloudflareBinding => Ok(()),
-        AuthScheme::OAuth {
-            provider: oauth_provider,
-            token_ref,
-            ..
-        } => {
-            let token = oauth_token(
-                env,
-                provider,
-                auth,
-                oauth_provider.as_deref(),
-                token_ref.as_deref(),
-            )
-            .await?;
+        AuthScheme::OAuth { .. } => {
+            let token = grant.expect("required upstream grant resolver returned no grant");
             headers
                 .set(
                     "authorization",
                     &format!(
                         "{} {}",
                         token.token_type,
-                        token.access_token.as_deref().unwrap_or_default()
+                        upstream_grant_secret(&token).unwrap_or_default()
                     ),
                 )
                 .map_err(HeaderBuildError::Runtime)?;
@@ -6939,110 +7842,417 @@ async fn apply_auth_headers(
     }
 }
 
-async fn oauth_token(
+async fn upstream_grant_for_request(
+    env: &Env,
+    provider: &CompiledProvider,
+    auth: &AuthorizedKey,
+) -> std::result::Result<Option<UpstreamGrantRecord>, HeaderBuildError> {
+    match provider.auth.schemes.first() {
+        Some(AuthScheme::OAuth {
+            provider: oauth_provider,
+            token_ref,
+            ..
+        }) => {
+            selected_upstream_grant(
+                env,
+                provider,
+                auth,
+                oauth_provider.as_deref(),
+                token_ref.as_deref(),
+                true,
+            )
+            .await
+        }
+        Some(
+            AuthScheme::Bearer { .. } | AuthScheme::ApiKey { .. } | AuthScheme::QueryApiKey { .. },
+        ) => selected_upstream_grant(env, provider, auth, None, None, false).await,
+        _ => Ok(None),
+    }
+}
+
+async fn selected_upstream_grant(
     env: &Env,
     provider: &CompiledProvider,
     auth: &AuthorizedKey,
     oauth_provider: Option<&str>,
     token_ref: Option<&str>,
-) -> std::result::Result<OAuthTokenRecord, HeaderBuildError> {
-    let kv = env.kv("POLICY_KV").map_err(|_| HeaderBuildError::Client {
-        code: "policy_store_unavailable",
-        message: "POLICY_KV binding is required for OAuth-backed proxy requests",
-        status: 503,
-    })?;
-    for key in oauth_token_keys(provider, auth, oauth_provider, token_ref) {
-        let record = kv.get(&key).text().await.map_err(|error| {
-            HeaderBuildError::Runtime(Error::RustError(format!(
-                "failed to read OAuth token grant: {error}"
-            )))
-        })?;
-        let Some(record) = record else {
+    required: bool,
+) -> std::result::Result<Option<UpstreamGrantRecord>, HeaderBuildError> {
+    let kv = match env.kv("POLICY_KV") {
+        Ok(kv) => kv,
+        Err(_) if !required => return Ok(None),
+        Err(_) => {
+            return Err(HeaderBuildError::Client {
+                code: "policy_store_unavailable",
+                message: "POLICY_KV binding is required for upstream grant requests",
+                status: 503,
+            });
+        }
+    };
+    for key in upstream_grant_keys(provider, auth, oauth_provider, token_ref) {
+        let Some(mut grant) = get_upstream_grant(&kv, &key)
+            .await
+            .map_err(HeaderBuildError::Runtime)?
+        else {
             continue;
         };
-        let token = parse_oauth_token_record(&record).map_err(HeaderBuildError::Runtime)?;
-        if !token.enabled {
-            return Err(HeaderBuildError::Client {
-                code: "oauth_grant_revoked",
-                message: "OAuth grant is revoked for this proxy key",
-                status: 403,
-            });
+        if grant.refresh.is_none() && grant.refresh_token.is_some() {
+            grant.refresh = upstream_grant_refresh_from_manifest(provider);
         }
-        if token
-            .access_token
+        if grant
+            .provider
             .as_deref()
-            .is_none_or(|value| value.trim().is_empty())
+            .is_some_and(|grant_provider| grant_provider != provider.id)
         {
             return Err(HeaderBuildError::Client {
-                code: "oauth_grant_invalid",
-                message: "OAuth grant is missing an access token",
+                code: "upstream_grant_invalid",
+                message: "upstream grant does not match the requested provider",
                 status: 403,
             });
         }
-        return Ok(token);
+        if !grant.enabled {
+            return Err(HeaderBuildError::Client {
+                code: "upstream_grant_revoked",
+                message: "upstream grant is revoked for this policy",
+                status: 403,
+            });
+        }
+        if upstream_grant_needs_refresh(&grant) {
+            grant = refresh_upstream_grant(env, &kv, &key, grant, false).await?;
+        }
+        if !upstream_grant_usable(&grant) {
+            return Err(HeaderBuildError::Client {
+                code: "upstream_grant_invalid",
+                message: "upstream grant is missing a usable credential",
+                status: 403,
+            });
+        }
+        return Ok(Some(grant));
     }
-    Err(HeaderBuildError::Client {
-        code: "oauth_grant_missing",
-        message: "OAuth grant is not registered for this proxy key",
-        status: 403,
+    if required {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_missing",
+            message: "upstream grant is not registered for this policy",
+            status: 403,
+        });
+    }
+    Ok(None)
+}
+
+async fn refresh_upstream_grant(
+    env: &Env,
+    kv: &KvStore,
+    key: &str,
+    mut grant: UpstreamGrantRecord,
+    force: bool,
+) -> std::result::Result<UpstreamGrantRecord, HeaderBuildError> {
+    if !force && !upstream_grant_needs_refresh(&grant) {
+        return Ok(grant);
+    }
+    if !grant.enabled {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_revoked",
+            message: "upstream grant is revoked for this policy",
+            status: 403,
+        });
+    }
+    if !matches!(
+        grant.kind,
+        UpstreamGrantKind::OAuth | UpstreamGrantKind::Subscription
+    ) {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_not_refreshable",
+            message: "upstream grant kind cannot be refreshed",
+            status: 409,
+        });
+    }
+    let Some(refresh_token) = grant
+        .refresh_token
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_not_refreshable",
+            message: "upstream grant has no refresh token",
+            status: 409,
+        });
+    };
+    let Some(refresh) = grant.refresh.as_ref() else {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_not_refreshable",
+            message: "upstream grant has no refresh configuration",
+            status: 409,
+        });
+    };
+    let Some(provider_id) = grant.provider.as_deref() else {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_not_refreshable",
+            message: "upstream grant must identify its provider before refresh",
+            status: 409,
+        });
+    };
+    let snapshot = provider_snapshot().map_err(HeaderBuildError::Runtime)?;
+    let Some(provider) = snapshot
+        .providers
+        .iter()
+        .find(|provider| provider.id == provider_id)
+    else {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_not_refreshable",
+            message: "upstream grant provider is not registered",
+            status: 409,
+        });
+    };
+    if !provider_approves_refresh(provider, refresh) {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_refresh_not_approved",
+            message: "provider manifest does not approve this refresh configuration",
+            status: 409,
+        });
+    }
+    let client_id = match (
+        refresh
+            .client_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty()),
+        refresh.client_id_config.as_deref(),
+    ) {
+        (Some(client_id), _) => client_id.to_string(),
+        (None, Some(config)) => {
+            exact_runtime_config_value(env, config).map_err(|_| HeaderBuildError::Client {
+                code: "upstream_grant_refresh_not_configured",
+                message: "OAuth refresh client configuration is missing",
+                status: 503,
+            })?
+        }
+        (None, None) => {
+            return Err(HeaderBuildError::Client {
+                code: "upstream_grant_refresh_not_configured",
+                message: "OAuth refresh client configuration is missing",
+                status: 503,
+            });
+        }
+    };
+    let client_secret = refresh
+        .client_secret_config
+        .as_deref()
+        .map(|name| exact_runtime_config_value(env, name))
+        .transpose()
+        .map_err(|_| HeaderBuildError::Client {
+            code: "upstream_grant_refresh_not_configured",
+            message: "OAuth refresh client configuration is missing",
+            status: 503,
+        })?;
+    let mut form = BTreeMap::from([
+        ("client_id".to_string(), client_id),
+        ("grant_type".to_string(), "refresh_token".to_string()),
+        ("refresh_token".to_string(), refresh_token.to_string()),
+    ]);
+    if let Some(client_secret) = client_secret {
+        form.insert("client_secret".to_string(), client_secret);
+    }
+    for (name, value) in &refresh.extra_params {
+        form.insert(name.clone(), value.clone());
+    }
+    let body = form_urlencoded(&form);
+    let headers = Headers::new();
+    headers
+        .set("accept", "application/json")
+        .map_err(HeaderBuildError::Runtime)?;
+    headers
+        .set("content-type", "application/x-www-form-urlencoded")
+        .map_err(HeaderBuildError::Runtime)?;
+    let mut init = RequestInit::new();
+    init.with_method(Method::Post)
+        .with_headers(headers)
+        .with_body(Some(JsValue::from_str(&body)));
+    let request =
+        Request::new_with_init(&refresh.token_url, &init).map_err(HeaderBuildError::Runtime)?;
+    let mut response =
+        Fetch::Request(request)
+            .send()
+            .await
+            .map_err(|_| HeaderBuildError::Client {
+                code: "upstream_grant_refresh_failed",
+                message: "upstream OAuth refresh request failed",
+                status: 502,
+            })?;
+    if !(200..=299).contains(&response.status_code()) {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_refresh_failed",
+            message: "upstream OAuth refresh request was rejected",
+            status: 502,
+        });
+    }
+    let refreshed =
+        response
+            .json::<OAuthRefreshResponse>()
+            .await
+            .map_err(|_| HeaderBuildError::Client {
+                code: "upstream_grant_refresh_failed",
+                message: "upstream OAuth refresh response was invalid",
+                status: 502,
+            })?;
+    if refreshed.access_token.trim().is_empty() {
+        return Err(HeaderBuildError::Client {
+            code: "upstream_grant_refresh_failed",
+            message: "upstream OAuth refresh response was invalid",
+            status: 502,
+        });
+    }
+    grant.access_token = Some(refreshed.access_token);
+    if let Some(refresh_token) = refreshed
+        .refresh_token
+        .filter(|value| !value.trim().is_empty())
+    {
+        grant.refresh_token = Some(refresh_token);
+    }
+    if let Some(token_type) = refreshed
+        .token_type
+        .filter(|value| !value.trim().is_empty())
+    {
+        grant.token_type = token_type;
+    }
+    if let Some(expires_in) = refreshed.expires_in {
+        grant.expires_at = Some(timestamp_after_seconds(expires_in));
+    }
+    if let Some(scope) = refreshed.scope {
+        grant.scopes = normalize_grant_scopes(
+            scope
+                .split_ascii_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|_| HeaderBuildError::Client {
+            code: "upstream_grant_refresh_failed",
+            message: "upstream OAuth refresh response was invalid",
+            status: 502,
+        })?;
+    }
+    grant.updated_at = Some(current_iso_timestamp());
+    put_kv_record(kv, key, &grant, "refreshed upstream grant")
+        .await
+        .map_err(HeaderBuildError::Runtime)?;
+    Ok(grant)
+}
+
+fn provider_approves_refresh(provider: &CompiledProvider, refresh: &UpstreamGrantRefresh) -> bool {
+    provider.auth.refresh.as_ref().is_some_and(|approved| {
+        approved.token_url == refresh.token_url
+            && approved.client_id == refresh.client_id
+            && approved.client_id_config == refresh.client_id_config
+            && approved.client_secret_config == refresh.client_secret_config
+            && approved.extra_params == refresh.extra_params
     })
 }
 
-fn parse_oauth_token_record(raw: &str) -> Result<OAuthTokenRecord> {
+fn upstream_grant_refresh_from_manifest(
+    provider: &CompiledProvider,
+) -> Option<UpstreamGrantRefresh> {
+    let refresh = provider.auth.refresh.as_ref()?;
+    Some(UpstreamGrantRefresh {
+        token_url: refresh.token_url.clone(),
+        client_id: refresh.client_id.clone(),
+        client_id_config: refresh.client_id_config.clone(),
+        client_secret_config: refresh.client_secret_config.clone(),
+        extra_params: refresh.extra_params.clone(),
+    })
+}
+
+fn exact_runtime_config_value(env: &Env, name: &str) -> Result<String> {
+    if let Ok(secret) = env.secret(name) {
+        let value = secret.to_string();
+        if !value.trim().is_empty() {
+            return Ok(value);
+        }
+    }
+    if let Ok(var) = env.var(name) {
+        let value = var.to_string();
+        if !value.trim().is_empty() {
+            return Ok(value);
+        }
+    }
+    Err(Error::RustError(format!(
+        "missing Cloudflare config value `{name}`"
+    )))
+}
+
+fn form_urlencoded(values: &BTreeMap<String, String>) -> String {
+    values
+        .iter()
+        .map(|(name, value)| format!("{}={}", encode_component(name), encode_component(value)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn timestamp_after_seconds(seconds: u64) -> String {
+    let date = js_sys::Date::new(&JsValue::from_f64(
+        js_sys::Date::now() + seconds as f64 * 1_000.0,
+    ));
+    date.to_iso_string().into()
+}
+
+fn parse_upstream_grant_record(raw: &str) -> Result<UpstreamGrantRecord> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Err(Error::RustError("OAuth token grant is empty".to_string()));
+        return Err(Error::RustError("upstream grant is empty".to_string()));
     }
     if !trimmed.starts_with('{') {
-        return Ok(OAuthTokenRecord {
+        return Ok(UpstreamGrantRecord {
+            version: default_upstream_grant_version(),
             enabled: true,
+            kind: UpstreamGrantKind::OAuth,
+            provider: None,
+            label: None,
+            credential: None,
             access_token: Some(trimmed.to_string()),
+            refresh_token: None,
             token_type: default_oauth_token_type(),
+            expires_at: None,
+            scopes: Vec::new(),
+            account_id: None,
+            subscription: None,
+            refresh: None,
+            created_at: None,
+            updated_at: None,
+            revoked_at: None,
         });
     }
     serde_json::from_str(trimmed)
-        .map_err(|error| Error::RustError(format!("OAuth token grant is invalid JSON: {error}")))
+        .map_err(|error| Error::RustError(format!("upstream grant is invalid JSON: {error}")))
 }
 
-fn oauth_token_keys(
+fn upstream_grant_keys(
     provider: &CompiledProvider,
     auth: &AuthorizedKey,
     oauth_provider: Option<&str>,
     token_ref: Option<&str>,
 ) -> Vec<String> {
-    let mut keys = Vec::new();
+    let mut refs = Vec::new();
     if let Some(token_ref) = token_ref.filter(|value| !value.is_empty()) {
-        keys.push(format!("oauth/{}/{}", auth.policy_id, token_ref));
-        if let Some(tenant) = auth
-            .policy
-            .tenant_id
-            .as_deref()
-            .filter(|value| !value.is_empty())
-        {
-            keys.push(format!("oauth/tenants/{tenant}/{token_ref}"));
-        }
+        refs.push(token_ref.to_string());
     }
     if let Some(oauth_provider) = oauth_provider.filter(|value| !value.is_empty()) {
-        keys.push(format!("oauth/{}/{}", auth.policy_id, oauth_provider));
-        if let Some(tenant) = auth
-            .policy
-            .tenant_id
-            .as_deref()
-            .filter(|value| !value.is_empty())
-        {
-            keys.push(format!("oauth/tenants/{tenant}/{oauth_provider}"));
-        }
+        refs.push(oauth_provider.to_string());
     }
-    keys.push(format!("oauth/{}/{}", auth.policy_id, provider.id));
+    refs.push(provider.id.clone());
+    dedupe_preserving_order(&mut refs);
+
+    let mut keys = refs
+        .iter()
+        .map(|token_ref| format!("oauth/{}/{token_ref}", auth.policy_id))
+        .collect::<Vec<_>>();
     if let Some(tenant) = auth
         .policy
         .tenant_id
         .as_deref()
         .filter(|value| !value.is_empty())
     {
-        keys.push(format!("oauth/tenants/{tenant}/{}", provider.id));
+        keys.extend(
+            refs.iter()
+                .map(|token_ref| format!("oauth/tenants/{tenant}/{token_ref}")),
+        );
     }
-    dedupe_preserving_order(&mut keys);
     keys
 }
 
@@ -7196,19 +8406,21 @@ fn aws_amz_date_now() -> Result<String> {
     Ok(format!("{date}T{time}Z"))
 }
 
-fn query_api_key(
+fn query_api_key_for_grant(
     provider: &CompiledProvider,
-    env: Option<&Env>,
-) -> Result<Option<(String, String)>> {
-    let Some(env) = env else {
-        return Ok(None);
-    };
+    env: &Env,
+    grant: Option<&UpstreamGrantRecord>,
+) -> std::result::Result<Option<(String, String)>, HeaderBuildError> {
     for scheme in &provider.auth.schemes {
         if let AuthScheme::QueryApiKey { param, secret_kind } = scheme {
-            return Ok(Some((
-                param.clone(),
-                provider_secret(env, provider, secret_kind)?,
-            )));
+            let secret = grant
+                .and_then(upstream_grant_secret)
+                .map(str::to_string)
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    provider_secret(env, provider, secret_kind).map_err(HeaderBuildError::Runtime)
+                })?;
+            return Ok(Some((param.clone(), secret)));
         }
     }
     Ok(None)
@@ -9887,6 +11099,31 @@ mod tests {
         provider
     }
 
+    fn subscription_test_grant(provider: &str) -> UpstreamGrantRecord {
+        UpstreamGrantRecord {
+            version: 1,
+            enabled: true,
+            kind: UpstreamGrantKind::Subscription,
+            provider: Some(provider.to_string()),
+            label: Some("maintainer subscription".to_string()),
+            credential: None,
+            access_token: Some("test-access-token".to_string()),
+            refresh_token: Some("test-refresh-token".to_string()),
+            token_type: "Bearer".to_string(),
+            expires_at: None,
+            scopes: vec!["openid".to_string()],
+            account_id: Some("acct_test".to_string()),
+            subscription: Some(UpstreamGrantSubscription {
+                plan: Some("plus".to_string()),
+                subject: Some("subject_test".to_string()),
+            }),
+            refresh: None,
+            created_at: Some("2026-06-16T00:00:00.000Z".to_string()),
+            updated_at: Some("2026-06-16T00:00:00.000Z".to_string()),
+            revoked_at: None,
+        }
+    }
+
     fn entitlement_test_row(
         provider: &str,
         allowed: bool,
@@ -9912,6 +11149,7 @@ mod tests {
                 connection_enabled: true,
                 oauth_grant_required: false,
                 oauth_grant_count: 0,
+                upstream_grant_count: 0,
                 openai_compatible: true,
                 manifest_routes: 1,
                 model_count: 1,
@@ -11525,36 +12763,36 @@ mod tests {
     }
 
     #[test]
-    fn provider_oauth_refs_cover_token_ref_and_provider_fallbacks() {
+    fn provider_upstream_grant_refs_cover_token_ref_and_provider_fallbacks() {
         let provider = oauth_test_provider();
-        let refs = provider_oauth_refs(&provider);
+        let refs = provider_upstream_grant_refs(&provider);
 
         assert!(refs.iter().any(|value| value == "/oauth.acme.access_token"));
         assert!(refs.iter().any(|value| value == "/acme-oauth"));
     }
 
     #[test]
-    fn provider_oauth_grant_count_requires_enabled_token_records() {
+    fn provider_upstream_grant_count_requires_enabled_usable_records() {
         let provider = oauth_test_provider();
         let grants = vec![
             OAuthGrantRecord {
                 key: "oauth/svc_docs/oauth.acme.access_token".to_string(),
                 enabled: true,
-                has_access_token: true,
+                usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/default/acme-oauth".to_string(),
                 enabled: false,
-                has_access_token: true,
+                usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
                 enabled: true,
-                has_access_token: false,
+                usable: false,
             },
         ];
 
-        assert_eq!(provider_oauth_grant_count(&provider, &grants), 1);
+        assert_eq!(provider_upstream_grant_count(&provider, &grants), 1);
     }
 
     #[test]
@@ -11563,17 +12801,17 @@ mod tests {
             OAuthGrantRecord {
                 key: "oauth/svc_docs/acme-oauth".to_string(),
                 enabled: true,
-                has_access_token: true,
+                usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/tenants/research/acme-oauth".to_string(),
                 enabled: true,
-                has_access_token: true,
+                usable: true,
             },
             OAuthGrantRecord {
                 key: "oauth/svc_other/acme-oauth".to_string(),
                 enabled: true,
-                has_access_token: true,
+                usable: true,
             },
         ];
         let docs = AccessPolicyEntry {
@@ -11634,7 +12872,7 @@ mod tests {
         let grants = vec![OAuthGrantRecord {
             key: "oauth/svc_research/acme-oauth".to_string(),
             enabled: true,
-            has_access_token: true,
+            usable: true,
         }];
 
         let entries = [&docs, &research];
@@ -11662,7 +12900,8 @@ mod tests {
             query: Map::from_iter([("topic".to_string(), Value::String("news".to_string()))]),
             ..ManifestProxyRequest::default()
         };
-        let url = manifest_upstream_url(provider, endpoint, &proxy, None).unwrap();
+        let url =
+            manifest_upstream_url(provider, endpoint, &proxy, None, None, None, None).unwrap();
         assert_eq!(url, "https://api.tavily.com/search?topic=news");
     }
 
@@ -11702,6 +12941,103 @@ mod tests {
             "/v1beta/models/gemini-2.5-pro:generateContent"
         )
         .is_none());
+    }
+
+    #[test]
+    fn openai_subscription_grants_use_the_manifest_codex_transport() {
+        let snapshot = provider_snapshot().unwrap();
+        let provider = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "openai")
+            .unwrap();
+        let grant = subscription_test_grant("openai");
+        let responses = provider
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "responses")
+            .unwrap();
+        let chat = provider
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "chat_completions")
+            .unwrap();
+
+        assert_eq!(
+            provider_upstream_base_url(provider, Some(&grant)).unwrap(),
+            "https://chatgpt.com/backend-api/codex"
+        );
+        assert_eq!(
+            grant_transport_endpoint_path(provider, responses, Some(&grant)).unwrap(),
+            Some("/responses".to_string())
+        );
+        assert!(matches!(
+            grant_transport_endpoint_path(provider, chat, Some(&grant)),
+            Err(HeaderBuildError::Client {
+                code: "upstream_grant_transport_unsupported",
+                ..
+            })
+        ));
+        assert_eq!(
+            resolve_grant_template("${grant.accountId}", &grant).unwrap(),
+            "acct_test"
+        );
+    }
+
+    #[test]
+    fn upstream_grant_admin_metadata_never_serializes_secrets() {
+        let grant = subscription_test_grant("openai");
+        let value = serde_json::to_value(
+            admin_upstream_grant_response("oauth/svc_docs/openai", &grant).unwrap(),
+        )
+        .unwrap();
+        let raw = serde_json::to_string(&value).unwrap();
+
+        assert_eq!(value["scope"], "policies");
+        assert_eq!(value["scopeId"], "svc_docs");
+        assert_eq!(value["tokenRef"], "openai");
+        assert_eq!(value["hasAccessToken"], true);
+        assert_eq!(value["hasRefreshToken"], true);
+        assert!(!raw.contains("test-access-token"));
+        assert!(!raw.contains("test-refresh-token"));
+    }
+
+    #[test]
+    fn upstream_grant_secret_shapes_do_not_cross_kind_boundaries() {
+        let mut grant = subscription_test_grant("openai");
+        grant.kind = UpstreamGrantKind::ApiKey;
+        grant.credential = None;
+        assert!(upstream_grant_secret(&grant).is_none());
+        assert!(validate_upstream_grant_secret_shape(&grant).is_err());
+
+        grant.kind = UpstreamGrantKind::OAuth;
+        grant.access_token = None;
+        grant.refresh_token = None;
+        grant.credential = Some("api-key-placeholder".to_string());
+        assert!(upstream_grant_secret(&grant).is_none());
+        assert!(validate_upstream_grant_secret_shape(&grant).is_err());
+
+        grant.kind = UpstreamGrantKind::Subscription;
+        grant.access_token = Some("subscription-token-placeholder".to_string());
+        assert!(validate_upstream_grant_secret_shape(&grant).is_err());
+    }
+
+    #[test]
+    fn enabled_upstream_grants_require_revoke_before_identity_changes() {
+        let existing = subscription_test_grant("openai");
+        let mut changed_kind = existing.clone();
+        changed_kind.kind = UpstreamGrantKind::OAuth;
+        assert_eq!(
+            normalize_upstream_grant(changed_kind, Some(&existing)).unwrap_err(),
+            "revoke an enabled grant before changing its kind"
+        );
+
+        let mut changed_provider = existing.clone();
+        changed_provider.provider = Some("anthropic".to_string());
+        assert_eq!(
+            normalize_upstream_grant(changed_provider, Some(&existing)).unwrap_err(),
+            "revoke an enabled grant before changing its provider"
+        );
     }
 
     #[test]
@@ -11789,7 +13125,8 @@ mod tests {
             )]),
             ..ManifestProxyRequest::default()
         };
-        let url = manifest_upstream_url(provider, endpoint, &proxy, None).unwrap();
+        let url =
+            manifest_upstream_url(provider, endpoint, &proxy, None, None, None, None).unwrap();
         assert_eq!(url, "https://api.replicate.com/v1/predictions/abc%20123");
     }
 
@@ -11809,7 +13146,8 @@ mod tests {
             )]),
             ..ManifestProxyRequest::default()
         };
-        let url = manifest_upstream_url(&provider, endpoint, &proxy, None).unwrap();
+        let url =
+            manifest_upstream_url(&provider, endpoint, &proxy, None, None, None, None).unwrap();
         assert_eq!(url, "https://api.example.com/v1/repos/openclaw/clawrouter");
     }
 
@@ -11829,7 +13167,8 @@ mod tests {
             )]),
             ..ManifestProxyRequest::default()
         };
-        let error = manifest_upstream_url(&provider, endpoint, &proxy, None).unwrap_err();
+        let error =
+            manifest_upstream_url(&provider, endpoint, &proxy, None, None, None, None).unwrap_err();
         match error {
             ManifestProxyError::Client(message) => {
                 assert!(message.contains("safe relative path"));
@@ -11839,7 +13178,7 @@ mod tests {
     }
 
     #[test]
-    fn oauth_token_keys_prefer_key_token_ref_before_fallbacks() {
+    fn upstream_grant_keys_prefer_policy_scope_before_tenant_fallbacks() {
         let provider = oauth_test_provider();
         let auth = AuthorizedKey {
             credential_id: Some("cred_docs".to_string()),
@@ -11858,7 +13197,7 @@ mod tests {
         };
 
         assert_eq!(
-            oauth_token_keys(
+            upstream_grant_keys(
                 &provider,
                 &auth,
                 Some("acme-oauth"),
@@ -11866,32 +13205,32 @@ mod tests {
             ),
             vec![
                 "oauth/svc_docs/oauth.acme.access_token",
-                "oauth/tenants/team_docs/oauth.acme.access_token",
                 "oauth/svc_docs/acme-oauth",
-                "oauth/tenants/team_docs/acme-oauth",
                 "oauth/svc_docs/oauth-test",
+                "oauth/tenants/team_docs/oauth.acme.access_token",
+                "oauth/tenants/team_docs/acme-oauth",
                 "oauth/tenants/team_docs/oauth-test",
             ]
         );
     }
 
     #[test]
-    fn oauth_token_records_accept_json_or_raw_tokens() {
-        let json = parse_oauth_token_record(
+    fn upstream_grant_records_accept_json_or_raw_tokens() {
+        let json = parse_upstream_grant_record(
             r#"{"enabled":true,"accessToken":"gho_test","tokenType":"Bearer"}"#,
         )
         .unwrap();
         assert_eq!(json.access_token.as_deref(), Some("gho_test"));
         assert_eq!(json.token_type, "Bearer");
 
-        let raw = parse_oauth_token_record("xoxb-test").unwrap();
+        let raw = parse_upstream_grant_record("xoxb-test").unwrap();
         assert_eq!(raw.access_token.as_deref(), Some("xoxb-test"));
         assert_eq!(raw.token_type, "Bearer");
         let tombstone =
-            parse_oauth_token_record(r#"{"enabled":false,"tokenType":"Bearer"}"#).unwrap();
+            parse_upstream_grant_record(r#"{"enabled":false,"tokenType":"Bearer"}"#).unwrap();
         assert!(!tombstone.enabled);
         assert_eq!(tombstone.access_token, None);
-        assert!(parse_oauth_token_record("   ").is_err());
+        assert!(parse_upstream_grant_record("   ").is_err());
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -5819,7 +5819,7 @@ fn oauth_authorization_client_id(
 
 fn oauth_authorization_result_redirect(status: &str, provider: &str) -> Result<Response> {
     redirect_to(&format!(
-        "/dashboard/access?tab=upstream&oauth={}&provider={}",
+        "/dashboard/access?resource=upstream&oauth={}&provider={}",
         encode_component(status),
         encode_component(provider)
     ))
@@ -5937,6 +5937,15 @@ fn normalize_upstream_grant(
     merge_upstream_grant_secrets(&mut grant, existing);
     grant.credentials = normalize_grant_credentials(grant.credentials)?;
     validate_upstream_grant_secret_shape(&grant)?;
+    if grant.enabled
+        && provider
+            .as_ref()
+            .is_some_and(|provider| !upstream_grant_supports_provider(provider, &grant))
+    {
+        return Err(
+            "upstream grant credentials do not satisfy the provider auth contract".to_string(),
+        );
+    }
     if grant.refresh.is_none() && grant.refresh_token.is_some() {
         grant.refresh = provider
             .as_ref()
@@ -6580,13 +6589,26 @@ fn provider_auth_secret_config_keys(provider: &CompiledProvider) -> BTreeSet<Str
         .auth
         .schemes
         .iter()
-        .filter_map(|scheme| match scheme {
+        .flat_map(|scheme| match scheme {
             AuthScheme::Bearer { secret_kind, .. }
             | AuthScheme::ApiKey { secret_kind, .. }
             | AuthScheme::QueryApiKey { secret_kind, .. } => Some(secret_kind),
+            AuthScheme::SigV4 { .. } => None,
             _ => None,
         })
         .flat_map(|secret_kind| secret_binding_candidates(provider, secret_kind))
+        .chain(
+            provider
+                .auth
+                .schemes
+                .iter()
+                .filter(|scheme| matches!(scheme, AuthScheme::SigV4 { .. }))
+                .flat_map(|_| {
+                    ["access_key_id", "secret_access_key"]
+                        .into_iter()
+                        .flat_map(|name| template_binding_candidates(provider, name))
+                }),
+        )
         .collect()
 }
 
@@ -12695,6 +12717,13 @@ mod tests {
         assert!(template_binding_candidates(provider, "secret_access_key")
             .iter()
             .any(|binding| binding == "AWS_SECRET_ACCESS_KEY"));
+        assert_eq!(
+            provider_auth_secret_config_keys(provider),
+            BTreeSet::from([
+                "AWS_ACCESS_KEY_ID".to_string(),
+                "AWS_SECRET_ACCESS_KEY".to_string(),
+            ])
+        );
     }
 
     #[test]
@@ -14421,6 +14450,23 @@ mod tests {
         );
         assert!(!raw.contains("AKID_PLACEHOLDER"));
         assert!(!raw.contains("secret-placeholder"));
+    }
+
+    #[test]
+    fn sigv4_grants_reject_incomplete_provider_credentials() {
+        let mut grant = subscription_test_grant("aws-bedrock");
+        grant.kind = UpstreamGrantKind::ApiKey;
+        grant.credential = None;
+        grant.access_token = None;
+        grant.refresh_token = None;
+        grant.subscription = None;
+        grant.credentials =
+            BTreeMap::from([("accessKeyId".to_string(), "AKID_PLACEHOLDER".to_string())]);
+
+        assert_eq!(
+            normalize_upstream_grant(grant, None).unwrap_err(),
+            "upstream grant credentials do not satisfy the provider auth contract"
+        );
     }
 
     #[test]

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -279,6 +279,9 @@ PUT /v1/admin/access-users/<email>
 PUT /v1/admin/access-user-grants/<email>
 GET /v1/admin/policy-bindings
 PUT /v1/admin/policy-bindings
+GET /v1/admin/assignment-rules
+PUT /v1/admin/assignment-rules/<rule-id>
+POST /v1/admin/assignment-rules/reconcile
 ```
 
 `PUT /v1/admin/access-users/<email>` patches identity fields and preserves
@@ -313,6 +316,33 @@ copies:
 
 Lower priority numbers win when multiple bindings allow the same provider.
 
+Automatic assignment rules are stored separately from users and manual
+bindings. Exact-email and verified email-domain rules reconcile on first
+Cloudflare Access login and through the admin reconcile endpoint. Policy grants
+use a rule-owned `assignment.<rule-id>` group, so reconciliation never replaces
+manual direct user bindings. GitHub organization/team rules require explicit
+verified GitHub evidence for one user; a reconcile without GitHub evidence
+retains existing GitHub-derived assignments instead of treating unknown
+membership as loss.
+
+```json
+{
+  "enabled": true,
+  "kind": "email_domain",
+  "subject": "example.com",
+  "groups": ["maintainers"],
+  "policyIds": ["maintainer_models"],
+  "priority": 10,
+  "revokeOnLoss": true,
+  "provenance": "cloudflare_access"
+}
+```
+
+Use `POST /v1/admin/assignment-rules/reconcile` with `{"all":true}` to
+reconcile all known users against email rules. For a verified GitHub
+reconciliation, send one `email` plus an evidence object with `source:
+"github"`, `verified: true`, and normalized `githubOrgs`/`githubTeams`.
+
 The console also exposes a Cloudflare Access-backed playground for
 OpenAI-compatible routes and manifest-proxy service routes. Model playground
 calls send requests through `/v1/playground/*`; service playground calls send to
@@ -340,6 +370,7 @@ GET /v1/admin/policy-bindings
 GET /v1/admin/provider-status
 GET /v1/admin/provider-health
 GET /v1/admin/upstream-grants
+GET /v1/admin/assignment-rules
 PUT /v1/admin/access-users/<email>
 PUT /v1/admin/access-user-grants/<email>
 PUT /v1/admin/policy-bindings
@@ -347,10 +378,12 @@ PUT /v1/admin/policies/<policy-id>
 PUT /v1/admin/credentials/<credential-id>
 PUT /v1/admin/connections/<provider-id>
 PUT /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>
+PUT /v1/admin/assignment-rules/<rule-id>
 POST /v1/admin/policies/<policy-id>/revoke
 POST /v1/admin/credentials/<credential-id>/revoke
 POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke
 POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh
+POST /v1/admin/assignment-rules/reconcile
 ```
 
 Policies, credentials, and provider connections are separate control-plane

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -339,14 +339,18 @@ GET /v1/admin/access-users
 GET /v1/admin/policy-bindings
 GET /v1/admin/provider-status
 GET /v1/admin/provider-health
+GET /v1/admin/upstream-grants
 PUT /v1/admin/access-users/<email>
 PUT /v1/admin/access-user-grants/<email>
 PUT /v1/admin/policy-bindings
 PUT /v1/admin/policies/<policy-id>
 PUT /v1/admin/credentials/<credential-id>
 PUT /v1/admin/connections/<provider-id>
+PUT /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>
 POST /v1/admin/policies/<policy-id>/revoke
 POST /v1/admin/credentials/<credential-id>/revoke
+POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke
+POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh
 ```
 
 Policies, credentials, and provider connections are separate control-plane
@@ -466,39 +470,95 @@ accepted request. If `requestCostMicros` is omitted, ClawRouter charges one
 micro unit per request so budget enforcement still works for keys with a
 monthly budget.
 
-## OAuth Grants
+## Upstream Grants
 
-OAuth-backed providers read access tokens from `POLICY_KV`. Register a grant
-for one access policy:
+The compatibility `cf:oauth:*` helpers manage version 1 upstream grants in
+`POLICY_KV`. Despite their legacy names, the helpers support `api_key`, `oauth`,
+and `subscription` grants. Register an OAuth grant for one access policy:
 
 ```sh
 printf '%s' "$PROVIDER_ACCESS_TOKEN" | pnpm cf:oauth:put -- \
   --kid svc_docs \
-  --token-ref oauth.provider.access_token \
+  --token-ref openai \
+  --kind oauth \
+  --provider openai \
+  --label "maintainer OAuth" \
   --access-token-stdin
 ```
 
-Tenant-wide grants are also supported:
+Register a tenant-wide API-key grant:
 
 ```sh
 pnpm cf:oauth:put -- \
   --tenant default \
-  --token-ref oauth.provider.access_token \
-  --access-token-env PROVIDER_ACCESS_TOKEN
+  --token-ref anthropic \
+  --kind api_key \
+  --provider anthropic \
+  --label "primary API key" \
+  --credential-env ANTHROPIC_API_KEY
 ```
 
 This stores a grant at `oauth/<policy-id>/<tokenRef>` or
-`oauth/tenants/<tenant>/<tokenRef>`. Active grant records contain `enabled`,
-`accessToken`, and `tokenType`; the token is never printed by the helper.
+`oauth/tenants/<tenant>/<tokenRef>`. Canonical records contain `version: 1`,
+`enabled`, `kind`, `provider`, `label`, `tokenType`, `scopes`, timestamps, and
+the selected primary secret field. `api_key` grants require `credential`,
+`oauth` grants require `accessToken`, and `subscription` grants accept either.
+Use the provider id as `tokenRef` for the provider's default connection.
+Provider manifests may declare a different explicit token reference when a
+provider needs multiple named connection contracts.
+
+Secrets are never accepted in argv. Supply `accessToken`, `credential`, and an
+optional `refreshToken` only through the matching `--*-stdin`, `--*-env`, or
+`--*-file` option. Only one secret can use stdin in a single invocation. Other
+optional metadata flags are:
+
+- `--token-type`, `--expires-at`, `--scopes`, and `--account-id`
+- `--subscription-plan` and `--subscription-subject`
+- `--refresh-token-url`, `--refresh-client-id` or `--refresh-client-id-config`,
+  `--refresh-client-secret-config`, and `--refresh-extra-params-json`
+
+When a provider manifest declares standard refresh configuration, ClawRouter
+uses that manifest-approved configuration automatically. Explicit refresh flags
+are only for matching custom provider manifests. Refresh extra parameters must
+be non-secret string metadata. Store client secrets in Worker configuration and
+pass only the configuration binding name with
+`--refresh-client-secret-config`.
+
+For example, add refresh and subscription metadata without exposing either
+token in argv:
+
+```sh
+pnpm cf:oauth:put -- \
+  --kid svc_docs \
+  --token-ref openai \
+  --kind subscription \
+  --provider openai \
+  --label "maintainer subscription" \
+  --access-token-env PROVIDER_ACCESS_TOKEN \
+  --refresh-token-file .secrets/provider-refresh-token \
+  --expires-at 2026-06-16T12:00:00Z \
+  --scopes openid,profile \
+  --subscription-plan plus \
+  --subscription-subject "$PROVIDER_ACCOUNT_ID" \
+  --account-id "$PROVIDER_ACCOUNT_ID"
+```
+
+The bundled OpenAI manifest maps `subscription` grants to the ChatGPT Codex
+transport, injects the required account metadata, and refreshes through the
+manifest-declared OpenAI OAuth endpoint. OpenAI API-key grants continue to use
+the normal OpenAI Platform transport.
 
 Revoke a grant without deleting audit history:
 
 ```sh
-pnpm cf:oauth:revoke -- --kid svc_docs --token-ref oauth.provider.access_token
+pnpm cf:oauth:revoke -- --kid svc_docs --token-ref openai
 ```
 
-Revocation overwrites the grant with a disabled tombstone and removes the stored
-access token.
+Revocation overwrites the grant with a canonical disabled tombstone. It retains
+the grant's metadata and timestamps, adds `revokedAt`, and recursively removes
+stored access tokens, refresh tokens, credentials, and other recognized secret
+fields. When revoking a raw legacy token, pass `--kind`, `--provider`, and
+`--label` to attach identifying metadata to its tombstone.
 
 ## Proxy Routes
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -59,9 +59,10 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
 destinations are `/dashboard/*`, `/v1/session`, `/v1/entitlements`,
-`/v1/playground/*`, and `/v1/admin/*`. This stays within Cloudflare's
+`/v1/playground/*`, `/v1/admin/*`, and `/v1/oauth/callback`. This stays within Cloudflare's
 per-application destination limit while still protecting the console entrypoint
-and the Access-backed session, entitlement, playground, and admin APIs. Override
+and the Access-backed session, entitlement, playground, admin, and OAuth
+callback APIs. Override
 them with `CLAWROUTER_ACCESS_PATHS` only if the API contract changes. Do not add
 `/` on the shared API hostname: Cloudflare Access
 path inheritance would protect the public `/v1/*` API too. Root reaches Access
@@ -268,7 +269,8 @@ bootstrap entitlements/readiness payload when `POLICY_KV` is available.
 `GET /v1/entitlements` remains available for deployments that also protect that
 compatibility route. The admin UI can call admin routes through the same-origin
 Access session; the admin bearer token is only a fallback for automation or
-emergency access.
+emergency access. Browser OAuth providers return to `/v1/oauth/callback`, which
+must also require the same verified Access admin session that started the flow.
 
 Admins can inspect materialized Access users, update tenant/status/groups, and
 assign explicit user or group policy bindings in the console or API:
@@ -383,6 +385,7 @@ POST /v1/admin/policies/<policy-id>/revoke
 POST /v1/admin/credentials/<credential-id>/revoke
 POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke
 POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh
+POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/authorize
 POST /v1/admin/assignment-rules/reconcile
 ```
 
@@ -534,16 +537,17 @@ pnpm cf:oauth:put -- \
 This stores a grant at `oauth/<policy-id>/<tokenRef>` or
 `oauth/tenants/<tenant>/<tokenRef>`. Canonical records contain `version: 1`,
 `enabled`, `kind`, `provider`, `label`, `tokenType`, `scopes`, timestamps, and
-the selected primary secret field. `api_key` grants require `credential`,
-`oauth` grants require `accessToken`, and `subscription` grants accept either.
+the selected primary secret field. `api_key` grants require `credential` or a
+non-empty `credentials` string map, `oauth` grants require `accessToken`, and
+`subscription` grants accept either a credential or access token.
 Use the provider id as `tokenRef` for the provider's default connection.
 Provider manifests may declare a different explicit token reference when a
 provider needs multiple named connection contracts.
 
-Secrets are never accepted in argv. Supply `accessToken`, `credential`, and an
-optional `refreshToken` only through the matching `--*-stdin`, `--*-env`, or
-`--*-file` option. Only one secret can use stdin in a single invocation. Other
-optional metadata flags are:
+Secrets are never accepted in argv. Supply `accessToken`, `credential`,
+`credentials-json`, and an optional `refreshToken` only through the matching
+`--*-stdin`, `--*-env`, or `--*-file` option. Only one secret can use stdin in
+a single invocation. Other optional metadata flags are:
 
 - `--token-type`, `--expires-at`, `--scopes`, and `--account-id`
 - `--subscription-plan` and `--subscription-subject`
@@ -556,6 +560,20 @@ are only for matching custom provider manifests. Refresh extra parameters must
 be non-secret string metadata. Store client secrets in Worker configuration and
 pass only the configuration binding name with
 `--refresh-client-secret-config`.
+
+For SigV4 providers, store the canonical signing fields as a write-only
+credential bundle. Region remains a non-secret runtime binding:
+
+```sh
+export AWS_BEDROCK_CREDENTIALS='{"accessKeyId":"...","secretAccessKey":"...","sessionToken":"..."}'
+pnpm cf:oauth:put -- \
+  --kid svc_models \
+  --token-ref aws-bedrock \
+  --kind api_key \
+  --provider aws-bedrock \
+  --label "maintainer Bedrock" \
+  --credentials-json-env AWS_BEDROCK_CREDENTIALS
+```
 
 For example, add refresh and subscription metadata without exposing either
 token in argv:
@@ -581,6 +599,27 @@ transport, injects the required account metadata, and refreshes through the
 manifest-declared OpenAI OAuth endpoint. OpenAI API-key grants continue to use
 the normal OpenAI Platform transport.
 
+### Browser OAuth
+
+When a provider manifest declares `auth.authorization`, a verified Cloudflare
+Access admin can start its browser flow from the upstream-grants console or:
+
+```text
+POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/authorize
+{"provider":"openai"}
+```
+
+ClawRouter creates a one-time, ten-minute PKCE state bound to the Access admin,
+grant key, provider, and callback URI. The provider returns to
+`https://<clawrouter-host>/v1/oauth/callback`; ClawRouter consumes the state
+before exchanging the code and persists the canonical grant without exposing
+tokens to the browser. Admin bearer tokens cannot start or finish this browser
+flow.
+
+The provider OAuth client must allow that exact callback URI. Treat a provider
+as browser-OAuth-ready only after its redirect allowlist has been verified in
+the deployed environment.
+
 Revoke a grant without deleting audit history:
 
 ```sh
@@ -589,9 +628,10 @@ pnpm cf:oauth:revoke -- --kid svc_docs --token-ref openai
 
 Revocation overwrites the grant with a canonical disabled tombstone. It retains
 the grant's metadata and timestamps, adds `revokedAt`, and recursively removes
-stored access tokens, refresh tokens, credentials, and other recognized secret
-fields. When revoking a raw legacy token, pass `--kind`, `--provider`, and
-`--label` to attach identifying metadata to its tombstone.
+stored access tokens, refresh tokens, single credentials, credential bundles,
+and other recognized secret fields. When revoking a raw legacy token, pass
+`--kind`, `--provider`, and `--label` to attach identifying metadata to its
+tombstone.
 
 ## Proxy Routes
 

--- a/providers/README.md
+++ b/providers/README.md
@@ -63,6 +63,9 @@ billing:
 - `routing.modelPrefixes` maps model names like `openai/gpt-4.1-mini` to the
   provider snapshot.
 - `auth.schemes` declares how ClawRouter injects the upstream credential.
+- `auth.authorization` declares a provider-approved browser OAuth flow,
+  including its trusted endpoints, client configuration, scopes, grant kind,
+  and optional account metadata mappings.
 - `adapter` declares the request/response family. Use `custom_adapter` only after
   the declarative format cannot express the provider.
 - `billing.meter` and `billing.counters` produce OpenMeter/Lago/Meteroid style
@@ -91,8 +94,12 @@ or from request path params:
   executable today.
 - OAuth-backed REST providers are executable when `POLICY_KV` has a grant at
   `oauth/<kid>/<tokenRef>` or `oauth/tenants/<tenant>/<tokenRef>`.
-- SigV4 providers are executable when `service.configKeys` declares access key,
-  secret key, and region bindings. Session tokens are optional.
+- SigV4 providers are executable with an access/secret key credential bundle in
+  a scoped upstream grant plus the manifest-declared region binding. Worker
+  access/secret key bindings remain a fallback; session tokens are optional.
+- Browser OAuth is available only when the manifest declares
+  `auth.authorization`, and the provider OAuth client must allow ClawRouter's
+  `/v1/oauth/callback` URI.
 
 ## Smoke Coverage
 

--- a/providers/_schema/service-provider.schema.json
+++ b/providers/_schema/service-provider.schema.json
@@ -53,6 +53,9 @@
           "items": { "$ref": "#/$defs/authScheme" },
           "minItems": 1
         },
+        "authorization": {
+          "$ref": "#/$defs/authAuthorization"
+        },
         "refresh": {
           "$ref": "#/$defs/authRefresh"
         },
@@ -144,6 +147,34 @@
     }
   },
   "$defs": {
+    "authAuthorization": {
+      "type": "object",
+      "required": ["authorizeUrl", "tokenUrl", "scopes"],
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["clientId"] },
+        { "required": ["clientIdConfig"] }
+      ],
+      "properties": {
+        "authorizeUrl": { "type": "string", "pattern": "^https://" },
+        "tokenUrl": { "type": "string", "pattern": "^https://" },
+        "clientId": { "type": "string" },
+        "clientIdConfig": { "type": "string" },
+        "clientSecretConfig": { "type": "string" },
+        "scopes": { "type": "array", "items": { "type": "string" } },
+        "grantKind": { "enum": ["oauth", "subscription"] },
+        "extraAuthorizeParams": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "extraTokenParams": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "accountIdJsonPointer": { "type": "string", "pattern": "^/" },
+        "subscriptionPlanJsonPointer": { "type": "string", "pattern": "^/" }
+      }
+    },
     "authRefresh": {
       "type": "object",
       "required": ["tokenUrl"],

--- a/providers/_schema/service-provider.schema.json
+++ b/providers/_schema/service-provider.schema.json
@@ -218,8 +218,11 @@
       "properties": {
         "path": { "type": "string", "pattern": "^/" },
         "method": { "type": "string" },
+        "nativeProxy": { "type": "boolean" },
         "auth": { "type": "string" },
         "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+        "requestHeaders": { "type": "array", "items": { "type": "string" } },
+        "responseHeaders": { "type": "array", "items": { "type": "string" } },
         "query": { "type": "object", "additionalProperties": { "type": "string" } },
         "pathParams": { "type": "array", "items": { "type": "string" } },
         "pathParamStyles": {

--- a/providers/_schema/service-provider.schema.json
+++ b/providers/_schema/service-provider.schema.json
@@ -52,6 +52,13 @@
           "type": "array",
           "items": { "$ref": "#/$defs/authScheme" },
           "minItems": 1
+        },
+        "refresh": {
+          "$ref": "#/$defs/authRefresh"
+        },
+        "grantTransports": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/grantTransport" }
         }
       }
     },
@@ -137,6 +144,40 @@
     }
   },
   "$defs": {
+    "authRefresh": {
+      "type": "object",
+      "required": ["tokenUrl"],
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["clientId"] },
+        { "required": ["clientIdConfig"] }
+      ],
+      "properties": {
+        "tokenUrl": { "type": "string", "pattern": "^https://" },
+        "clientId": { "type": "string" },
+        "clientIdConfig": { "type": "string" },
+        "clientSecretConfig": { "type": "string" },
+        "extraParams": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "grantTransport": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "baseUrl": { "type": "string", "pattern": "^https://" },
+        "endpointPaths": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "pattern": "^/" }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
     "authScheme": {
       "oneOf": [
         {

--- a/providers/openai.provider.yaml
+++ b/providers/openai.provider.yaml
@@ -14,6 +14,18 @@ auth:
       header: Authorization
       format: "Bearer ${secret}"
       secretKind: api_key
+  refresh:
+    tokenUrl: https://auth.openai.com/oauth/token
+    clientId: app_EMoamEEZ73f0CkXaXp7hrann
+  grantTransports:
+    subscription:
+      baseUrl: https://chatgpt.com/backend-api/codex
+      endpointPaths:
+        responses: /responses
+      headers:
+        ChatGPT-Account-ID: "${grant.accountId}"
+        OpenAI-Beta: responses=experimental
+        originator: clawrouter
 baseUrls:
   default: https://api.openai.com
 routing:
@@ -39,6 +51,7 @@ capabilities:
 endpoints:
   responses:
     path: /v1/responses
+    requestHeaders: [session_id, x-client-request-id]
     requestFormat: openai.responses
     responseFormat: openai.responses
     streaming: sse

--- a/providers/openai.provider.yaml
+++ b/providers/openai.provider.yaml
@@ -14,6 +14,18 @@ auth:
       header: Authorization
       format: "Bearer ${secret}"
       secretKind: api_key
+  authorization:
+    authorizeUrl: https://auth.openai.com/oauth/authorize
+    tokenUrl: https://auth.openai.com/oauth/token
+    clientId: app_EMoamEEZ73f0CkXaXp7hrann
+    scopes: [openid, profile, email, offline_access]
+    grantKind: subscription
+    extraAuthorizeParams:
+      id_token_add_organizations: "true"
+      codex_cli_simplified_flow: "true"
+      originator: clawrouter
+    accountIdJsonPointer: /https:~1~1api.openai.com~1auth/chatgpt_account_id
+    subscriptionPlanJsonPointer: /https:~1~1api.openai.com~1auth/chatgpt_plan_type
   refresh:
     tokenUrl: https://auth.openai.com/oauth/token
     clientId: app_EMoamEEZ73f0CkXaXp7hrann

--- a/scripts/oauth-put.mjs
+++ b/scripts/oauth-put.mjs
@@ -13,8 +13,9 @@ const label = optionalValue(args, "label");
 assertSingleStdinSecret(args);
 const accessToken = readSecret(args, "access-token");
 const credential = readSecret(args, "credential");
+const credentials = parseSecretStringMap(readSecret(args, "credentials-json"), "--credentials-json");
 const refreshToken = readSecret(args, "refresh-token");
-validatePrimarySecret(kind, { accessToken, credential });
+validatePrimarySecret(kind, { accessToken, credential, credentials });
 if (kind === "api_key" && refreshToken) {
   throw new Error("--refresh-token-* is only supported for oauth and subscription grants");
 }
@@ -41,6 +42,7 @@ setOptional(grant, "provider", provider);
 setOptional(grant, "label", label);
 setOptional(grant, "accessToken", accessToken);
 setOptional(grant, "credential", credential);
+setOptional(grant, "credentials", credentials);
 setOptional(grant, "refreshToken", refreshToken);
 setOptional(grant, "expiresAt", parseTimestamp(optionalValue(args, "expires-at"), "--expires-at"));
 setOptional(grant, "accountId", optionalValue(args, "account-id"));
@@ -140,7 +142,7 @@ function readSecret(args, name) {
 }
 
 function assertSingleStdinSecret(args) {
-  const stdinSecrets = ["access-token", "credential", "refresh-token"].filter(
+  const stdinSecrets = ["access-token", "credential", "credentials-json", "refresh-token"].filter(
     (name) => args[`${name}-stdin`] !== undefined,
   );
   if (stdinSecrets.length > 1) {
@@ -148,12 +150,12 @@ function assertSingleStdinSecret(args) {
   }
 }
 
-function validatePrimarySecret(kind, { accessToken, credential }) {
-  if (accessToken && credential) {
-    throw new Error("use exactly one primary secret: accessToken or credential");
+function validatePrimarySecret(kind, { accessToken, credential, credentials }) {
+  if ([accessToken, credential, credentials].filter(Boolean).length > 1) {
+    throw new Error("use exactly one primary secret: accessToken, credential, or credentials");
   }
-  if (kind === "api_key" && !credential) {
-    throw new Error("api_key grants require --credential-stdin, --credential-env, or --credential-file");
+  if (kind === "api_key" && !credential && !credentials) {
+    throw new Error("api_key grants require credential or credentials-json from stdin, env, or file");
   }
   if (kind === "oauth" && !accessToken) {
     throw new Error("oauth grants require --access-token-stdin, --access-token-env, or --access-token-file");
@@ -163,6 +165,28 @@ function validatePrimarySecret(kind, { accessToken, credential }) {
       "subscription grants require an accessToken or credential supplied through stdin, env, or file",
     );
   }
+}
+
+function parseSecretStringMap(value, name) {
+  if (!value) {
+    return undefined;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${name} must be valid JSON`);
+  }
+  if (
+    !parsed ||
+    Array.isArray(parsed) ||
+    typeof parsed !== "object" ||
+    Object.keys(parsed).length === 0 ||
+    Object.values(parsed).some((item) => typeof item !== "string" || !item)
+  ) {
+    throw new Error(`${name} must be a non-empty JSON object with non-empty string values`);
+  }
+  return parsed;
 }
 
 function parseKind(value) {

--- a/scripts/oauth-put.mjs
+++ b/scripts/oauth-put.mjs
@@ -7,21 +7,45 @@ const args = parseArgs(process.argv.slice(2));
 const kid = args.kid;
 const tenant = args.tenant;
 const tokenRef = required(args["token-ref"] ?? args.provider, "--token-ref or --provider");
-const accessToken = readAccessToken(args);
-const tokenType = args["token-type"] ?? "Bearer";
+const kind = parseKind(args.kind ?? "oauth");
+const provider = optionalValue(args, "provider");
+const label = optionalValue(args, "label");
+assertSingleStdinSecret(args);
+const accessToken = readSecret(args, "access-token");
+const credential = readSecret(args, "credential");
+const refreshToken = readSecret(args, "refresh-token");
+validatePrimarySecret(kind, { accessToken, credential });
+if (kind === "api_key" && refreshToken) {
+  throw new Error("--refresh-token-* is only supported for oauth and subscription grants");
+}
+const tokenType = optionalValue(args, "token-type") ?? "Bearer";
 const binding = args.binding ?? "POLICY_KV";
 const config = args.config ?? ".wrangler.generated.toml";
 
-if (!kid && !tenant) {
-  throw new Error("--kid or --tenant is required");
+if (Boolean(kid) === Boolean(tenant)) {
+  throw new Error("exactly one of --kid or --tenant is required");
 }
 
 const key = kid ? `oauth/${kid}/${tokenRef}` : `oauth/tenants/${tenant}/${tokenRef}`;
+const now = new Date().toISOString();
 const grant = {
+  version: 1,
   enabled: true,
-  accessToken,
+  kind,
   tokenType,
+  scopes: parseList(optionalValue(args, "scopes")),
+  createdAt: now,
+  updatedAt: now,
 };
+setOptional(grant, "provider", provider);
+setOptional(grant, "label", label);
+setOptional(grant, "accessToken", accessToken);
+setOptional(grant, "credential", credential);
+setOptional(grant, "refreshToken", refreshToken);
+setOptional(grant, "expiresAt", parseTimestamp(optionalValue(args, "expires-at"), "--expires-at"));
+setOptional(grant, "accountId", optionalValue(args, "account-id"));
+setOptional(grant, "subscription", subscriptionMetadata(args));
+setOptional(grant, "refresh", refreshMetadata(args));
 const grantPath = writeSecretJson(grant);
 
 try {
@@ -45,7 +69,7 @@ try {
   rmSync(join(grantPath, ".."), { force: true, recursive: true });
 }
 
-console.log(`stored OAuth grant ${key}; token was not printed`);
+console.log(`stored canonical upstream grant ${key}; secrets were not printed`);
 
 function parseArgs(values) {
   const out = {};
@@ -66,28 +90,189 @@ function parseArgs(values) {
 }
 
 function required(value, name) {
-  if (!value) {
+  if (typeof value !== "string" || !value.trim()) {
     throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function requiredOption(args, name) {
+  return required(optionalValue(args, name), `--${name}`);
+}
+
+function optionalValue(args, name) {
+  const value = args[name];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === true) {
+    throw new Error(`--${name} requires a value`);
+  }
+  return value.trim();
+}
+
+function readSecret(args, name) {
+  if (args[name] !== undefined) {
+    throw new Error(
+      `--${name} would expose the secret in process argv; use --${name}-stdin, --${name}-env, or --${name}-file`,
+    );
+  }
+  const envName = optionalValue(args, `${name}-env`);
+  const file = optionalValue(args, `${name}-file`);
+  const stdin = args[`${name}-stdin`];
+  if (stdin !== undefined && stdin !== true) {
+    throw new Error(`--${name}-stdin is a flag and does not accept a value`);
+  }
+  const sourceCount = [envName, file, stdin === true].filter(Boolean).length;
+  if (sourceCount > 1) {
+    throw new Error(`use only one of --${name}-stdin, --${name}-env, or --${name}-file`);
+  }
+  if (envName) {
+    return required(process.env[envName], `env ${envName}`);
+  }
+  if (file) {
+    return required(readFileSync(file, "utf8").trim(), `--${name}-file`);
+  }
+  if (stdin) {
+    return required(readFileSync(0, "utf8").trim(), `stdin ${name}`);
+  }
+  return undefined;
+}
+
+function assertSingleStdinSecret(args) {
+  const stdinSecrets = ["access-token", "credential", "refresh-token"].filter(
+    (name) => args[`${name}-stdin`] !== undefined,
+  );
+  if (stdinSecrets.length > 1) {
+    throw new Error("only one secret may be read from stdin; use env or file for other secrets");
+  }
+}
+
+function validatePrimarySecret(kind, { accessToken, credential }) {
+  if (accessToken && credential) {
+    throw new Error("use exactly one primary secret: accessToken or credential");
+  }
+  if (kind === "api_key" && !credential) {
+    throw new Error("api_key grants require --credential-stdin, --credential-env, or --credential-file");
+  }
+  if (kind === "oauth" && !accessToken) {
+    throw new Error("oauth grants require --access-token-stdin, --access-token-env, or --access-token-file");
+  }
+  if (kind === "subscription" && !accessToken && !credential) {
+    throw new Error(
+      "subscription grants require an accessToken or credential supplied through stdin, env, or file",
+    );
+  }
+}
+
+function parseKind(value) {
+  if (!["api_key", "oauth", "subscription"].includes(value)) {
+    throw new Error("--kind must be api_key, oauth, or subscription");
   }
   return value;
 }
 
-function readAccessToken(args) {
-  if (args["access-token"]) {
-    throw new Error(
-      "--access-token would expose the token in process argv; use --access-token-stdin, --access-token-env, or --access-token-file",
-    );
+function parseList(value) {
+  if (!value) {
+    return [];
   }
-  if (args["access-token-env"]) {
-    return required(process.env[args["access-token-env"]], `env ${args["access-token-env"]}`);
+  return [...new Set(value.split(",").map((item) => item.trim()).filter(Boolean))];
+}
+
+function parseTimestamp(value, name) {
+  if (!value) {
+    return undefined;
   }
-  if (args["access-token-file"]) {
-    return required(readFileSync(args["access-token-file"], "utf8").trim(), "--access-token-file");
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.valueOf())) {
+    throw new Error(`${name} must be a valid timestamp`);
   }
-  if (args["access-token-stdin"]) {
-    return required(readFileSync(0, "utf8").trim(), "stdin token");
+  return timestamp.toISOString();
+}
+
+function subscriptionMetadata(args) {
+  const plan = optionalValue(args, "subscription-plan");
+  const subject = optionalValue(args, "subscription-subject");
+  if (!plan && !subject) {
+    return undefined;
   }
-  throw new Error("--access-token-stdin, --access-token-env, or --access-token-file is required");
+  return compact({ plan, subject });
+}
+
+function refreshMetadata(args) {
+  const tokenUrl = optionalValue(args, "refresh-token-url");
+  const clientId = optionalValue(args, "refresh-client-id");
+  const clientIdConfig = optionalValue(args, "refresh-client-id-config");
+  const clientSecretConfig = optionalValue(args, "refresh-client-secret-config");
+  const extraParams = parseStringMap(
+    optionalValue(args, "refresh-extra-params-json"),
+    "--refresh-extra-params-json",
+  );
+  if (!tokenUrl && !clientId && !clientIdConfig && !clientSecretConfig && !extraParams) {
+    return undefined;
+  }
+  if (clientId && clientIdConfig) {
+    throw new Error("use only one of --refresh-client-id or --refresh-client-id-config");
+  }
+  return {
+    tokenUrl: required(tokenUrl, "--refresh-token-url"),
+    ...(clientId
+      ? { clientId }
+      : { clientIdConfig: required(clientIdConfig, "--refresh-client-id or --refresh-client-id-config") }),
+    ...(clientSecretConfig ? { clientSecretConfig } : {}),
+    extraParams: extraParams ?? {},
+  };
+}
+
+function parseStringMap(value, name) {
+  if (!value) {
+    return undefined;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${name} must be valid JSON`);
+  }
+  if (
+    !parsed ||
+    Array.isArray(parsed) ||
+    typeof parsed !== "object" ||
+    Object.values(parsed).some((item) => typeof item !== "string")
+  ) {
+    throw new Error(`${name} must be a JSON object with string values`);
+  }
+  if (Object.keys(parsed).some(isSecretFieldName)) {
+    throw new Error(`${name} must not contain secret fields`);
+  }
+  return parsed;
+}
+
+function isSecretFieldName(name) {
+  return [
+    "accessToken",
+    "access_token",
+    "refreshToken",
+    "refresh_token",
+    "credential",
+    "apiKey",
+    "api_key",
+    "token",
+    "secret",
+    "clientSecret",
+    "client_secret",
+    "password",
+  ].includes(name);
+}
+
+function compact(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
+}
+
+function setOptional(target, name, value) {
+  if (value !== undefined) {
+    target[name] = value;
+  }
 }
 
 function run(command, args) {

--- a/scripts/oauth-revoke.mjs
+++ b/scripts/oauth-revoke.mjs
@@ -10,8 +10,8 @@ const tokenRef = required(args["token-ref"] ?? args.provider, "--token-ref or --
 const binding = args.binding ?? "POLICY_KV";
 const config = args.config ?? ".wrangler.generated.toml";
 
-if (!kid && !tenant) {
-  throw new Error("--kid or --tenant is required");
+if (Boolean(kid) === Boolean(tenant)) {
+  throw new Error("exactly one of --kid or --tenant is required");
 }
 
 const key = kid ? `oauth/${kid}/${tokenRef}` : `oauth/tenants/${tenant}/${tokenRef}`;
@@ -53,24 +53,81 @@ try {
   rmSync(join(grantPath, ".."), { force: true, recursive: true });
 }
 
-console.log(`revoked OAuth grant ${key}`);
+console.log(`revoked upstream grant ${key}; tombstone contains no secrets`);
 
 function revokeGrant(raw) {
   const trimmed = raw.trim();
   const revokedAt = new Date().toISOString();
-  if (trimmed.startsWith("{")) {
-    const grant = JSON.parse(trimmed);
-    return {
-      enabled: false,
-      tokenType: grant.tokenType ?? grant.token_type ?? "Bearer",
-      revokedAt,
-    };
+  const metadata = parseMetadata(trimmed);
+  canonicalizeAlias(metadata, "tokenType", "token_type");
+  canonicalizeAlias(metadata, "expiresAt", "expires_at");
+  canonicalizeAlias(metadata, "accountId", "account_id");
+  canonicalizeAlias(metadata, "createdAt", "created_at");
+  canonicalizeAlias(metadata, "updatedAt", "updated_at");
+  canonicalizeAlias(metadata, "revokedAt", "revoked_at");
+  if (args.kind !== undefined) {
+    metadata.kind = parseKind(requiredOption(args, "kind"));
+  }
+  if (args.provider !== undefined) {
+    metadata.provider = requiredOption(args, "provider");
+  }
+  if (args.label !== undefined) {
+    metadata.label = requiredOption(args, "label");
   }
   return {
+    ...stripSecrets(metadata),
+    version: 1,
     enabled: false,
-    tokenType: "Bearer",
+    tokenType: metadata.tokenType ?? "Bearer",
+    updatedAt: revokedAt,
     revokedAt,
   };
+}
+
+function parseMetadata(value) {
+  if (value.startsWith("{")) {
+    const parsed = JSON.parse(value);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+      return {};
+    }
+    return parsed;
+  }
+  return {};
+}
+
+function canonicalizeAlias(target, canonical, alias) {
+  if (target[canonical] === undefined && target[alias] !== undefined) {
+    target[canonical] = target[alias];
+  }
+  delete target[alias];
+}
+
+function stripSecrets(value) {
+  if (Array.isArray(value)) {
+    return value.map(stripSecrets);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const secretFields = new Set([
+    "accessToken",
+    "access_token",
+    "refreshToken",
+    "refresh_token",
+    "credential",
+    "apiKey",
+    "api_key",
+    "token",
+    "secret",
+    "clientSecret",
+    "client_secret",
+    "password",
+  ]);
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([name]) => !secretFields.has(name))
+      .map(([name, item]) => [name, stripSecrets(item)]),
+  );
 }
 
 function parseArgs(values) {
@@ -92,8 +149,23 @@ function parseArgs(values) {
 }
 
 function required(value, name) {
-  if (!value) {
+  if (typeof value !== "string" || !value.trim()) {
     throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function requiredOption(args, name) {
+  const value = args[name];
+  if (value === true) {
+    throw new Error(`--${name} requires a value`);
+  }
+  return required(value, `--${name}`);
+}
+
+function parseKind(value) {
+  if (!["api_key", "oauth", "subscription"].includes(value)) {
+    throw new Error("--kind must be api_key, oauth, or subscription");
   }
   return value;
 }

--- a/scripts/oauth-revoke.mjs
+++ b/scripts/oauth-revoke.mjs
@@ -115,6 +115,7 @@ function stripSecrets(value) {
     "refreshToken",
     "refresh_token",
     "credential",
+    "credentials",
     "apiKey",
     "api_key",
     "token",

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -344,6 +344,7 @@ function defaultAccessPaths() {
     "/v1/entitlements",
     "/v1/playground/*",
     "/v1/admin/*",
+    "/v1/oauth/callback",
   ];
 }
 
@@ -421,7 +422,7 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   console.log("");
   console.log("Expected live root check after redeploy:");
   console.log(`curl -sS -D - -o /dev/null https://${host}/`);
-  console.log("Root should 302 to /dashboard, /dashboard should 302 to /dashboard/catalog, and Cloudflare Access should challenge /dashboard/*.");
+  console.log("Root should 302 to /dashboard, /dashboard should 302 to /dashboard/catalog, and Cloudflare Access should challenge console, admin, playground, and OAuth callback paths.");
 }
 
 function syncGitHubVariable(repoName, name, value) {

--- a/scripts/smoke-access-gate.mjs
+++ b/scripts/smoke-access-gate.mjs
@@ -1,0 +1,21 @@
+export function assertAccessGateResponse(response, contentType, body, name) {
+  if (contentType.includes("application/json")) {
+    let code = null;
+    try {
+      code = JSON.parse(body)?.error?.code ?? null;
+    } catch {}
+    throw new Error(
+      `${name} reached ClawRouter's ${code ?? "JSON"} fallback; Cloudflare Access is not protecting the path`,
+    );
+  }
+  if (response.ok && contentType.includes("text/html") && body.includes("ClawRouter")) {
+    throw new Error(`${name} returned the ClawRouter console without Cloudflare Access`);
+  }
+  if (response.status >= 300 && response.status < 400) {
+    return;
+  }
+  if ((response.status === 401 || response.status === 403) && !body.includes("ClawRouter")) {
+    return;
+  }
+  throw new Error(`${name} returned ${response.status}, expected Cloudflare Access challenge`);
+}

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -25,6 +25,19 @@ const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alia
 expectRouteCatalog(aliasedRoutes, "route catalog alias");
 await expectAccessGate(`${baseUrl}/v1/session`, "session access gate");
 await expectAccessGate(`${baseUrl}/v1/playground/v1/chat/completions`, "playground access gate");
+await expectAccessGate(`${baseUrl}/v1/oauth/callback`, "OAuth callback access gate");
+await expectAccessGate(
+  `${baseUrl}/v1/admin/upstream-grants/policies/smoke/openai/authorize`,
+  "OAuth authorization access gate",
+  { method: "POST" },
+);
+await expectClientAuthGate(`${baseUrl}/v1/models`, "models client auth gate");
+await expectClientAuthGate(`${baseUrl}/v1/catalog`, "catalog client auth gate");
+await expectClientAuthGate(
+  `${baseUrl}/v1/native/openai/v1/responses`,
+  "native proxy client auth gate",
+  { method: "POST" },
+);
 const plan = buildProviderSmokePlan(providers);
 if (plan.targetCount !== plan.providerCount) {
   throw new Error(`provider smoke plan is incomplete: ${plan.targetCount}/${plan.providerCount}`);
@@ -96,14 +109,39 @@ async function expectRedirectOrAccessGate(url, name, location) {
   assertAccessGateResponse(response, contentType, body, name);
 }
 
-async function expectAccessGate(url, name) {
+async function expectAccessGate(url, name, init = {}) {
   const response = await fetch(url, {
+    ...init,
     headers: { accept: "text/html,application/json" },
     redirect: "manual",
   });
   const contentType = response.headers.get("content-type") ?? "";
   const body = await response.text();
   assertAccessGateResponse(response, contentType, body, name);
+}
+
+async function expectClientAuthGate(url, name, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    headers: { accept: "text/html,application/json" },
+    redirect: "manual",
+  });
+  const location = response.headers.get("location") ?? "";
+  if (response.status >= 300 && response.status < 400 && looksLikeAccessRedirect(location, url)) {
+    return;
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = await response.text();
+  if ((response.status === 401 || response.status === 403) && contentType.includes("application/json")) {
+    let json = null;
+    try {
+      json = JSON.parse(body);
+    } catch {}
+    if (["client_auth_required", "invalid_proxy_key", "access_session_required"].includes(json?.error?.code)) {
+      return;
+    }
+  }
+  throw new Error(`${name} returned ${response.status}, expected a ClawRouter or Cloudflare Access auth challenge`);
 }
 
 function assertAccessGateResponse(response, contentType, body, name) {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -6,6 +6,7 @@ import {
   selectLiveProviderPlans,
   summarizePlan,
 } from "./provider-smoke-plan.mjs";
+import { assertAccessGateResponse } from "./smoke-access-gate.mjs";
 
 const baseUrl = required(process.env.CLAWROUTER_BASE_URL, "CLAWROUTER_BASE_URL").replace(/\/$/, "");
 const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
@@ -142,30 +143,6 @@ async function expectClientAuthGate(url, name, init = {}) {
     }
   }
   throw new Error(`${name} returned ${response.status}, expected a ClawRouter or Cloudflare Access auth challenge`);
-}
-
-function assertAccessGateResponse(response, contentType, body, name) {
-  if (contentType.includes("application/json")) {
-    let json = null;
-    try {
-      json = JSON.parse(body);
-    } catch {}
-    if (json?.error?.code === "access_session_required") {
-      throw new Error(
-        `${name} reached ClawRouter's fallback 401; Cloudflare Access is not protecting the console path`,
-      );
-    }
-  }
-  if (response.ok && contentType.includes("text/html") && body.includes("ClawRouter")) {
-    throw new Error(`${name} returned the ClawRouter console without Cloudflare Access`);
-  }
-  if (response.status >= 300 && response.status < 400) {
-    return;
-  }
-  if ((response.status === 401 || response.status === 403) && !body.includes("ClawRouter")) {
-    return;
-  }
-  throw new Error(`${name} returned ${response.status}, expected Cloudflare Access challenge`);
 }
 
 function looksLikeAccessRedirect(location, requestUrl) {

--- a/test/oauth-grants.test.mjs
+++ b/test/oauth-grants.test.mjs
@@ -158,6 +158,49 @@ test("oauth put supports api_key credentials from stdin and rejects argv secrets
   }
 });
 
+test("oauth put supports multi-field credential bundles without argv exposure", () => {
+  const fixture = scriptFixture();
+
+  try {
+    const result = runScript(
+      "oauth-put.mjs",
+      [
+        "--kid",
+        "svc_models",
+        "--token-ref",
+        "aws-bedrock",
+        "--kind",
+        "api_key",
+        "--provider",
+        "aws-bedrock",
+        "--credentials-json-env",
+        "TEST_AWS_CREDENTIALS",
+        "--local",
+      ],
+      fixture,
+      {
+        TEST_AWS_CREDENTIALS: JSON.stringify({
+          accessKeyId: "AKID_PLACEHOLDER",
+          secretAccessKey: "secret-placeholder",
+          sessionToken: "session-placeholder",
+        }),
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const [{ value }] = payloads(fixture.payloadLogPath);
+    assert.deepEqual(value.credentials, {
+      accessKeyId: "AKID_PLACEHOLDER",
+      secretAccessKey: "secret-placeholder",
+      sessionToken: "session-placeholder",
+    });
+    assert.doesNotMatch(readFileSync(fixture.commandLogPath, "utf8"), /AKID_PLACEHOLDER/);
+    assert.doesNotMatch(readFileSync(fixture.commandLogPath, "utf8"), /secret-placeholder/);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test("oauth put accepts a public literal refresh client id", () => {
   const fixture = scriptFixture();
 
@@ -206,6 +249,10 @@ test("oauth revoke preserves canonical metadata and removes secrets recursively"
       accessToken: "access-token-placeholder",
       refreshToken: "refresh-token-placeholder",
       credential: "credential-placeholder",
+      credentials: {
+        accessKeyId: "AKID_PLACEHOLDER",
+        secretAccessKey: "secret-placeholder",
+      },
       expiresAt: "2026-06-16T12:00:00Z",
       scopes: ["openid"],
       accountId: "stable-account-id",
@@ -242,6 +289,7 @@ test("oauth revoke preserves canonical metadata and removes secrets recursively"
     assert.equal(value.accessToken, undefined);
     assert.equal(value.refreshToken, undefined);
     assert.equal(value.credential, undefined);
+    assert.equal(value.credentials, undefined);
     assert.deepEqual(value.refresh.extraParams, { audience: "provider-api" });
     assert.doesNotMatch(JSON.stringify(value), /placeholder/);
   } finally {

--- a/test/oauth-grants.test.mjs
+++ b/test/oauth-grants.test.mjs
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("oauth put writes a canonical upstream grant from non-argv secrets", () => {
+  const fixture = scriptFixture();
+  const refreshPath = join(fixture.dir, "refresh-token");
+  writeFileSync(refreshPath, "refresh-token-placeholder\n", { mode: 0o600 });
+
+  try {
+    const result = runScript(
+      "oauth-put.mjs",
+      [
+        "--kid",
+        "svc_docs",
+        "--token-ref",
+        "openai-maintainer",
+        "--kind",
+        "subscription",
+        "--provider",
+        "openai",
+        "--label",
+        "maintainer subscription",
+        "--access-token-env",
+        "TEST_ACCESS_TOKEN",
+        "--refresh-token-file",
+        refreshPath,
+        "--expires-at",
+        "2026-06-16T12:00:00Z",
+        "--scopes",
+        "openid,profile,openid",
+        "--account-id",
+        "stable-account-id",
+        "--subscription-plan",
+        "plus",
+        "--subscription-subject",
+        "stable-subject-id",
+        "--refresh-token-url",
+        "https://provider.example/oauth/token",
+        "--refresh-client-id-config",
+        "PROVIDER_OAUTH_CLIENT_ID",
+        "--refresh-client-secret-config",
+        "PROVIDER_OAUTH_CLIENT_SECRET",
+        "--refresh-extra-params-json",
+        '{"audience":"provider-api"}',
+        "--local",
+      ],
+      fixture,
+      { TEST_ACCESS_TOKEN: "access-token-placeholder" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const [{ key, value }] = payloads(fixture.payloadLogPath);
+    assert.equal(key, "oauth/svc_docs/openai-maintainer");
+    assert.equal(value.version, 1);
+    assert.equal(value.enabled, true);
+    assert.equal(value.kind, "subscription");
+    assert.equal(value.provider, "openai");
+    assert.equal(value.label, "maintainer subscription");
+    assert.equal(value.accessToken, "access-token-placeholder");
+    assert.equal(value.refreshToken, "refresh-token-placeholder");
+    assert.equal(value.credential, undefined);
+    assert.equal(value.tokenType, "Bearer");
+    assert.equal(value.expiresAt, "2026-06-16T12:00:00.000Z");
+    assert.deepEqual(value.scopes, ["openid", "profile"]);
+    assert.equal(value.accountId, "stable-account-id");
+    assert.deepEqual(value.subscription, {
+      plan: "plus",
+      subject: "stable-subject-id",
+    });
+    assert.deepEqual(value.refresh, {
+      tokenUrl: "https://provider.example/oauth/token",
+      clientIdConfig: "PROVIDER_OAUTH_CLIENT_ID",
+      clientSecretConfig: "PROVIDER_OAUTH_CLIENT_SECRET",
+      extraParams: { audience: "provider-api" },
+    });
+    assert.match(value.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(value.updatedAt, value.createdAt);
+    assert.doesNotMatch(readFileSync(fixture.commandLogPath, "utf8"), /access-token-placeholder/);
+    assert.doesNotMatch(readFileSync(fixture.commandLogPath, "utf8"), /refresh-token-placeholder/);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("oauth put supports api_key credentials from stdin and rejects argv secrets", () => {
+  const fixture = scriptFixture();
+
+  try {
+    const result = runScript(
+      "oauth-put.mjs",
+      [
+        "--tenant",
+        "default",
+        "--token-ref",
+        "anthropic-primary",
+        "--kind",
+        "api_key",
+        "--provider",
+        "anthropic",
+        "--label",
+        "primary api key",
+        "--credential-stdin",
+        "--local",
+      ],
+      fixture,
+      {},
+      "api-key-placeholder\n",
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const [{ key, value }] = payloads(fixture.payloadLogPath);
+    assert.equal(key, "oauth/tenants/default/anthropic-primary");
+    assert.equal(value.credential, "api-key-placeholder");
+    assert.equal(value.accessToken, undefined);
+
+    for (const unsafeSecret of [
+      { kind: "oauth", option: "--access-token", extraArgs: [] },
+      { kind: "api_key", option: "--credential", extraArgs: [] },
+      {
+        kind: "oauth",
+        option: "--refresh-token",
+        extraArgs: ["--access-token-env", "TEST_ACCESS_TOKEN"],
+      },
+    ]) {
+      const unsafe = runScript(
+        "oauth-put.mjs",
+        [
+          "--kid",
+          "svc_docs",
+          "--kind",
+          unsafeSecret.kind,
+          "--provider",
+          "openai",
+          "--label",
+          "unsafe",
+          ...unsafeSecret.extraArgs,
+          unsafeSecret.option,
+          "argv-secret-placeholder",
+          "--local",
+        ],
+        fixture,
+        { TEST_ACCESS_TOKEN: "access-token-placeholder" },
+      );
+      assert.notEqual(unsafe.status, 0);
+      assert.match(unsafe.stderr, /would expose the secret in process argv/);
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("oauth put accepts a public literal refresh client id", () => {
+  const fixture = scriptFixture();
+
+  try {
+    const result = runScript(
+      "oauth-put.mjs",
+      [
+        "--kid",
+        "svc_docs",
+        "--provider",
+        "openai",
+        "--kind",
+        "oauth",
+        "--access-token-env",
+        "TEST_ACCESS_TOKEN",
+        "--refresh-token-url",
+        "https://provider.example/oauth/token",
+        "--refresh-client-id",
+        "public-client-id",
+        "--local",
+      ],
+      fixture,
+      { TEST_ACCESS_TOKEN: "access-token-placeholder" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const [{ value }] = payloads(fixture.payloadLogPath);
+    assert.deepEqual(value.refresh, {
+      tokenUrl: "https://provider.example/oauth/token",
+      clientId: "public-client-id",
+      extraParams: {},
+    });
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("oauth revoke preserves canonical metadata and removes secrets recursively", () => {
+  const fixture = scriptFixture({
+    getValue: JSON.stringify({
+      version: 1,
+      enabled: true,
+      kind: "oauth",
+      provider: "openai",
+      label: "maintainer subscription",
+      tokenType: "Bearer",
+      accessToken: "access-token-placeholder",
+      refreshToken: "refresh-token-placeholder",
+      credential: "credential-placeholder",
+      expiresAt: "2026-06-16T12:00:00Z",
+      scopes: ["openid"],
+      accountId: "stable-account-id",
+      subscription: { plan: "plus", subject: "stable-subject-id" },
+      refresh: {
+        tokenUrl: "https://provider.example/oauth/token",
+        clientIdConfig: "PROVIDER_OAUTH_CLIENT_ID",
+        clientSecretConfig: "PROVIDER_OAUTH_CLIENT_SECRET",
+        extraParams: {
+          audience: "provider-api",
+          client_secret: "nested-secret-placeholder",
+        },
+      },
+      createdAt: "2026-06-16T00:00:00Z",
+      updatedAt: "2026-06-16T01:00:00Z",
+    }),
+  });
+
+  try {
+    const result = runScript(
+      "oauth-revoke.mjs",
+      ["--kid", "svc_docs", "--token-ref", "openai-maintainer", "--local"],
+      fixture,
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const [{ value }] = payloads(fixture.payloadLogPath);
+    assert.equal(value.version, 1);
+    assert.equal(value.enabled, false);
+    assert.equal(value.provider, "openai");
+    assert.equal(value.label, "maintainer subscription");
+    assert.equal(value.accountId, "stable-account-id");
+    assert.equal(value.createdAt, "2026-06-16T00:00:00Z");
+    assert.equal(value.updatedAt, value.revokedAt);
+    assert.equal(value.accessToken, undefined);
+    assert.equal(value.refreshToken, undefined);
+    assert.equal(value.credential, undefined);
+    assert.deepEqual(value.refresh.extraParams, { audience: "provider-api" });
+    assert.doesNotMatch(JSON.stringify(value), /placeholder/);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+function scriptFixture({ getValue = "Value not found" } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "clawrouter-oauth-grant-test-"));
+  const commandLogPath = join(dir, "commands.log");
+  const payloadLogPath = join(dir, "payloads.log");
+  const fakePnpm = join(dir, "pnpm");
+  writeFileSync(
+    fakePnpm,
+    [
+      "#!/usr/bin/env node",
+      'const { appendFileSync, readFileSync } = require("node:fs");',
+      "const args = process.argv.slice(2);",
+      'appendFileSync(process.env.CLAWROUTER_TEST_COMMAND_LOG, `${args.join(" ")}\\n`);',
+      'if (args.includes("get")) { process.stdout.write(process.env.CLAWROUTER_TEST_GET_VALUE); process.exit(0); }',
+      'const pathIndex = args.indexOf("--path");',
+      'const putIndex = args.indexOf("put");',
+      'if (pathIndex !== -1 && putIndex !== -1) appendFileSync(process.env.CLAWROUTER_TEST_PAYLOAD_LOG, `${JSON.stringify({ key: args[putIndex + 1], value: JSON.parse(readFileSync(args[pathIndex + 1], "utf8")) })}\\n`);',
+    ].join("\n"),
+  );
+  chmodSync(fakePnpm, 0o755);
+  return {
+    dir,
+    commandLogPath,
+    payloadLogPath,
+    env: {
+      CLAWROUTER_TEST_COMMAND_LOG: commandLogPath,
+      CLAWROUTER_TEST_PAYLOAD_LOG: payloadLogPath,
+      CLAWROUTER_TEST_GET_VALUE: getValue,
+      PATH: `${dir}:${process.env.PATH}`,
+    },
+    cleanup() {
+      rmSync(dir, { force: true, recursive: true });
+    },
+  };
+}
+
+function runScript(name, args, fixture, extraEnv = {}, input) {
+  return spawnSync(process.execPath, [resolve("scripts", name), ...args], {
+    cwd: resolve("."),
+    encoding: "utf8",
+    env: { ...process.env, ...fixture.env, ...extraEnv },
+    input,
+  });
+}
+
+function payloads(path) {
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/test/provision-access.test.mjs
+++ b/test/provision-access.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("Access provisioning protects the browser OAuth callback by default", () => {
+  const result = spawnSync("node", ["scripts/provision-access.mjs", "--dry-run"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLOUDFLARE_ACCOUNT_ID: "account-placeholder",
+      CLAWROUTER_ACCESS_ALLOWED_DOMAINS: "example.com",
+      CLAWROUTER_ACCESS_DOMAIN: "clawrouter.example.com",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /clawrouter\.example\.com\/dashboard\/\*/);
+  assert.match(result.stdout, /clawrouter\.example\.com\/v1\/admin\/\*/);
+  assert.match(result.stdout, /clawrouter\.example\.com\/v1\/oauth\/callback/);
+});

--- a/test/smoke-access-gate.test.mjs
+++ b/test/smoke-access-gate.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertAccessGateResponse } from "../scripts/smoke-access-gate.mjs";
+
+test("Access smoke rejects ClawRouter JSON fallbacks", () => {
+  for (const code of ["access_session_required", "access_admin_required", "admin_auth_required"]) {
+    const response = Response.json({ error: { code } }, { status: 403 });
+    assert.throws(
+      () =>
+        assertAccessGateResponse(
+          response,
+          response.headers.get("content-type") ?? "",
+          JSON.stringify({ error: { code } }),
+          "protected route",
+        ),
+      new RegExp(code),
+    );
+  }
+});
+
+test("Access smoke accepts redirects and non-ClawRouter challenges", () => {
+  assert.doesNotThrow(() =>
+    assertAccessGateResponse(new Response(null, { status: 302 }), "", "", "protected route"),
+  );
+  assert.doesNotThrow(() =>
+    assertAccessGateResponse(
+      new Response("Forbidden", { status: 403 }),
+      "text/plain",
+      "Forbidden",
+      "protected route",
+    ),
+  );
+});


### PR DESCRIPTION
## Summary
- add provider-neutral native proxy routes with policy, budget, credential, and streaming enforcement
- add canonical API key, OAuth, subscription, and credential-bundle grants with browser OAuth and automatic Access assignments
- add entitlement-aware models/catalog discovery and admin workflows for provider connections

## Verification
- `pnpm check`
- `pnpm build`
- `pnpm test:scripts`
- `pnpm provider:compile` (19 manifests)
- `pnpm provider:smoke-plan` (19/19 plans)
- autoreview clean with no accepted/actionable findings
- privacy/secret diff scan clean; only deliberate test placeholders found

## Deployment status
- not deployed yet; deploy and live smoke will run after merge

## Remaining risk
- OpenAI browser OAuth still needs live proof that the public client accepts the remote ClawRouter callback URI
- local browser visual QA was blocked because the required in-app Browser runtime was unavailable