### PR TITLE
fix: add Mistral embedding model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Generate route-specific Playground service requests so switching providers no longer sends stale bodies or path values.
 - Resolve configured dynamic model aliases for Playground service routes such as Azure OpenAI deployments.
 - Apply provider request transforms to manifest-proxy calls so service routes match model-proxy behavior.
+- Add the Mistral embedding model and list pricing so embedding requests no longer select a chat-only model.

--- a/providers/mistral.provider.yaml
+++ b/providers/mistral.provider.yaml
@@ -49,6 +49,17 @@ models:
       upstream: mistral-small-latest
       capabilities: [llm.chat]
       pricingRef: mistral-default
+    - id: mistral/mistral-embed
+      upstream: mistral-embed
+      capabilities: [llm.embeddings]
+      pricingRef: mistral-embed-23-12-standard-2026-06-21
+      pricing:
+        effectiveAt: "2026-06-21"
+        source: https://docs.mistral.ai/models/mistral-embed-23-12
+        inputMicrosPerMillion: 100000
+        outputMicrosPerMillion: 0
+        maxInputTokens: 8192
+        defaultMaxOutputTokens: 0
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -74,6 +74,13 @@ test("newly budgeted provider defaults compile with dated pricing", () => {
   assert.equal(xai.pricing.longContext.thresholdInputTokens, 200000);
   assert.equal(xai.pricing.longContext.inputMicrosPerMillion, 2500000);
   assert.equal(xai.pricing.longContext.outputMicrosPerMillion, 5000000);
+  const mistralEmbed = snapshot.providers
+    .find((provider) => provider.id === "mistral")
+    .models.find((model) => model.id === "mistral/mistral-embed");
+  assert.equal(mistralEmbed.upstream, "mistral-embed");
+  assert.deepEqual(mistralEmbed.capabilities, ["llm.embeddings"]);
+  assert.equal(mistralEmbed.pricing.inputMicrosPerMillion, 100000);
+  assert.equal(mistralEmbed.pricing.outputMicrosPerMillion, 0);
 });
 
 test("live provider defaults compile to current upstream models and transports", () => {


### PR DESCRIPTION
## Summary

- add the endpoint-compatible Mistral embedding model
- record dated list pricing from official Mistral documentation
- cover the compiled model capability and price

## Verification

- all provider manifests compile
- provider smoke-plan tests pass
- route-catalog tests pass
- autoreview clean

## Deployment status

Pending merge and production deployment.

## Remaining risk

Requires live Mistral embedding verification after deployment.
