### PR TITLE
fix: normalize policy provider edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Resolve configured dynamic model aliases for Playground service routes such as Azure OpenAI deployments.
 - Apply provider request transforms to manifest-proxy calls so service routes match model-proxy behavior.
 - Add the Mistral embedding model and list pricing so embedding requests no longer select a chat-only model.
+- Remove stale provider IDs when editing policies so valid access changes are not blocked by obsolete catalog entries.

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -420,6 +420,11 @@ export function unique(values: string[]) {
   return Array.from(new Set(values.filter(Boolean)));
 }
 
+export function knownPolicyProviders(selected: string[], available: string[]) {
+  const known = new Set(available);
+  return unique(selected.filter((provider) => known.has(provider))).sort();
+}
+
 export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["manifestProxy"][number]) {
   if (form.mode === "service") {
     const body = form.servicePayload.trim() ? JSON.parse(form.servicePayload) : {};

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -28,6 +28,7 @@ import {
   effectiveAccess,
   errorMessage,
   grantNamesForService,
+  knownPolicyProviders,
   optionalCurrencyMicros,
   optionalNumber,
   parseGroups,
@@ -796,14 +797,15 @@ function App() {
     try {
       setPolicyError("");
       setStatus("saving policy");
-      if (!policyForm.allProviders && !policyForm.providers.length) throw new Error("select at least one service");
+      const policyProviders = knownPolicyProviders(policyForm.providers, providers.map((provider) => provider.id));
+      if (!policyForm.allProviders && !policyProviders.length) throw new Error("select at least one service");
       if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.policyId)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
       const existingPolicy = keys.some((key) => key.policyId === policyForm.policyId);
       if (existingPolicy && selectedPolicyId !== policyForm.policyId) throw new Error("policy id already exists; select it from the policy list to edit it");
       const next: AccessPolicy = {
         policyId: policyForm.policyId,
         enabled: policyForm.enabled,
-        providers: policyForm.allProviders ? [] : policyForm.providers,
+        providers: policyForm.allProviders ? [] : policyProviders,
         tenantId: policyForm.tenantId || "default",
         tokenRole: policyForm.tokenRole || null,
         monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   directUserBindingChanges,
   effectiveAccess,
+  knownPolicyProviders,
   optionalCurrencyMicros,
   optionalNumber,
   playgroundAccessEndpoint,
@@ -81,6 +82,13 @@ test("direct user binding changes separate removals from additions", () => {
 
   assert.deepEqual(changes.removals.map((binding) => binding.policyId), ["models"]);
   assert.deepEqual(changes.additions.map((binding) => binding.policyId), ["tools"]);
+});
+
+test("policy edits discard stale provider ids before saving", () => {
+  assert.deepEqual(
+    knownPolicyProviders(["openai", "github", "firecrawl", "openai"], ["firecrawl", "openai"]),
+    ["firecrawl", "openai"],
+  );
 });
 
 test("service outcome and playground blocker require both access and readiness", () => {


### PR DESCRIPTION
## Summary

- filter obsolete provider IDs from policy edits
- validate the normalized service scope before saving
- preserve wildcard policy behavior

## Verification

- admin typecheck passes
- 12 admin domain tests pass
- autoreview clean

## Deployment status

Pending merge and production deployment.

## Remaining risk

Requires live re-save of the maintainer policy and Firecrawl access verification.
