### PR TITLE
fix: harden ClawRouter production access and providers

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -31,7 +31,12 @@ on:
       access_allowed_domains:
         description: "Comma-separated email domains allowed through Cloudflare Access"
         required: false
-        default: "openclaw.ai"
+        default: ""
+        type: string
+      access_github_orgs:
+        description: "Comma-separated GitHub organizations or org/team selectors allowed through Access"
+        required: false
+        default: "openclaw"
         type: string
       access_admin_emails:
         description: "Comma-separated emails treated as ClawRouter admins"
@@ -48,6 +53,11 @@ on:
         required: false
         default: ""
         type: string
+      configure_provider_secrets:
+        description: "Upload configured provider transport secrets before deployment"
+        required: false
+        default: false
+        type: boolean
       skip_kv_write_preflight:
         description: "Deprecated: ignored for real deploys because Wrangler requires KV write permission for KV bindings"
         required: false
@@ -76,6 +86,7 @@ jobs:
       CLAWROUTER_ACCESS_DEFAULT_TENANT: ${{ vars.CLAWROUTER_ACCESS_DEFAULT_TENANT }}
       CLAWROUTER_ACCESS_ALLOWED_EMAILS: ${{ inputs.access_allowed_emails }}
       CLAWROUTER_ACCESS_ALLOWED_DOMAINS: ${{ inputs.access_allowed_domains }}
+      CLAWROUTER_ACCESS_GITHUB_ORGS: ${{ inputs.access_github_orgs }}
       CLAWROUTER_ACCESS_IDP_IDS: ${{ inputs.access_idp_ids }}
       CLAWROUTER_BASE_URL: ${{ inputs.worker_url }}
       CLAWROUTER_SMOKE_KEY: ${{ secrets.CLAWROUTER_SMOKE_KEY }}
@@ -109,6 +120,38 @@ jobs:
           CLAWROUTER_ACCESS_ADMIN_DOMAINS: ${{ inputs.access_admin_domains || vars.CLAWROUTER_ACCESS_ADMIN_DOMAINS }}
         run: pnpm cf:access -- --write-github-env
       - run: pnpm cf:config
+      - if: ${{ inputs.configure_provider_secrets }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_ANTHROPIC_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLAWROUTER_PROVIDER_AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.CLAWROUTER_PROVIDER_AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLAWROUTER_PROVIDER_AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.CLAWROUTER_PROVIDER_AWS_SESSION_TOKEN }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.CLAWROUTER_PROVIDER_AZURE_OPENAI_API_VERSION }}
+          AZURE_OPENAI_COMPLETION_TOKEN_DEPLOYMENTS: ${{ secrets.CLAWROUTER_PROVIDER_AZURE_OPENAI_COMPLETION_TOKEN_DEPLOYMENTS }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.CLAWROUTER_PROVIDER_AZURE_OPENAI_ENDPOINT }}
+          CLAWROUTER_PROVIDER_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLAWROUTER_PROVIDER_CLOUDFLARE_ACCOUNT_ID }}
+          CLAWROUTER_PROVIDER_CLOUDFLARE_AI_GATEWAY_ID: ${{ secrets.CLAWROUTER_PROVIDER_CLOUDFLARE_AI_GATEWAY_ID }}
+          CLAWROUTER_PROVIDER_CLOUDFLARE_API_TOKEN: ${{ secrets.CLAWROUTER_PROVIDER_CLOUDFLARE_API_TOKEN }}
+          COHERE_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_COHERE_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_DEEPSEEK_API_KEY }}
+          FIRECRAWL_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_FIRECRAWL_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_FIREWORKS_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_GOOGLE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_GROQ_API_KEY }}
+          HUGGINGFACE_API_TOKEN: ${{ secrets.CLAWROUTER_PROVIDER_HUGGINGFACE_API_TOKEN }}
+          MINIMAX_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_MINIMAX_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_MISTRAL_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_OPENROUTER_API_KEY }}
+          OPENROUTER_SITE_URL: https://openclaw.ai
+          PERPLEXITY_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_PERPLEXITY_API_KEY }}
+          REPLICATE_API_TOKEN: ${{ secrets.CLAWROUTER_PROVIDER_REPLICATE_API_TOKEN }}
+          TAVILY_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_TAVILY_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_TOGETHER_API_KEY }}
+          XAI_API_KEY: ${{ secrets.CLAWROUTER_PROVIDER_XAI_API_KEY }}
+        run: pnpm cf:secrets
       - run: pnpm exec wrangler deploy --config .wrangler.generated.toml
       - env:
           CLAWROUTER_CLOUDFLARE_AI_GATEWAY_OPENAI_API_KEY: ${{ secrets.CLAWROUTER_CLOUDFLARE_AI_GATEWAY_OPENAI_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Gate the Cloudflare console by verified GitHub organization membership and support secure bulk provider-secret deployment.
+- Add versioned list pricing for Together Qwen 2.5 7B, DeepSeek V4 Flash, and MiniMax M3 budget enforcement.
+- Fix the Anthropic token-count live smoke request so provider verification no longer sends a messages-only field.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ edge gate with:
 ```sh
 CLOUDFLARE_ACCOUNT_ID=... \
 CLOUDFLARE_API_TOKEN=... \
-CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai \
+CLAWROUTER_ACCESS_GITHUB_ORGS=openclaw \
 CLAWROUTER_ACCESS_ADMIN_EMAILS=you@example.com \
 pnpm cf:access
 ```
@@ -80,7 +80,9 @@ deployment smoke.
 
 The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
 `provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
-Zero Trust Access apps and policies. Real deploys also require KV write
+Zero Trust Access apps and policies. The production default admits verified
+members of the `openclaw` GitHub organization through the configured GitHub
+identity provider. Real deploys also require KV write
 permission because Wrangler validates the Worker `POLICY_KV` binding while
 publishing. Keep `access_domain` set to the console hostname; `worker_url` is
 only the post-deploy smoke-test target.

--- a/docs/agent-spend-control.md
+++ b/docs/agent-spend-control.md
@@ -70,6 +70,12 @@ Rates are integer micro-US-dollars per million tokens. Update `pricingRef` and
 the equivalent public API list price for governance; it is not an invoice for
 the subscription.
 
+Bundled dated pricing also covers Together Qwen 2.5 7B, DeepSeek V4 Flash, and
+MiniMax M3, including DeepSeek cached input and MiniMax's long-context tier.
+Dynamic catalogs such as OpenRouter and generic Hugging Face model routes stay
+unpriced: monthly-budget policies fail closed unless an operator supplies a
+fixed `requestCostMicros` override.
+
 Long-context tiers are selected conservatively from the preflight input bound
 and exactly from reported input usage during settlement. For OpenAI list-priced
 routes, ClawRouter pins absent or `auto` service tiers to `default`; premium or

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -44,7 +44,7 @@ domain as ready:
 ```sh
 export CLOUDFLARE_ACCOUNT_ID=...
 export CLOUDFLARE_API_TOKEN=... # must be able to manage Zero Trust Access apps/policies
-export CLAWROUTER_ACCESS_ALLOWED_DOMAINS=openclaw.ai
+export CLAWROUTER_ACCESS_GITHUB_ORGS=openclaw
 export CLAWROUTER_ACCESS_ADMIN_EMAILS=you@example.com
 pnpm cf:access
 ```
@@ -58,7 +58,12 @@ without calling Cloudflare, or `-- --set-github-vars` to write the non-secret
 GitHub Actions variables after provisioning. In GitHub Actions,
 `-- --write-github-env` writes those same values into `GITHUB_ENV` so the
 current deploy job renders and deploys a Worker that can verify Access JWTs.
-`CLAWROUTER_ACCESS_ALLOWED_*` controls who can pass Cloudflare Access;
+`CLAWROUTER_ACCESS_GITHUB_ORGS` accepts `org` or `org/team` selectors and
+resolves the account's sole GitHub identity provider. Set
+`CLAWROUTER_ACCESS_GITHUB_IDP_ID` when multiple GitHub identity providers
+exist. `CLAWROUTER_ACCESS_ALLOWED_*` remains available for explicit email or
+email-domain exceptions; multiple include rules are ORed by Cloudflare Access.
+These settings control who can pass Cloudflare Access;
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
@@ -109,8 +114,9 @@ CLAWROUTER_ACCESS_DEFAULT_TENANT      # optional, defaults to default
 
 The `Deploy Cloudflare` workflow can provision Access and deploy in one run
 when `CLOUDFLARE_API_TOKEN` has Zero Trust Access application/policy
-permissions. Dispatch it with `provision_access=true`, set the allowlist inputs
-such as `access_allowed_domains=openclaw.ai`, set `access_domain` if the console
+permissions. Dispatch it with `provision_access=true`; the repository default
+uses `access_github_orgs=openclaw` and no email-domain exception. Set
+`access_domain` if the console
 host is not `clawrouter.openclaw.ai`, and optionally set `access_admin_emails`
 or `access_admin_domains`. The workflow runs
 `pnpm cf:access -- --write-github-env` before rendering the Wrangler config, so
@@ -144,6 +150,14 @@ export CLAWROUTER_ADMIN_TOKEN_SHA256=$(printf '%s' "$CLAWROUTER_ADMIN_TOKEN" | s
 printf '%s' "$CLAWROUTER_ADMIN_TOKEN_SHA256" | pnpm exec wrangler secret put CLAWROUTER_ADMIN_TOKEN_SHA256 --config .wrangler.generated.toml
 pnpm exec wrangler secret put OPENAI_API_KEY --config .wrangler.generated.toml
 ```
+
+For a controlled bulk rotation, the deploy workflow can stream temporary
+repository secrets to `wrangler secret bulk` without writing values to disk.
+Store each temporary transport secret as
+`CLAWROUTER_PROVIDER_<WORKER_BINDING>`, dispatch with
+`configure_provider_secrets=true`, verify the live provider smoke, then delete
+the temporary GitHub secrets. `pnpm cf:secrets -- --dry-run` prints binding
+names only; the live command sends a JSON object to Wrangler over stdin.
 
 AWS Bedrock uses SigV4. Bind these values before enabling the Bedrock provider:
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cf:config": "node scripts/render-wrangler-config.mjs",
     "cf:provision": "node scripts/provision-cloudflare.mjs",
     "cf:access": "node scripts/provision-access.mjs",
+    "cf:secrets": "node scripts/put-provider-secrets.mjs",
     "cf:deploy": "pnpm --dir admin build && pnpm cf:config && wrangler deploy --config .wrangler.generated.toml",
     "cf:key:put": "node scripts/key-put.mjs",
     "cf:key:revoke": "node scripts/key-revoke.mjs",

--- a/providers/deepseek.provider.yaml
+++ b/providers/deepseek.provider.yaml
@@ -38,10 +38,17 @@ endpoints:
 models:
   entries:
     - id: deepseek/default
-      upstream: deepseek-chat
+      upstream: deepseek-v4-flash
       capabilities: [llm.chat]
-      pricingRef: deepseek-default
+      pricingRef: deepseek-v4-flash-standard-2026-06-21
+      pricing:
+        effectiveAt: "2026-06-21"
+        source: https://api-docs.deepseek.com/quick_start/pricing
+        inputMicrosPerMillion: 140000
+        cachedInputMicrosPerMillion: 2800
+        outputMicrosPerMillion: 280000
+        maxInputTokens: 1000000
+        defaultMaxOutputTokens: 384000
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]
-

--- a/providers/minimax.provider.yaml
+++ b/providers/minimax.provider.yaml
@@ -40,7 +40,20 @@ models:
     - id: minimax/MiniMax-M3
       upstream: MiniMax-M3
       capabilities: [llm.chat]
-      pricingRef: minimax-m3
+      pricingRef: minimax-m3-standard-2026-06-21
+      pricing:
+        effectiveAt: "2026-06-21"
+        source: https://platform.minimax.io/docs/guides/pricing-paygo
+        inputMicrosPerMillion: 300000
+        cachedInputMicrosPerMillion: 60000
+        outputMicrosPerMillion: 1200000
+        maxInputTokens: 1000000
+        defaultMaxOutputTokens: 128000
+        longContext:
+          thresholdInputTokens: 512000
+          inputMicrosPerMillion: 600000
+          cachedInputMicrosPerMillion: 120000
+          outputMicrosPerMillion: 2400000
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/providers/together.provider.yaml
+++ b/providers/together.provider.yaml
@@ -40,7 +40,14 @@ models:
     - id: together/default
       upstream: Qwen/Qwen2.5-7B-Instruct-Turbo
       capabilities: [llm.chat]
-      pricingRef: together-default
+      pricingRef: together-qwen-2-5-7b-instruct-turbo-2026-06-21
+      pricing:
+        effectiveAt: "2026-06-21"
+        source: https://www.together.ai/pricing
+        inputMicrosPerMillion: 300000
+        outputMicrosPerMillion: 300000
+        maxInputTokens: 32768
+        defaultMaxOutputTokens: 8192
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/scripts/provider-smoke-plan.mjs
+++ b/scripts/provider-smoke-plan.mjs
@@ -537,11 +537,14 @@ function sampleBody(provider, endpoint, method, env) {
     return { contents: [{ parts: [{ text: "reply with ok" }] }] };
   }
   if (provider.id === "anthropic") {
-    return {
+    const body = {
       model: provider.models.find((model) => !model.upstream.includes("${"))?.upstream,
-      max_tokens: 16,
       messages: [{ role: "user", content: "reply with ok" }],
     };
+    if (endpoint.id === "messages") {
+      body.max_tokens = 16;
+    }
+    return body;
   }
   if (provider.id === "cohere") {
     return { model: "command", messages: [{ role: "user", content: "reply with ok" }] };

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -24,41 +24,46 @@ const adminEmails = csv(process.env.CLAWROUTER_ACCESS_ADMIN_EMAILS);
 const adminDomains = csv(process.env.CLAWROUTER_ACCESS_ADMIN_DOMAINS);
 const accessAllowedEmails = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_EMAILS);
 const accessAllowedDomains = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_DOMAINS);
-const allowedEmails = accessAllowedEmails.length > 0 ? accessAllowedEmails : adminEmails;
-const allowedDomains = accessAllowedDomains.length > 0 ? accessAllowedDomains : adminDomains;
+const githubOrganizations = csv(process.env.CLAWROUTER_ACCESS_GITHUB_ORGS);
+const configuredGithubIdpId = process.env.CLAWROUTER_ACCESS_GITHUB_IDP_ID?.trim() || "";
+const allowedEmails =
+  accessAllowedEmails.length > 0
+    ? accessAllowedEmails
+    : githubOrganizations.length > 0
+      ? []
+      : adminEmails;
+const allowedDomains =
+  accessAllowedDomains.length > 0
+    ? accessAllowedDomains
+    : githubOrganizations.length > 0
+      ? []
+      : adminDomains;
 const serviceTokenIds = csv(process.env.CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS);
 const allowedIdps = csv(process.env.CLAWROUTER_ACCESS_IDP_IDS);
 const defaultTenant =
   process.env.CLAWROUTER_ACCESS_DEFAULT_TENANT?.trim() || "default";
-const requestedAutoRedirect = process.env.CLAWROUTER_ACCESS_AUTO_REDIRECT?.trim();
-if (requestedAutoRedirect === "1" && allowedIdps.length !== 1) {
-  throw new Error(
-    "CLAWROUTER_ACCESS_AUTO_REDIRECT=1 requires exactly one CLAWROUTER_ACCESS_IDP_IDS value",
-  );
-}
-const autoRedirect =
-  requestedAutoRedirect === "1" ||
-  (requestedAutoRedirect !== "0" && allowedIdps.length === 1);
 const repo = process.env.CLAWROUTER_GITHUB_REPO?.trim() || "openclaw/clawrouter";
 const setGitHubVars = Boolean(args["set-github-vars"]);
 const writeGitHubEnv = Boolean(args["write-github-env"]);
 const keepExtraPolicies = process.env.CLAWROUTER_ACCESS_KEEP_EXTRA_POLICIES === "1";
 
-const humanInclude = buildHumanPolicyInclude({
-  allowedEmails,
-  allowedDomains,
-  allowEveryone: process.env.CLAWROUTER_ACCESS_ALLOW_EVERYONE === "1",
-});
 const serviceInclude = serviceTokenIds.map((tokenId) => ({
   service_token: { token_id: tokenId },
 }));
 
-if (humanInclude.length === 0 && serviceInclude.length === 0) {
+if (
+  allowedEmails.length === 0 &&
+  allowedDomains.length === 0 &&
+  githubOrganizations.length === 0 &&
+  process.env.CLAWROUTER_ACCESS_ALLOW_EVERYONE !== "1" &&
+  serviceInclude.length === 0
+) {
   throw new Error(
     [
       "refusing to create an Access policy with no include rules",
       "set CLAWROUTER_ACCESS_ALLOWED_EMAILS, CLAWROUTER_ACCESS_ALLOWED_DOMAINS,",
-      "CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS, or CLAWROUTER_ACCESS_ALLOW_EVERYONE=1",
+      "CLAWROUTER_ACCESS_GITHUB_ORGS, CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS,",
+      "or CLAWROUTER_ACCESS_ALLOW_EVERYONE=1",
     ].join(" "),
   );
 }
@@ -66,6 +71,30 @@ if (humanInclude.length === 0 && serviceInclude.length === 0) {
 if (!dryRun && !token) {
   throw new Error("CLOUDFLARE_API_TOKEN is required unless --dry-run is set");
 }
+
+const githubIdpId =
+  githubOrganizations.length === 0
+    ? ""
+    : configuredGithubIdpId ||
+      (dryRun ? "<github-identity-provider-id>" : await githubIdentityProviderId());
+const effectiveAllowedIdps =
+  allowedIdps.length > 0 ? allowedIdps : githubIdpId ? [githubIdpId] : [];
+const requestedAutoRedirect = process.env.CLAWROUTER_ACCESS_AUTO_REDIRECT?.trim();
+if (requestedAutoRedirect === "1" && effectiveAllowedIdps.length !== 1) {
+  throw new Error(
+    "CLAWROUTER_ACCESS_AUTO_REDIRECT=1 requires exactly one effective identity provider",
+  );
+}
+const autoRedirect =
+  requestedAutoRedirect === "1" ||
+  (requestedAutoRedirect !== "0" && effectiveAllowedIdps.length === 1);
+const humanInclude = buildHumanPolicyInclude({
+  allowedEmails,
+  allowedDomains,
+  githubOrganizations,
+  githubIdpId,
+  allowEveryone: process.env.CLAWROUTER_ACCESS_ALLOW_EVERYONE === "1",
+});
 
 const appPayload = {
   name: appName,
@@ -76,8 +105,8 @@ const appPayload = {
   app_launcher_visible: false,
   auto_redirect_to_identity: autoRedirect,
 };
-if (allowedIdps.length > 0) {
-  appPayload.allowed_idps = allowedIdps;
+if (effectiveAllowedIdps.length > 0) {
+  appPayload.allowed_idps = effectiveAllowedIdps;
 }
 
 const policyPayloads = [
@@ -210,6 +239,26 @@ async function getAccessOrganization() {
   }
 }
 
+async function githubIdentityProviderId() {
+  const providers = asArray(
+    await request("GET", `/accounts/${accountId}/access/identity_providers`),
+  );
+  const githubProviders = providers.filter(
+    (provider) =>
+      provider.type === "github" &&
+      (allowedIdps.length === 0 || allowedIdps.includes(provider.id)),
+  );
+  if (githubProviders.length !== 1) {
+    throw new Error(
+      [
+        `expected exactly one GitHub identity provider, found ${githubProviders.length}`,
+        "set CLAWROUTER_ACCESS_GITHUB_IDP_ID explicitly when the account has multiple providers",
+      ].join("; "),
+    );
+  }
+  return githubProviders[0].id;
+}
+
 async function findAccessApplication(targetName, targetHost, targetDomains) {
   const apps = asArray(await request("GET", `/accounts/${accountId}/access/apps?per_page=100`));
   return (
@@ -278,6 +327,8 @@ async function request(method, path, body) {
 function buildHumanPolicyInclude({
   allowedEmails: emails,
   allowedDomains: domains,
+  githubOrganizations: organizations,
+  githubIdpId: identityProviderId,
   allowEveryone,
 }) {
   const rules = [];
@@ -287,10 +338,34 @@ function buildHumanPolicyInclude({
   for (const domainValue of domains) {
     rules.push({ email_domain: { domain: domainValue } });
   }
+  for (const subject of organizations) {
+    rules.push(githubOrganizationRule(subject, identityProviderId));
+  }
   if (allowEveryone) {
     rules.push({ everyone: {} });
   }
   return rules;
+}
+
+function githubOrganizationRule(subject, identityProviderId) {
+  const parts = subject.split("/");
+  if (
+    !identityProviderId ||
+    parts.length > 2 ||
+    parts.some((part) => !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/.test(part))
+  ) {
+    throw new Error(
+      `invalid GitHub organization rule ${JSON.stringify(subject)}; expected org or org/team`,
+    );
+  }
+  const [name, team] = parts;
+  return {
+    "github-organization": {
+      identity_provider_id: identityProviderId,
+      name,
+      ...(team ? { team } : {}),
+    },
+  };
 }
 
 function accessTeamDomain(organization) {
@@ -403,6 +478,18 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   for (const policy of policies.filter((entry) => entry.include.length > 0)) {
     console.log(`policy=${policy.name} decision=${policy.decision}`);
   }
+  if (githubOrganizations.length > 0) {
+    console.log(`githubOrganizations=${githubOrganizations.join(",")}`);
+  }
+  console.log(
+    `humanIncludeKinds=${[
+      ...new Set(
+        policies
+          .filter((entry) => entry.decision === "allow")
+          .flatMap((entry) => entry.include.flatMap((rule) => Object.keys(rule))),
+      ),
+    ].join(",")}`,
+  );
   console.log(`created=${created}`);
   console.log(`updated=${updated}`);
   console.log(`teamDomain=${teamDomain || "<pending>"}`);

--- a/scripts/put-provider-secrets.mjs
+++ b/scripts/put-provider-secrets.mjs
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const providerSecretNames = [
+  "ANTHROPIC_API_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_API_VERSION",
+  "AZURE_OPENAI_COMPLETION_TOKEN_DEPLOYMENTS",
+  "AZURE_OPENAI_ENDPOINT",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_AI_GATEWAY_ID",
+  "CLOUDFLARE_API_TOKEN",
+  "COHERE_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "FIRECRAWL_API_KEY",
+  "FIREWORKS_API_KEY",
+  "GOOGLE_API_KEY",
+  "GROQ_API_KEY",
+  "HUGGINGFACE_API_TOKEN",
+  "MINIMAX_API_KEY",
+  "MISTRAL_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "OPENROUTER_SITE_URL",
+  "PERPLEXITY_API_KEY",
+  "REPLICATE_API_TOKEN",
+  "TAVILY_API_KEY",
+  "TOGETHER_API_KEY",
+  "XAI_API_KEY",
+];
+
+const providerSecretSources = {
+  CLOUDFLARE_ACCOUNT_ID: "CLAWROUTER_PROVIDER_CLOUDFLARE_ACCOUNT_ID",
+  CLOUDFLARE_AI_GATEWAY_ID: "CLAWROUTER_PROVIDER_CLOUDFLARE_AI_GATEWAY_ID",
+  CLOUDFLARE_API_TOKEN: "CLAWROUTER_PROVIDER_CLOUDFLARE_API_TOKEN",
+};
+
+export function configuredProviderSecrets(env = process.env) {
+  const secrets = Object.fromEntries(
+    providerSecretNames
+      .map((name) => [name, env[providerSecretSources[name] ?? name]])
+      .filter(([, value]) => typeof value === "string" && value.length > 0),
+  );
+  if (!secrets.OPENROUTER_API_KEY) {
+    delete secrets.OPENROUTER_SITE_URL;
+  }
+  return secrets;
+}
+
+export function putProviderSecrets({ env = process.env, dryRun = false } = {}) {
+  const secrets = configuredProviderSecrets(env);
+  const names = Object.keys(secrets);
+  if (names.length === 0) {
+    throw new Error("no provider secrets are configured");
+  }
+  if (dryRun) {
+    console.log(`provider secrets ready: count=${names.length} names=${names.join(",")}`);
+    return;
+  }
+
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "wrangler", "secret", "bulk", "--config", ".wrangler.generated.toml"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env,
+      input: JSON.stringify(secrets),
+      stdio: ["pipe", "inherit", "inherit"],
+    },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`wrangler secret bulk failed with status ${result.status}`);
+  }
+  console.log(`provider secrets uploaded: count=${names.length} names=${names.join(",")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  putProviderSecrets({ dryRun: process.argv.includes("--dry-run") });
+}

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -43,6 +43,31 @@ test("Firecrawl uses keyless mode without a configured API key", () => {
   });
 });
 
+test("Anthropic count_tokens smoke omits messages-only max_tokens", () => {
+  const provider = buildProviderSmokePlan(compileProviderSnapshot(), {}).providers.find(
+    (entry) => entry.id === "anthropic",
+  );
+  assert.equal(provider.target.kind, "manifest_proxy");
+  assert.equal(provider.target.endpoint, "count_tokens");
+  assert.equal(provider.target.envelope.body.max_tokens, undefined);
+  assert.equal(provider.target.envelope.body.model, "claude-sonnet-4-5-20250929");
+});
+
+test("newly budgeted provider defaults compile with dated pricing", () => {
+  const snapshot = compileProviderSnapshot();
+  const expectations = {
+    deepseek: [140000, 280000],
+    minimax: [300000, 1200000],
+    together: [300000, 300000],
+  };
+  for (const [providerId, [input, output]] of Object.entries(expectations)) {
+    const model = snapshot.providers.find((provider) => provider.id === providerId).models[0];
+    assert.equal(model.pricing.effectiveAt, "2026-06-21");
+    assert.equal(model.pricing.inputMicrosPerMillion, input);
+    assert.equal(model.pricing.outputMicrosPerMillion, output);
+  }
+});
+
 test("gateway failures do not overwrite provider health", async () => {
   await withFetch(
     () =>

--- a/test/provision-access.test.mjs
+++ b/test/provision-access.test.mjs
@@ -22,3 +22,44 @@ test("Access provisioning protects the browser OAuth callback by default", () =>
   const destinations = result.stdout.match(/^destinations=(.+)$/m)?.[1].split(",") ?? [];
   assert.equal(destinations.length, 5);
 });
+
+test("Access provisioning supports an exact GitHub organization rule", () => {
+  const result = spawnSync("node", ["scripts/provision-access.mjs", "--dry-run"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLOUDFLARE_ACCOUNT_ID: "account-placeholder",
+      CLAWROUTER_ACCESS_ALLOWED_EMAILS: "",
+      CLAWROUTER_ACCESS_ALLOWED_DOMAINS: "",
+      CLAWROUTER_ACCESS_ADMIN_EMAILS: "break-glass@example.com",
+      CLAWROUTER_ACCESS_ADMIN_DOMAINS: "example.com",
+      CLAWROUTER_ACCESS_GITHUB_ORGS: "openclaw,openclaw/maintainers",
+      CLAWROUTER_ACCESS_DOMAIN: "clawrouter.example.com",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^githubOrganizations=openclaw,openclaw\/maintainers$/m);
+  assert.match(result.stdout, /^policy=ClawRouter Console Users decision=allow$/m);
+  assert.match(result.stdout, /^humanIncludeKinds=github-organization$/m);
+});
+
+test("Access provisioning rejects malformed GitHub organization selectors", () => {
+  const result = spawnSync("node", ["scripts/provision-access.mjs", "--dry-run"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLOUDFLARE_ACCOUNT_ID: "account-placeholder",
+      CLAWROUTER_ACCESS_ALLOWED_EMAILS: "",
+      CLAWROUTER_ACCESS_ALLOWED_DOMAINS: "",
+      CLAWROUTER_ACCESS_ADMIN_EMAILS: "",
+      CLAWROUTER_ACCESS_ADMIN_DOMAINS: "",
+      CLAWROUTER_ACCESS_GITHUB_ORGS: "openclaw/team/extra",
+    },
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /invalid GitHub organization rule/);
+});

--- a/test/put-provider-secrets.test.mjs
+++ b/test/put-provider-secrets.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  configuredProviderSecrets,
+  providerSecretNames,
+} from "../scripts/put-provider-secrets.mjs";
+
+test("provider secret selection keeps only the declared non-empty bindings", () => {
+  assert.deepEqual(
+    configuredProviderSecrets({
+      CLOUDFLARE_API_TOKEN: "deploy-token-must-not-be-uploaded",
+      OPENAI_API_KEY: "secret",
+      OPENROUTER_SITE_URL: "https://example.com",
+      XAI_API_KEY: "",
+    }),
+    { OPENAI_API_KEY: "secret" },
+  );
+  assert.deepEqual(
+    configuredProviderSecrets({
+      CLAWROUTER_PROVIDER_CLOUDFLARE_ACCOUNT_ID: "account-id",
+      CLAWROUTER_PROVIDER_CLOUDFLARE_API_TOKEN: "gateway-token",
+    }),
+    {
+      CLOUDFLARE_ACCOUNT_ID: "account-id",
+      CLOUDFLARE_API_TOKEN: "gateway-token",
+    },
+  );
+  assert.equal(providerSecretNames.includes("COHERE_API_KEY"), true);
+  assert.equal(providerSecretNames.includes("REPLICATE_API_TOKEN"), true);
+  assert.equal(providerSecretNames.includes("TAVILY_API_KEY"), true);
+});
+
+test("provider secret dry-run reports names without values", () => {
+  const result = spawnSync("node", ["scripts/put-provider-secrets.mjs", "--dry-run"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...process.env, OPENAI_API_KEY: "must-not-be-printed" },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /OPENAI_API_KEY/);
+  assert.doesNotMatch(result.stdout, /must-not-be-printed/);
+});


### PR DESCRIPTION
## Summary

- gate the Cloudflare console with verified OpenClaw GitHub organization membership
- upload configured provider credentials through a temporary, allowlisted Wrangler bulk-secret path
- add dated Together, DeepSeek, and MiniMax pricing and fix the Anthropic count-tokens smoke request

## Verification

- `pnpm check`
- `pnpm test:scripts`
- `pnpm provider:compile`
- `actionlint .github/workflows/deploy-cloudflare.yml`
- autoreview clean
- reproduced the existing GitHub OAuth denial in the real Chrome profile

## Deployment

- pending merge; deploy workflow will reprovision Access, upload provider secrets, deploy, and run live provider smoke

## Remaining risk

- live provider validity and GitHub organization authorization require production verification after merge
