### PR TITLE
feat(edge): publish client catalog transport contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,13 @@ still fail closed during migration or incomplete rotations. Canonical policy
 edits preserve their generation. The legacy key mutation alias rejects changing
 policy scope and secret together.
 
+`GET /v1/catalog` is the credential-scoped client integration contract. It
+returns only allowed providers and executable models. Each provider row reports
+whether the unified OpenAI-compatible `/v1` route is available, its native proxy
+base URL, and the request/response formats for its executable native routes.
+Clients can use those fields to choose the real provider transport without
+guessing from provider ids.
+
 Disable a credential to revoke one issued key, disable a policy to revoke every
 user and credential bound to it, or disable a provider connection to stop that
 provider globally. Legacy `keys/<kid>` records remain readable during

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2574,12 +2574,14 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                 .iter()
                 .find(|provider| provider.id == row.provider)?;
             let executable_endpoints = &row.readiness.executable_endpoints;
+            let openai_compatible =
+                row.readiness.executable && supports_openai_compatible_proxy(provider);
             Some(serde_json::json!({
                 "id": provider.id,
                 "displayName": provider.display_name,
                 "allowed": true,
                 "executable": row.readiness.executable,
-                "openAiCompatible": supports_openai_compatible_proxy(provider),
+                "openAiCompatible": openai_compatible,
                 "nativeBaseUrl": format!("/v1/native/{}", provider.id),
                 "policies": row.policies,
                 "readiness": row.readiness,
@@ -12810,7 +12812,7 @@ mod tests {
             catalog["providers"][0]["models"][0]["capabilities"],
             serde_json::json!(["llm.responses"])
         );
-        assert_eq!(catalog["providers"][1]["openAiCompatible"], true);
+        assert_eq!(catalog["providers"][1]["openAiCompatible"], false);
     }
 
     #[test]

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2581,7 +2581,7 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                 "displayName": provider.display_name,
                 "allowed": true,
                 "executable": row.readiness.executable,
-                "openAiCompatible": openai_compatible,
+                "openaiCompatible": openai_compatible,
                 "nativeBaseUrl": format!("/v1/native/{}", provider.id),
                 "policies": row.policies,
                 "readiness": row.readiness,
@@ -12795,7 +12795,7 @@ mod tests {
             catalog["providers"][0]["nativeBaseUrl"],
             "/v1/native/openai"
         );
-        assert_eq!(catalog["providers"][0]["openAiCompatible"], true);
+        assert_eq!(catalog["providers"][0]["openaiCompatible"], true);
         assert_eq!(
             catalog["providers"][0]["routes"][0]["endpoint"],
             "responses"
@@ -12812,7 +12812,7 @@ mod tests {
             catalog["providers"][0]["models"][0]["capabilities"],
             serde_json::json!(["llm.responses"])
         );
-        assert_eq!(catalog["providers"][1]["openAiCompatible"], false);
+        assert_eq!(catalog["providers"][1]["openaiCompatible"], false);
     }
 
     #[test]
@@ -12822,7 +12822,7 @@ mod tests {
         anthropic.readiness.executable_endpoints = vec!["messages".to_string()];
         let catalog = client_catalog_value(&snapshot, vec![anthropic]);
         let provider = &catalog["providers"][0];
-        assert_eq!(provider["openAiCompatible"], false);
+        assert_eq!(provider["openaiCompatible"], false);
         assert_eq!(provider["nativeBaseUrl"], "/v1/native/anthropic");
         assert_eq!(provider["routes"][0]["path"], "/v1/messages");
         assert_eq!(provider["routes"][0]["requestFormat"], "anthropic.messages");

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -2579,6 +2579,7 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                 "displayName": provider.display_name,
                 "allowed": true,
                 "executable": row.readiness.executable,
+                "openAiCompatible": supports_openai_compatible_proxy(provider),
                 "nativeBaseUrl": format!("/v1/native/{}", provider.id),
                 "policies": row.policies,
                 "readiness": row.readiness,
@@ -2590,6 +2591,8 @@ fn client_catalog_value(snapshot: &ProviderSnapshot, rows: Vec<EntitlementProvid
                         "endpoint": endpoint.id,
                         "methods": endpoint.methods,
                         "path": endpoint.path,
+                        "requestFormat": endpoint.request_format,
+                        "responseFormat": endpoint.response_format,
                         "streaming": endpoint.streaming
                     })
                 }).collect::<Vec<_>>(),
@@ -12790,13 +12793,40 @@ mod tests {
             catalog["providers"][0]["nativeBaseUrl"],
             "/v1/native/openai"
         );
+        assert_eq!(catalog["providers"][0]["openAiCompatible"], true);
         assert_eq!(
             catalog["providers"][0]["routes"][0]["endpoint"],
             "responses"
         );
         assert_eq!(
+            catalog["providers"][0]["routes"][0]["requestFormat"],
+            "openai.responses"
+        );
+        assert_eq!(
+            catalog["providers"][0]["routes"][0]["responseFormat"],
+            "openai.responses"
+        );
+        assert_eq!(
             catalog["providers"][0]["models"][0]["capabilities"],
             serde_json::json!(["llm.responses"])
+        );
+        assert_eq!(catalog["providers"][1]["openAiCompatible"], true);
+    }
+
+    #[test]
+    fn client_catalog_describes_native_transport_formats() {
+        let snapshot = provider_snapshot().unwrap();
+        let mut anthropic = entitlement_test_row("anthropic", true, true);
+        anthropic.readiness.executable_endpoints = vec!["messages".to_string()];
+        let catalog = client_catalog_value(&snapshot, vec![anthropic]);
+        let provider = &catalog["providers"][0];
+        assert_eq!(provider["openAiCompatible"], false);
+        assert_eq!(provider["nativeBaseUrl"], "/v1/native/anthropic");
+        assert_eq!(provider["routes"][0]["path"], "/v1/messages");
+        assert_eq!(provider["routes"][0]["requestFormat"], "anthropic.messages");
+        assert_eq!(
+            provider["routes"][0]["responseFormat"],
+            "anthropic.messages"
         );
     }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,7 +1,7 @@
 use clawrouter_core::{
     parse_proxy_key, AuthAuthorizationConfig, AuthScheme, CompiledEndpoint, CompiledModel,
     CompiledProvider, GrantTransportConfig, PathParamStyle, ProviderClass, ProviderSnapshot,
-    UsageEvent, UsageStatus,
+    ProxyKeyParts, UsageEvent, UsageStatus,
 };
 use futures_util::future::try_join_all;
 use hmac::{Hmac, Mac};
@@ -7916,9 +7916,28 @@ async fn authorize_request(
 }
 
 fn proxy_key_header_present(headers: &Headers) -> Result<bool> {
+    Ok(proxy_key_from_headers(headers)?.is_some())
+}
+
+fn proxy_key_from_headers(headers: &Headers) -> Result<Option<ProxyKeyParts>> {
     let auth = headers.get("authorization")?.unwrap_or_default();
-    let token = auth.strip_prefix("Bearer ").unwrap_or("");
-    Ok(parse_proxy_key(token).is_ok())
+    let anthropic = headers.get("x-api-key")?.unwrap_or_default();
+    let google = headers.get("x-goog-api-key")?.unwrap_or_default();
+    let azure = headers.get("api-key")?.unwrap_or_default();
+    Ok(parse_proxy_key_candidates([
+        auth.strip_prefix("Bearer ").unwrap_or(""),
+        &anthropic,
+        &google,
+        &azure,
+    ]))
+}
+
+fn parse_proxy_key_candidates<'a>(
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Option<ProxyKeyParts> {
+    candidates
+        .into_iter()
+        .find_map(|candidate| parse_proxy_key(candidate).ok())
 }
 
 async fn disabled_provider_connection_response(
@@ -7951,11 +7970,9 @@ async fn authorize_proxy_key_for_provider(
     env: &Env,
     provider_id: Option<&str>,
 ) -> Result<AuthOutcome> {
-    let auth = headers.get("authorization")?.unwrap_or_default();
-    let token = auth.strip_prefix("Bearer ").unwrap_or("");
-    let key = match parse_proxy_key(token) {
-        Ok(key) => key,
-        Err(_) => {
+    let key = match proxy_key_from_headers(headers)? {
+        Some(key) => key,
+        None => {
             return json_error(
                 "invalid_proxy_key",
                 "a valid ClawRouter proxy key is required",
@@ -8769,6 +8786,7 @@ fn native_request_header_allowed(
     if matches!(
         name.as_str(),
         "authorization"
+            | "api-key"
             | "cookie"
             | "host"
             | "connection"
@@ -8779,6 +8797,8 @@ fn native_request_header_allowed(
             | "trailer"
             | "transfer-encoding"
             | "upgrade"
+            | "x-api-key"
+            | "x-goog-api-key"
     ) || name.starts_with("cf-")
     {
         return false;
@@ -15021,6 +15041,17 @@ mod tests {
             endpoint,
             "authorization"
         ));
+        assert!(!native_request_header_allowed(openai, endpoint, "api-key"));
+        assert!(!native_request_header_allowed(
+            openai,
+            endpoint,
+            "x-api-key"
+        ));
+        assert!(!native_request_header_allowed(
+            openai,
+            endpoint,
+            "x-goog-api-key"
+        ));
         assert!(!native_request_header_allowed(openai, endpoint, "cookie"));
         assert!(native_response_header_allowed(
             endpoint,
@@ -15047,6 +15078,24 @@ mod tests {
             &manifest_allowed,
             "x-provider-trace"
         ));
+    }
+
+    #[test]
+    fn proxy_key_candidates_accept_native_sdk_credentials_after_bearer() {
+        let key = parse_proxy_key_candidates([
+            "not-a-clawrouter-key",
+            "ocpk_test_native01_secret1234",
+            "ocpk_live_later01_secret5678",
+        ])
+        .unwrap();
+        assert_eq!(key.kid, "native01");
+
+        let key = parse_proxy_key_candidates([
+            "ocpk_live_bearer01_secret1234",
+            "ocpk_test_native01_secret5678",
+        ])
+        .unwrap();
+        assert_eq!(key.kid, "bearer01");
     }
 
     #[test]

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -53,6 +53,12 @@ if (liveProviders.length === 0) {
 if (!smokeKey) {
   throw new Error("CLAWROUTER_SMOKE_KEY is required for live provider smoke");
 }
+const clientCatalog = await expectAuthenticatedOk(
+  `${baseUrl}/v1/catalog`,
+  "credential-scoped client catalog",
+  smokeKey,
+);
+expectClientCatalog(clientCatalog);
 const selectedLiveProviders = selectLiveProviderPlans(plan, liveProviders).map(
   (provider) => provider.id,
 );
@@ -74,6 +80,16 @@ console.log("deployed smoke passed");
 
 async function expectOk(url, name) {
   const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${name} failed with ${response.status}`);
+  }
+  return response.json();
+}
+
+async function expectAuthenticatedOk(url, name, token) {
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${token}` },
+  });
   if (!response.ok) {
     throw new Error(`${name} failed with ${response.status}`);
   }
@@ -166,6 +182,25 @@ function expectRouteCatalog(catalog, name) {
   }
   if (!catalog.manifestProxy.some((route) => route.route === "/v1/proxy/tavily/search")) {
     throw new Error(`${name} is missing the Tavily manifest route`);
+  }
+}
+
+function expectClientCatalog(catalog) {
+  if (!Array.isArray(catalog.providers) || catalog.providers.length === 0) {
+    throw new Error("credential-scoped client catalog is empty");
+  }
+  for (const provider of catalog.providers) {
+    if (typeof provider.openAiCompatible !== "boolean") {
+      throw new Error(`client catalog provider ${provider.id} is missing openAiCompatible`);
+    }
+    if (!Array.isArray(provider.routes)) {
+      throw new Error(`client catalog provider ${provider.id} is missing routes`);
+    }
+    for (const route of provider.routes) {
+      if (typeof route.requestFormat !== "string" || typeof route.responseFormat !== "string") {
+        throw new Error(`client catalog provider ${provider.id} has an incomplete route contract`);
+      }
+    }
   }
 }
 

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -190,8 +190,8 @@ function expectClientCatalog(catalog) {
     throw new Error("credential-scoped client catalog is empty");
   }
   for (const provider of catalog.providers) {
-    if (typeof provider.openAiCompatible !== "boolean") {
-      throw new Error(`client catalog provider ${provider.id} is missing openAiCompatible`);
+    if (typeof provider.openaiCompatible !== "boolean") {
+      throw new Error(`client catalog provider ${provider.id} is missing openaiCompatible`);
     }
     if (!Array.isArray(provider.routes)) {
       throw new Error(`client catalog provider ${provider.id} is missing routes`);


### PR DESCRIPTION
## Summary
- publish authenticated provider transport metadata from `/v1/catalog`
- gate advertised routes on provider readiness
- accept ClawRouter proxy keys through native SDK credential headers and strip them before upstream forwarding
- verify the deployed catalog contract in the mandatory smoke workflow

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p clawrouter-edge --lib` (90 passed)
- `cargo run -p clawrouter -- provider compile providers/*.provider.yaml`
- `node --check scripts/smoke-deployed.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)
- CI: admin, Rust, and worker-package passed

## Deployment
Deployed commit `ab73a19ca4a8564007fd54ad196e746e62ccdd8e` through [Deploy Cloudflare run 27657825237](https://github.com/openclaw/clawrouter/actions/runs/27657825237). Mandatory live provider and deployed smoke passed.

## Remaining risk
The new catalog fields are additive. Native credential-header authentication intentionally recognizes only syntactically valid ClawRouter proxy keys; client credential headers remain blocked from upstream forwarding.