### PR TITLE
fix: reuse configured Access identity provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Gate the Cloudflare console by verified GitHub organization membership and support secure bulk provider-secret deployment.
 - Add versioned list pricing for Together Qwen 2.5 7B, DeepSeek V4 Flash, and MiniMax M3 budget enforcement.
 - Fix the Anthropic token-count live smoke request so provider verification no longer sends a messages-only field.
+- Allow Access provisioning to use an explicitly allowed GitHub identity provider without identity-provider list permission.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -61,7 +61,8 @@ current deploy job renders and deploys a Worker that can verify Access JWTs.
 `CLAWROUTER_ACCESS_GITHUB_ORGS` accepts `org` or `org/team` selectors and
 resolves the account's sole GitHub identity provider. Set
 `CLAWROUTER_ACCESS_GITHUB_IDP_ID` when multiple GitHub identity providers
-exist. `CLAWROUTER_ACCESS_ALLOWED_*` remains available for explicit email or
+exist, or set one `CLAWROUTER_ACCESS_IDP_IDS` value when the deployment token
+cannot list identity providers. `CLAWROUTER_ACCESS_ALLOWED_*` remains available for explicit email or
 email-domain exceptions; multiple include rules are ORed by Cloudflare Access.
 These settings control who can pass Cloudflare Access;
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -25,7 +25,6 @@ const adminDomains = csv(process.env.CLAWROUTER_ACCESS_ADMIN_DOMAINS);
 const accessAllowedEmails = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_EMAILS);
 const accessAllowedDomains = csv(process.env.CLAWROUTER_ACCESS_ALLOWED_DOMAINS);
 const githubOrganizations = csv(process.env.CLAWROUTER_ACCESS_GITHUB_ORGS);
-const configuredGithubIdpId = process.env.CLAWROUTER_ACCESS_GITHUB_IDP_ID?.trim() || "";
 const allowedEmails =
   accessAllowedEmails.length > 0
     ? accessAllowedEmails
@@ -40,6 +39,9 @@ const allowedDomains =
       : adminDomains;
 const serviceTokenIds = csv(process.env.CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS);
 const allowedIdps = csv(process.env.CLAWROUTER_ACCESS_IDP_IDS);
+const configuredGithubIdpId =
+  process.env.CLAWROUTER_ACCESS_GITHUB_IDP_ID?.trim() ||
+  (allowedIdps.length === 1 ? allowedIdps[0] : "");
 const defaultTenant =
   process.env.CLAWROUTER_ACCESS_DEFAULT_TENANT?.trim() || "default";
 const repo = process.env.CLAWROUTER_GITHUB_REPO?.trim() || "openclaw/clawrouter";
@@ -480,6 +482,9 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   }
   if (githubOrganizations.length > 0) {
     console.log(`githubOrganizations=${githubOrganizations.join(",")}`);
+    console.log(
+      `githubIdentityProviderSource=${configuredGithubIdpId ? "configured" : "discovered"}`,
+    );
   }
   console.log(
     `humanIncludeKinds=${[

--- a/test/provision-access.test.mjs
+++ b/test/provision-access.test.mjs
@@ -35,12 +35,14 @@ test("Access provisioning supports an exact GitHub organization rule", () => {
       CLAWROUTER_ACCESS_ADMIN_EMAILS: "break-glass@example.com",
       CLAWROUTER_ACCESS_ADMIN_DOMAINS: "example.com",
       CLAWROUTER_ACCESS_GITHUB_ORGS: "openclaw,openclaw/maintainers",
+      CLAWROUTER_ACCESS_IDP_IDS: "github-idp-explicit",
       CLAWROUTER_ACCESS_DOMAIN: "clawrouter.example.com",
     },
   });
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /^githubOrganizations=openclaw,openclaw\/maintainers$/m);
+  assert.match(result.stdout, /^githubIdentityProviderSource=configured$/m);
   assert.match(result.stdout, /^policy=ClawRouter Console Users decision=allow$/m);
   assert.match(result.stdout, /^humanIncludeKinds=github-organization$/m);
 });


### PR DESCRIPTION
## Summary

- reuse the single explicitly allowed Access identity provider as the GitHub organization rule provider
- avoid requiring identity-provider list permission from the deployment token

## Verification

- `pnpm test:scripts`
- autoreview clean
- production failure reproduced on the identity-provider list request before any mutation

## Deployment

- retry production Access provisioning and deploy after merge
