### PR TITLE
fix: generate route-specific playground requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Fix the Anthropic token-count live smoke request so provider verification no longer sends a messages-only field.
 - Allow Access provisioning to use an explicitly allowed GitHub identity provider without identity-provider list permission.
 - Replace stale Google, Groq, xAI, and Hugging Face defaults with live models and dated list pricing where provider-stable rates exist.
+- Generate route-specific Playground service requests so switching providers no longer sends stale bodies or path values.

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -11,6 +11,8 @@ export interface RouteCatalog {
     route: string;
     methods: string[];
     pathParams?: string[];
+    requestFormat?: string;
+    sampleModel?: string | null;
     streaming?: boolean | null;
   }>;
 }
@@ -433,6 +435,58 @@ export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["ma
     return { model: form.model, input: form.prompt, instructions: form.system || undefined, max_output_tokens: maxTokens, temperature };
   }
   return { model: form.model, messages: [...(form.system ? [{ role: "system", content: form.system }] : []), { role: "user", content: form.prompt }], max_tokens: maxTokens, temperature };
+}
+
+export function playgroundServicePreset(route?: RouteCatalog["manifestProxy"][number]) {
+  const model = route?.sampleModel ?? `${route?.provider ?? "provider"}/default`;
+  const format = route?.requestFormat ?? `${route?.provider ?? ""}.${route?.endpoint ?? ""}`;
+  let body: unknown = {};
+
+  if (format === "anthropic.messages") {
+    body = {
+      model,
+      messages: [{ role: "user", content: "Reply with ok." }],
+      ...(route?.endpoint === "messages" ? { max_tokens: 16 } : {}),
+    };
+  } else if (format === "aws_bedrock.invoke") {
+    body = {
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "Reply with ok." }],
+    };
+  } else if (format === "cloudflare_ai_gateway.universal") {
+    body = [{ provider: "workers-ai", endpoint: "@cf/meta/llama-3.1-8b-instruct", query: { prompt: "Reply with ok." } }];
+  } else if (format === "cohere.chat") {
+    body = { model, messages: [{ role: "user", content: "Reply with ok." }] };
+  } else if (format === "cohere.embed") {
+    body = { model, texts: ["OpenClaw"], input_type: "search_document", embedding_types: ["float"] };
+  } else if (format === "firecrawl.scrape") {
+    body = { url: "https://example.com", formats: ["markdown"] };
+  } else if (format === "google.generate_content") {
+    body = { contents: [{ parts: [{ text: "Reply with ok." }] }] };
+  } else if (format === "openai.chat_completions") {
+    body = { model, messages: [{ role: "user", content: "Reply with ok." }], max_tokens: 16 };
+  } else if (format === "openai.embeddings") {
+    body = { model, input: "OpenClaw" };
+  } else if (format === "openai.responses") {
+    body = { model, input: "Reply with ok.", max_output_tokens: 16 };
+  } else if (format === "replicate.prediction_create") {
+    body = { version: "MODEL_VERSION", input: { prompt: "A small red crab." } };
+  } else if (format === "tavily.search") {
+    body = { query: "OpenClaw", max_results: 1 };
+  } else if (format === "tavily.extract") {
+    body = { urls: ["https://example.com"] };
+  } else if (format === "tavily.crawl") {
+    body = { url: "https://example.com", max_depth: 1, limit: 1 };
+  }
+
+  const pathParam = route?.pathParams?.[0];
+  return {
+    serviceRoute: routeKey(route),
+    serviceMethod: route?.methods[0] ?? "POST",
+    servicePath: pathParam === "model" || pathParam === "deployment" ? model : pathParam ? pathParam.replaceAll("_", "-") : "",
+    servicePayload: JSON.stringify(body, null, 2),
+  };
 }
 
 export function playgroundAccessEndpoint(form: PlaygroundForm, route?: RouteCatalog["manifestProxy"][number]) {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -35,6 +35,7 @@ import {
   playgroundBlockedForService,
   playgroundBlocker,
   playgroundPayload,
+  playgroundServicePreset,
   policyCoversProvider,
   policyUsageFallback,
   readinessLabel,
@@ -121,6 +122,8 @@ interface RouteCatalog {
     route: string;
     methods: string[];
     pathParams?: string[];
+    requestFormat?: string;
+    sampleModel?: string | null;
     streaming?: boolean | null;
   }>;
 }
@@ -473,6 +476,7 @@ const demoDisabledProviderIds = new Set(["aws-bedrock", "cloudflare-ai-gateway"]
 const demoMissingConfigProviderIds = new Set(["azure-openai"]);
 const demo = demoData();
 const demoServiceRoute = demo.routes.manifestProxy.find((route) => route.provider === "tavily") ?? demo.routes.manifestProxy[0];
+const demoServicePreset = playgroundServicePreset(demoServiceRoute);
 const emptyRoutes: RouteCatalog = { openaiCompatible: [], manifestProxy: [] };
 const emptySession: SessionResponse = { authenticated: false, auth: "access", role: "user", email: null, tenantId: "default" };
 const emptyUsageSnapshot: UsageSnapshot = {
@@ -570,10 +574,7 @@ function App() {
     mode: "model",
     model: catalogModels(demo.routes)[0]?.id ?? "",
     endpoint: "/v1/chat/completions",
-    serviceRoute: routeKey(demoServiceRoute),
-    serviceMethod: demoServiceRoute?.methods[0] ?? "POST",
-    servicePath: "search",
-    servicePayload: '{\n  "query": "test"\n}',
+    ...demoServicePreset,
     system: "You are concise and useful.",
     prompt: "Say hello from ClawRouter in one short sentence.",
     maxTokens: "128",
@@ -631,7 +632,7 @@ function App() {
   useEffect(() => {
     if (serviceRoutes.length && !serviceRoutes.some((route) => routeKey(route) === playground.serviceRoute)) {
       const route = serviceRoutes[0];
-      setPlayground((current) => ({ ...current, serviceRoute: routeKey(route), serviceMethod: route.methods[0] ?? "POST" }));
+      setPlayground((current) => ({ ...current, ...playgroundServicePreset(route) }));
     }
   }, [playground.serviceRoute, serviceRoutes]);
 
@@ -1449,7 +1450,7 @@ function App() {
               const proxyRoute = serviceRoutes.find((route) => route.provider === service.provider);
               setPlayground((current) => model
                 ? { ...current, mode: "model", model: model.id }
-                : proxyRoute ? { ...current, mode: "service", serviceRoute: routeKey(proxyRoute), serviceMethod: proxyRoute.methods[0] ?? "POST" } : current);
+                : proxyRoute ? { ...current, mode: "service", ...playgroundServicePreset(proxyRoute) } : current);
               navigateTo("playground");
             }}
             onAdd={(service) => {
@@ -1730,10 +1731,10 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
             <>
               <label><span>Service route</span><select value={form.serviceRoute} onChange={(event) => {
                 const route = serviceRoutes.find((item) => routeKey(item) === event.target.value);
-                setForm({ ...form, serviceRoute: event.target.value, serviceMethod: route?.methods[0] ?? "POST" });
+                setForm({ ...form, ...playgroundServicePreset(route) });
               }}>{serviceRoutes.map((route) => <option key={routeKey(route)} value={routeKey(route)}>{route.provider} / {route.endpoint}</option>)}</select></label>
               <label><span>Method</span><select value={form.serviceMethod} onChange={(event) => setForm({ ...form, serviceMethod: event.target.value })}>{methods.map((method) => <option key={method} value={method}>{method}</option>)}</select></label>
-              <label><span>Path / id</span><input value={form.servicePath} onChange={(event) => setForm({ ...form, servicePath: event.target.value })} placeholder="replacement for route variables" /></label>
+              {selectedServiceRoute?.pathParams?.length ? <label><span>{selectedServiceRoute.pathParams.join(" / ")}</span><input value={form.servicePath} onChange={(event) => setForm({ ...form, servicePath: event.target.value })} placeholder="route path value" /></label> : null}
             </>
           )}
         </div>
@@ -1749,7 +1750,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
         <div className="playgroundHeader">
           <div className="modeTabs" role="tablist" aria-label="playground mode">
             <button type="button" className={form.mode === "model" ? "active" : ""} onClick={() => setForm({ ...form, mode: "model" })}>Model</button>
-            <button type="button" className={form.mode === "service" ? "active" : ""} onClick={() => setForm({ ...form, mode: "service" })}>Service</button>
+            <button type="button" className={form.mode === "service" ? "active" : ""} onClick={() => setForm({ ...form, mode: "service", ...playgroundServicePreset(selectedServiceRoute) })}>Service</button>
           </div>
           <button type="submit" disabled={busy || Boolean(blocker)} title={blocker ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Run request</span></button>
         </div>
@@ -2923,11 +2924,11 @@ function demoData() {
       modelRoute("xai", ["/v1/chat/completions"], [modelEntry("xai/default", ["llm.chat"], ["/v1/chat/completions"])]),
     ],
     manifestProxy: [
-      manifestRoute("replicate", "predictions", "/v1/proxy/replicate/predictions", ["POST"]),
-      manifestRoute("replicate", "prediction", "/v1/proxy/replicate/prediction", ["GET"], ["prediction_id"]),
-      manifestRoute("tavily", "search", "/v1/proxy/tavily/search", ["POST"]),
-      manifestRoute("tavily", "extract", "/v1/proxy/tavily/extract", ["POST"]),
-      manifestRoute("tavily", "crawl", "/v1/proxy/tavily/crawl", ["POST"]),
+      manifestRoute("replicate", "predictions", "/v1/proxy/replicate/predictions", ["POST"], [], "replicate.prediction_create", "replicate/predictions"),
+      manifestRoute("replicate", "prediction", "/v1/proxy/replicate/prediction", ["GET"], ["prediction_id"], "replicate.prediction_get", "replicate/predictions"),
+      manifestRoute("tavily", "search", "/v1/proxy/tavily/search", ["POST"], [], "tavily.search", "tavily/search"),
+      manifestRoute("tavily", "extract", "/v1/proxy/tavily/extract", ["POST"], [], "tavily.extract", "tavily/extract"),
+      manifestRoute("tavily", "crawl", "/v1/proxy/tavily/crawl", ["POST"], [], "tavily.crawl", "tavily/search"),
     ],
   };
   const keys: AccessPolicy[] = [
@@ -3026,8 +3027,8 @@ function modelEntry(id: string, capabilities: string[], endpoints: string[]) {
   return { id, capabilities, endpoints };
 }
 
-function manifestRoute(provider: string, endpoint: string, route: string, methods: string[], pathParams: string[] = []): RouteCatalog["manifestProxy"][number] {
-  return { provider, endpoint, route, methods, pathParams };
+function manifestRoute(provider: string, endpoint: string, route: string, methods: string[], pathParams: string[] = [], requestFormat?: string, sampleModel?: string): RouteCatalog["manifestProxy"][number] {
+  return { provider, endpoint, route, methods, pathParams, requestFormat, sampleModel };
 }
 
 function provider(id: string, display_name: string, providerClass: string, service_kind: string, capabilities: string[], authorizationKind?: "oauth" | "subscription"): ProviderRow {

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -8,6 +8,7 @@ import {
   playgroundAccessEndpoint,
   playgroundBlocker,
   playgroundPayload,
+  playgroundServicePreset,
   policyUsageFallback,
   reconcileDirectUserBindings,
   readinessTone,
@@ -121,6 +122,64 @@ test("playground payloads preserve model and service semantics", () => {
     body: { detail: true },
   });
   assert.equal(playgroundAccessEndpoint(form, route), "/v1/playground/proxy/replicate/prediction");
+});
+
+test("service route presets replace stale body, method, and path values", () => {
+  const countTokens = {
+    provider: "anthropic",
+    endpoint: "count_tokens",
+    route: "/v1/proxy/anthropic/count_tokens",
+    methods: ["POST"],
+    pathParams: [],
+    requestFormat: "anthropic.messages",
+    sampleModel: "anthropic/default",
+  };
+  assert.deepEqual(playgroundServicePreset(countTokens), {
+    serviceRoute: "anthropic:count_tokens:/v1/proxy/anthropic/count_tokens",
+    serviceMethod: "POST",
+    servicePath: "",
+    servicePayload: JSON.stringify({
+      model: "anthropic/default",
+      messages: [{ role: "user", content: "Reply with ok." }],
+    }, null, 2),
+  });
+
+  const google = {
+    provider: "google-gemini",
+    endpoint: "generate_content",
+    route: "/v1/proxy/google-gemini/generate_content",
+    methods: ["POST"],
+    pathParams: ["model"],
+    requestFormat: "google.generate_content",
+    sampleModel: "google/gemini-default",
+  };
+  const preset = playgroundServicePreset(google);
+  assert.equal(preset.servicePath, "google/gemini-default");
+  assert.deepEqual(JSON.parse(preset.servicePayload), {
+    contents: [{ parts: [{ text: "Reply with ok." }] }],
+  });
+});
+
+test("service route presets cover every bundled request format family", () => {
+  const cases = [
+    ["aws_bedrock.invoke", "invoke_model"],
+    ["cloudflare_ai_gateway.universal", "universal"],
+    ["cohere.chat", "chat"],
+    ["cohere.embed", "embed"],
+    ["firecrawl.scrape", "scrape"],
+    ["openai.chat_completions", "chat_completions"],
+    ["openai.embeddings", "embeddings"],
+    ["openai.responses", "responses"],
+    ["replicate.prediction_create", "predictions"],
+    ["tavily.search", "search"],
+    ["tavily.extract", "extract"],
+    ["tavily.crawl", "crawl"],
+  ];
+  for (const [requestFormat, endpoint] of cases) {
+    const preset = playgroundServicePreset({ provider: "test", endpoint, route: `/v1/proxy/test/${endpoint}`, methods: ["POST"], requestFormat, sampleModel: "test/default" });
+    assert.doesNotThrow(() => JSON.parse(preset.servicePayload), requestFormat);
+    assert.notEqual(preset.servicePayload, "{}", requestFormat);
+  }
 });
 
 test("budget parsing and fallback summaries keep blocked and wildcard states explicit", () => {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -468,12 +468,26 @@ fn route_catalog(snapshot: &ProviderSnapshot) -> Value {
         .iter()
         .flat_map(|provider| {
             provider.endpoints.iter().map(move |endpoint| {
+                let endpoint_capabilities = provider
+                    .capabilities
+                    .iter()
+                    .filter(|capability| capability.endpoint == endpoint.id)
+                    .map(|capability| capability.id.as_str())
+                    .collect::<Vec<_>>();
+                let sample_model = provider.models.iter().find(|model| {
+                    model
+                        .capabilities
+                        .iter()
+                        .any(|capability| endpoint_capabilities.contains(&capability.as_str()))
+                });
                 serde_json::json!({
                     "provider": provider.id,
                     "endpoint": endpoint.id,
                     "route": format!("/v1/proxy/{}/{}", provider.id, endpoint.id),
                     "methods": &endpoint.methods,
                     "pathParams": &endpoint.path_params,
+                    "requestFormat": &endpoint.request_format,
+                    "sampleModel": sample_model.map(|model| model.id.as_str()),
                     "streaming": &endpoint.streaming
                 })
             })
@@ -1050,11 +1064,10 @@ async fn proxy_manifest_endpoint(
     };
     let mut upstream_body_json = method_allows_body(&upstream_method)
         .then(|| proxy.body.unwrap_or(Value::Object(Map::new())));
-    let model_selection = path_model_selection.or_else(|| {
-        upstream_body_json
-            .as_mut()
-            .and_then(|body| normalize_native_model(provider, body))
-    });
+    let body_model_selection = upstream_body_json
+        .as_mut()
+        .and_then(|body| normalize_native_model(provider, body));
+    let model_selection = path_model_selection.or(body_model_selection);
     if let Some(upstream_body_json) = upstream_body_json.as_mut() {
         let listed_pricing = model_selection
             .as_ref()
@@ -8690,11 +8703,9 @@ fn select_native_model(provider: &CompiledProvider, body: &Value) -> Option<Nati
 
 fn select_model_value(provider: &CompiledProvider, model: &str) -> Option<NativeModelSelection> {
     let model = model.to_string();
-    if let Some(entry) = provider
-        .models
-        .iter()
-        .find(|entry| entry.id == model || entry.upstream == model)
-    {
+    if let Some(entry) = provider.models.iter().find(|entry| {
+        (entry.id == model && !contains_template(&entry.upstream)) || entry.upstream == model
+    }) {
         return Some(NativeModelSelection {
             model,
             upstream_model: entry.upstream.clone(),
@@ -8724,12 +8735,13 @@ fn normalize_manifest_path_model(
     endpoint: &CompiledEndpoint,
     proxy: &mut ManifestProxyRequest,
 ) -> Option<NativeModelSelection> {
-    if !endpoint.path_params.iter().any(|param| param == "model") {
-        return None;
-    }
-    let selection = select_model_value(provider, proxy.path_params.get("model")?.as_str()?)?;
+    let param = endpoint
+        .path_params
+        .iter()
+        .find(|param| matches!(param.as_str(), "model" | "deployment"))?;
+    let selection = select_model_value(provider, proxy.path_params.get(param)?.as_str()?)?;
     proxy.path_params.insert(
-        "model".to_string(),
+        param.to_string(),
         Value::String(selection.upstream_model.clone()),
     );
     Some(selection)
@@ -15408,6 +15420,8 @@ mod tests {
             route.get("provider").and_then(Value::as_str) == Some("tavily")
                 && route.get("endpoint").and_then(Value::as_str) == Some("search")
                 && route.get("route").and_then(Value::as_str) == Some("/v1/proxy/tavily/search")
+                && route.get("requestFormat").and_then(Value::as_str) == Some("tavily.search")
+                && route.get("sampleModel").and_then(Value::as_str) == Some("tavily/search")
         }));
         assert!(manifest_routes.iter().any(|route| {
             route.get("provider").and_then(Value::as_str) == Some("firecrawl")
@@ -15432,6 +15446,33 @@ mod tests {
                             .any(|param| param.as_str() == Some("prediction_id"))
                     })
         }));
+
+        for route in manifest_routes {
+            assert!(route.get("requestFormat").is_some_and(Value::is_string));
+            let provider_id = route.get("provider").and_then(Value::as_str).unwrap();
+            let endpoint_id = route.get("endpoint").and_then(Value::as_str).unwrap();
+            let provider = snapshot
+                .providers
+                .iter()
+                .find(|provider| provider.id == provider_id)
+                .unwrap();
+            let endpoint_capabilities = provider
+                .capabilities
+                .iter()
+                .filter(|capability| capability.endpoint == endpoint_id)
+                .map(|capability| capability.id.as_str())
+                .collect::<Vec<_>>();
+            let expected_model = provider.models.iter().find(|model| {
+                model
+                    .capabilities
+                    .iter()
+                    .any(|capability| endpoint_capabilities.contains(&capability.as_str()))
+            });
+            assert_eq!(
+                route.get("sampleModel").and_then(Value::as_str),
+                expected_model.map(|model| model.id.as_str())
+            );
+        }
 
         for route in openai_routes {
             let provider_id = route.get("provider").and_then(Value::as_str).unwrap();
@@ -17351,6 +17392,40 @@ mod tests {
             manifest_upstream_url(provider, endpoint, &proxy, None, None, None, None).unwrap(),
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
         );
+    }
+
+    #[test]
+    fn manifest_path_models_strip_public_prefixes_for_template_catalog_entries() {
+        let snapshot = provider_snapshot().unwrap();
+        let provider = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "azure-openai")
+            .unwrap();
+        let endpoint = provider
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.id == "chat_completions")
+            .unwrap();
+        let mut proxy = ManifestProxyRequest {
+            path_params: Map::from_iter([(
+                "deployment".to_string(),
+                Value::String("azure-openai/deployment".to_string()),
+            )]),
+            body: Some(serde_json::json!({
+                "model": "azure-openai/deployment",
+                "messages": [{"role": "user", "content": "hello"}]
+            })),
+            ..ManifestProxyRequest::default()
+        };
+
+        let path_selection = normalize_manifest_path_model(provider, endpoint, &mut proxy).unwrap();
+        assert_eq!(path_selection.upstream_model, "deployment");
+        assert_eq!(proxy.path_params["deployment"], "deployment");
+        let body = proxy.body.as_mut().unwrap();
+        let selection = normalize_native_model(provider, body).unwrap();
+        assert_eq!(selection.upstream_model, "deployment");
+        assert_eq!(body["model"], "deployment");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reset Playground service state from route-specific request presets
- expose request format and endpoint-compatible sample model metadata
- normalize model aliases in both manifest path and body fields

## Verification

- `pnpm check`
- `pnpm test:scripts`
- `pnpm provider:compile`
- `pnpm --dir admin build`
- real Chrome demo: Service toggle, Tavily preset, Replicate GET/path preset
- autoreview clean after two accepted fixes

## Deployment status

Pending merge and production deployment.

## Remaining risk

Provider-specific upstream validation will be rerun against every configured production provider after deployment.
