### PR TITLE
fix(deploy): stay within access destination limit

### DIFF
--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -58,11 +58,12 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
-destinations are `/dashboard/*`, `/v1/session`, `/v1/entitlements`,
-`/v1/playground/*`, `/v1/admin/*`, and `/v1/oauth/callback`. This stays within Cloudflare's
-per-application destination limit while still protecting the console entrypoint
-and the Access-backed session, entitlement, playground, admin, and OAuth
-callback APIs. Override
+destinations are `/dashboard/*`, `/v1/session`, `/v1/playground/*`,
+`/v1/admin/*`, and `/v1/oauth/callback`. This stays within Cloudflare's
+five-destination per-application limit while still protecting the console
+entrypoint and the Access-backed session, playground, admin, and OAuth callback
+APIs. `/v1/entitlements` still verifies the Access JWT inside the Worker, but is
+not a separate Access application destination. Override
 them with `CLAWROUTER_ACCESS_PATHS` only if the API contract changes. Do not add
 `/` on the shared API hostname: Cloudflare Access
 path inheritance would protect the public `/v1/*` API too. Root reaches Access

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -341,7 +341,6 @@ function defaultAccessPaths() {
   return [
     "/dashboard/*",
     "/v1/session",
-    "/v1/entitlements",
     "/v1/playground/*",
     "/v1/admin/*",
     "/v1/oauth/callback",

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -25,6 +25,7 @@ expectRouteCatalog(routes, "route catalog");
 const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alias");
 expectRouteCatalog(aliasedRoutes, "route catalog alias");
 await expectAccessGate(`${baseUrl}/v1/session`, "session access gate");
+await expectClientAuthGate(`${baseUrl}/v1/entitlements`, "entitlements Worker auth gate");
 await expectAccessGate(`${baseUrl}/v1/playground/v1/chat/completions`, "playground access gate");
 await expectAccessGate(`${baseUrl}/v1/oauth/callback`, "OAuth callback access gate");
 await expectAccessGate(

--- a/test/provision-access.test.mjs
+++ b/test/provision-access.test.mjs
@@ -18,4 +18,7 @@ test("Access provisioning protects the browser OAuth callback by default", () =>
   assert.match(result.stdout, /clawrouter\.example\.com\/dashboard\/\*/);
   assert.match(result.stdout, /clawrouter\.example\.com\/v1\/admin\/\*/);
   assert.match(result.stdout, /clawrouter\.example\.com\/v1\/oauth\/callback/);
+  assert.doesNotMatch(result.stdout, /clawrouter\.example\.com\/v1\/entitlements/);
+  const destinations = result.stdout.match(/^destinations=(.+)$/m)?.[1].split(",") ?? [];
+  assert.equal(destinations.length, 5);
 });


### PR DESCRIPTION
## Summary
- keep the managed Cloudflare Access app within the live five-destination limit
- leave `/v1/entitlements` Worker-authenticated with Access JWT verification
- verify the entitlements fallback remains non-public in deployed smoke

## Verification
- `pnpm test:scripts`
- `pnpm cf:access -- --dry-run` equivalent: five destinations
- autoreview clean with no accepted/actionable findings

## Deployment status
- fixes Access provisioning failure in https://github.com/openclaw/clawrouter/actions/runs/27607176848
- redeploy and live smoke will run immediately after merge