### PR TITLE
feat: add role-aware service dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add role-aware user and admin dashboards with service readiness, shared quota pools, traffic diagrams, and privacy-safe Access-session usage totals.
 - Gate the Cloudflare console by verified GitHub organization membership and support secure bulk provider-secret deployment.
 - Add versioned list pricing for Together Qwen 2.5 7B, DeepSeek V4 Flash, and MiniMax M3 budget enforcement.
 - Fix the Anthropic token-count live smoke request so provider verification no longer sends a messages-only field.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ pnpm cf:access
 
 Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
 `CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
-`/dashboard` path, `/dashboard` redirects to `/dashboard/catalog`, and canonical console views live under `/dashboard/*`, while
+`/dashboard` path, `/dashboard` redirects to the role-aware `/dashboard/home`, and canonical console views live under `/dashboard/*`, while
 public `/v1` catalog and proxy routes stay normal. The Access app must also
-protect `/v1/session`, `/v1/playground/*`, `/v1/admin/*`, and
+protect `/v1/session*`, `/v1/playground/*`, `/v1/admin/*`, and
 `/v1/oauth/callback` so the browser console can bootstrap identity,
-entitlements, playground calls, admin mutations, and OAuth callbacks from a
+entitlements, session quota usage, playground calls, admin mutations, and OAuth callbacks from a
 verified Access session. A ClawRouter `access_session_required` JSON body on
-`/dashboard/*`, `/v1/session`, `/v1/playground/*`, or `/v1/oauth/callback` means the Access app is not
+`/dashboard/*`, `/v1/session`, `/v1/session/usage`, `/v1/playground/*`, or `/v1/oauth/callback` means the Access app is not
 in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
 deployment smoke.
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -3,11 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ClawRouter Admin</title>
+    <meta name="description" content="ClawRouter service access, quota, and gateway console." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <title>ClawRouter Console</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/admin/public/favicon.svg
+++ b/admin/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#111815"/>
+  <g fill="none" stroke="#f4f7f2" stroke-linecap="round" stroke-width="4">
+    <path d="M17 20h20a8 8 0 0 1 0 16H27a8 8 0 0 0 0 16h20"/>
+    <circle cx="15" cy="20" r="5"/>
+    <circle cx="49" cy="52" r="5"/>
+  </g>
+</svg>

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -2,12 +2,15 @@ import React, { FormEvent, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   BarChart3,
+  Activity,
+  ArrowUpRight,
   Boxes,
   CheckCircle2,
   ChevronRight,
   CircleSlash2,
   FlaskConical,
   KeyRound,
+  LayoutDashboard,
   LogIn,
   Play,
   Plus,
@@ -50,15 +53,16 @@ import {
 } from "./domain";
 import "./style.css";
 
-type View = "catalog" | "playground" | "policies" | "users" | "usage";
+type View = "home" | "catalog" | "playground" | "policies" | "users" | "usage";
 
 const pathViews: Record<string, View> = {
-  "/": "catalog",
+  "/": "home",
   "/access": "policies",
   "/admin": "policies",
   "/catalog": "catalog",
   "/console": "catalog",
-  "/dashboard": "catalog",
+  "/dashboard": "home",
+  "/dashboard/home": "home",
   "/dashboard/access": "policies",
   "/dashboard/catalog": "catalog",
   "/dashboard/playground": "playground",
@@ -73,6 +77,7 @@ const pathViews: Record<string, View> = {
 };
 
 const viewPaths: Record<View, string> = {
+  home: "/dashboard/home",
   catalog: "/dashboard/catalog",
   playground: "/dashboard/playground",
   policies: "/dashboard/access",
@@ -518,6 +523,7 @@ const rolePresets = {
 };
 
 const navItems: Array<{ id: View; label: string; icon: IconComponent; section: "workspace" | "admin" }> = [
+  { id: "home", label: "Dashboard", icon: LayoutDashboard, section: "workspace" },
   { id: "catalog", label: "Catalog", icon: Boxes, section: "workspace" },
   { id: "playground", label: "Playground", icon: FlaskConical, section: "workspace" },
   { id: "policies", label: "Access", icon: KeyRound, section: "admin" },
@@ -605,6 +611,10 @@ function App() {
   const statusTone = statusKind(status);
 
   useEffect(() => {
+    if (localDemoRole() === "user") {
+      loadUserDemo();
+      return;
+    }
     void refresh();
   }, []);
 
@@ -619,7 +629,7 @@ function App() {
   }, [session.role, status, view]);
 
   useEffect(() => {
-    if (view === "usage" && session.role === "admin" && policyDataLoaded && !demoMode && !usageLoaded) {
+    if ((view === "home" || view === "usage") && session.role === "admin" && policyDataLoaded && !demoMode && !usageLoaded) {
       void refreshUsageLedger();
     }
   }, [demoMode, policyDataLoaded, session.role, usageLoaded, usageRefreshKey, view]);
@@ -742,9 +752,17 @@ function App() {
         setBindings([]);
         setAdminOverview(null);
         setTenantSummaries([]);
-        setUsageRows([]);
-        setUsageSnapshot(emptyUsageSnapshot);
-        setUsageLoaded(false);
+        const accessUsageResult = await settled(() => request<{ policies: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/session/usage"));
+        if (accessUsageResult.ok) {
+          setUsageRows(accessUsageResult.value.policies);
+          setUsageSnapshot(accessUsageResult.value.usage);
+          setUsageLoaded(true);
+        } else {
+          setUsageRows([]);
+          setUsageSnapshot(emptyUsageSnapshot);
+          setUsageLoaded(false);
+          refreshWarnings = [...refreshWarnings, `quota status unavailable: ${accessUsageResult.error}`];
+        }
         setSelectedUserEmail(user.email);
         setAccessForm(accessFormFromUser(user, []));
       }
@@ -790,6 +808,50 @@ function App() {
       setDemoMode(false);
       setStatus(`load error: ${message}`);
     }
+  }
+
+  function loadUserDemo() {
+    const user = demo.users.find((candidate) => candidate.email === "research@example.com") ?? demo.users.find((candidate) => candidate.role === "user")!;
+    const access = effectiveAccess(user, demo.keys, demo.bindings, demo.services);
+    const policyIds = new Set(access.policies.map((policy) => policy.policyId));
+    const providers = new Set(access.services.map((service) => service.provider));
+    const providerUsage = demo.usage.providers.filter((provider) => providers.has(provider.provider));
+    const usageSummary = providerUsage.reduce<UsageSummary>((summary, provider) => ({
+      ...summary,
+      requestCount: summary.requestCount + provider.requestCount,
+      successCount: summary.successCount + provider.successCount,
+      errorCount: summary.errorCount + provider.errorCount,
+      totalTokens: summary.totalTokens + provider.totalTokens,
+      actualCostMicros: summary.actualCostMicros + provider.actualCostMicros,
+    }), { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 });
+    const entitlements = {
+      session: { ...demo.session, ...user, auth: "demo" },
+      providers: demo.entitlements.providers.map((provider) => ({
+        ...provider,
+        allowed: providers.has(provider.provider),
+        policies: provider.policies.filter((policyId) => policyIds.has(policyId)),
+      })),
+    };
+    setSession(entitlements.session);
+    setProviders(demo.providers);
+    setRoutes(demo.routes);
+    setKeys([]);
+    setCredentials([]);
+    setConnections([]);
+    setUpstreamGrants([]);
+    setAssignmentRules([]);
+    setPolicyDataLoaded(false);
+    setUsers([user]);
+    setBindings([]);
+    setAdminOverview(null);
+    setTenantSummaries([]);
+    setUsageRows(access.policies.map(policyUsageFallback));
+    setUsageSnapshot({ ...demo.usage, summary: usageSummary, providers: providerUsage, events: [] });
+    setUsageLoaded(true);
+    setEntitlements(entitlements);
+    setProviderReadiness(readinessMap(entitlements.providers.map((provider) => provider.readiness)));
+    setStatus("local user demo loaded");
+    setDemoMode(true);
   }
 
   async function savePolicy(event: FormEvent) {
@@ -1432,6 +1494,25 @@ function App() {
 
         <div className={`statusBar statusBar-${statusTone}`} role="status" aria-live="polite"><strong>{statusLabel(statusTone)}</strong><span>{status}</span>{demoMode ? <em>demo</em> : null}</div>
 
+        {view === "home" ? (
+          <DashboardScreen
+            session={session}
+            services={services}
+            policies={keys}
+            credentials={credentials}
+            users={users}
+            tenants={tenantSummaries}
+            overview={adminOverview}
+            usageRows={usageRows}
+            usage={usageSnapshot}
+            usageLoaded={usageLoaded}
+            onOpenCatalog={() => navigateTo("catalog")}
+            onOpenPlayground={() => navigateTo("playground")}
+            onOpenUsage={() => navigateTo("usage")}
+            onOpenAccess={() => navigateTo("policies")}
+          />
+        ) : null}
+
         {view === "catalog" ? (
           <CatalogScreen
             services={filteredServices}
@@ -1574,6 +1655,151 @@ function App() {
       </section>
     </main>
   );
+}
+
+function DashboardScreen({ session, services, policies, credentials, users, tenants, overview, usageRows, usage, usageLoaded, onOpenCatalog, onOpenPlayground, onOpenUsage, onOpenAccess }: {
+  session: SessionResponse;
+  services: ServiceItem[];
+  policies: AccessPolicy[];
+  credentials: ProxyCredential[];
+  users: AccessUser[];
+  tenants: AdminTenantSummary[];
+  overview: AdminOverview | null;
+  usageRows: AdminUsageRow[];
+  usage: UsageSnapshot;
+  usageLoaded: boolean;
+  onOpenCatalog: () => void;
+  onOpenPlayground: () => void;
+  onOpenUsage: () => void;
+  onOpenAccess: () => void;
+}) {
+  const isAdmin = session.role === "admin";
+  const grantedServices = services.filter((service) => service.access?.allowed);
+  const visibleServices = isAdmin ? services : grantedServices;
+  const usableServices = grantedServices.filter((service) => serviceOutcome(service).playable);
+  const configuredServices = services.filter((service) => service.readiness?.executable);
+  const attentionServices = visibleServices.filter((service) => !serviceOutcome(service).playable);
+  const rows = (usageRows.length ? usageRows : isAdmin ? policies.map(policyUsageFallback) : []).filter((row) => row.enabled);
+  const successRate = usage.summary.requestCount ? Math.round((usage.summary.successCount / usage.summary.requestCount) * 100) : 100;
+  const servicePercent = isAdmin
+    ? services.length ? Math.round((configuredServices.length / services.length) * 100) : 0
+    : grantedServices.length ? Math.round((usableServices.length / grantedServices.length) * 100) : 0;
+  const providerMaximum = Math.max(1, ...usage.providers.map((provider) => provider.requestCount));
+  const displayName = session.email?.split("@")[0] ?? (isAdmin ? "operator" : "member");
+  const activePolicies = policies.filter((policy) => policy.enabled).length;
+  const activeCredentials = credentials.filter((credential) => credential.enabled && credential.active !== false).length;
+
+  return (
+    <div className="dashboardCanvas">
+      <section className={`dashboardHero ${isAdmin ? "admin" : "member"}`}>
+        <div className="heroCopy">
+          <span className="heroEyebrow">{isAdmin ? "gateway operations" : "personal access"} · {session.tenantId ?? "default"}</span>
+          <h2>{isAdmin ? "Every route, budget, and identity—under control." : `Your services are ready, ${displayName}.`}</h2>
+          <p>{isAdmin ? "Live posture across the complete gateway. Drill into access or usage when a signal needs attention." : "See what you can call, how healthy it is, and the shared quota pools backing your access."}</p>
+          <div className="heroActions">
+            <button type="button" onClick={onOpenCatalog}>Explore services <ArrowUpRight aria-hidden="true" /></button>
+            <button type="button" className="heroButtonSecondary" onClick={onOpenPlayground}><Play aria-hidden="true" /> Open playground</button>
+          </div>
+        </div>
+        <div className="heroMeters" aria-label="gateway status summary">
+          <RadialMeter label={isAdmin ? "configured" : "usable"} value={isAdmin ? configuredServices.length : usableServices.length} total={isAdmin ? services.length : grantedServices.length} tone="green" />
+          <RadialMeter label="success" value={successRate} total={100} suffix="%" tone={successRate >= 95 ? "green" : "amber"} />
+          <RadialMeter label="requests" value={usage.summary.requestCount} total={Math.max(usage.summary.requestCount, 100)} display={formatCount(usage.summary.requestCount)} tone="blue" />
+        </div>
+      </section>
+
+      <section className="dashboardStats" aria-label="access overview">
+        <DashboardStat label={isAdmin ? "catalog coverage" : "available services"} value={isAdmin ? `${configuredServices.length}/${services.length}` : String(grantedServices.length)} note={isAdmin ? `${services.length - configuredServices.length} need attention` : `${usableServices.length} ready to call`} />
+        <DashboardStat label="shared activity" value={formatCount(usage.summary.totalTokens)} note={`${formatCount(usage.summary.requestCount)} requests · ${successRate}% success`} />
+        <DashboardStat label={isAdmin ? "active policies" : "quota pools"} value={String(isAdmin ? overview?.policiesActive ?? activePolicies : rows.length)} note={isAdmin ? `${overview?.tenantsTotal ?? tenants.length} tenants` : usageLoaded ? "live policy ledgers" : "status unavailable"} />
+        <DashboardStat label="actual spend" value={formatMicros(usage.summary.actualCostMicros)} note={isAdmin ? `${usage.providers.length} active providers` : "across your policy pools"} />
+      </section>
+
+      <div className="dashboardGrid">
+        <section className="dashboardPanel servicePanel">
+          <DashboardPanelHeader eyebrow={isAdmin ? "service estate" : "your access"} title={isAdmin ? "Provider readiness" : "Services you can use"} meta={`${isAdmin ? configuredServices.length : usableServices.length} ready`} action="View catalog" onAction={onOpenCatalog} />
+          <div className="serviceSpectrum" role="img" aria-label={`${servicePercent}% of ${isAdmin ? "catalog services are configured" : "granted services are usable"}`}>
+            <span className="serviceSpectrumReady" style={{ width: `${servicePercent}%` }} />
+            <span className="serviceSpectrumBlocked" style={{ width: `${100 - servicePercent}%` }} />
+          </div>
+          <div className="dashboardServiceGrid">
+            {visibleServices.slice(0, isAdmin ? 10 : 8).map((service, index) => {
+              const outcome = serviceOutcome(service);
+              return (
+                <article className={`dashboardService ${outcome.playable ? "ready" : "attention"}`} key={service.id} style={{ "--reveal": `${index * 35}ms` } as React.CSSProperties}>
+                  <span className="dashboardServiceMark"><BrandMark brandIcon={service.brandIcon} fallback={kindIcon(service.kind)} /></span>
+                  <span><strong>{service.name}</strong><small>{kindLabel(service.kind)} · {outcome.detail}</small></span>
+                  <Status label={outcome.label} tone={outcome.tone} />
+                </article>
+              );
+            })}
+            {!visibleServices.length ? <div className="dashboardEmpty"><CircleSlash2 aria-hidden="true" /><strong>No services assigned</strong><p>Ask an administrator to bind a service policy to your identity or group.</p></div> : null}
+          </div>
+          {visibleServices.length > (isAdmin ? 10 : 8) ? <button className="dashboardTextAction" type="button" onClick={onOpenCatalog}>Show {visibleServices.length - (isAdmin ? 10 : 8)} more services <ChevronRight aria-hidden="true" /></button> : null}
+        </section>
+
+        <section className="dashboardPanel quotaPanel">
+          <DashboardPanelHeader eyebrow="policy budgets" title={isAdmin ? "Budget posture" : "Your shared quotas"} meta={usageLoaded ? "live ledger" : "policy fallback"} />
+          <p className="panelIntro">{isAdmin ? "Spend and remaining capacity across active policies." : "Your requests draw from these shared policy pools; totals may include activity from teammates on the same policy."}</p>
+          <div className="quotaList">
+            {rows.slice(0, 6).map((row) => {
+              const percent = budgetPercent(row);
+              const limit = row.budget.limitMicros ?? row.monthlyBudgetMicros;
+              const remaining = row.budget.remainingMicros;
+              return (
+                <article className="quotaRow" key={usagePolicyId(row)}>
+                  <RadialMeter label="used" value={percent ?? 0} total={100} suffix="%" display={percent === null ? limit === undefined || limit === null ? "∞" : "—" : `${Math.round(percent)}%`} compact tone={percent !== null && percent >= 90 ? "amber" : "green"} />
+                  <span className="quotaIdentity"><strong>{usagePolicyId(row)}</strong><small>{row.tokenRole ?? "custom"} · {effectiveProviderCount(row.providers, services)} services</small></span>
+                  <span className="quotaNumbers"><strong>{remaining === undefined || remaining === null ? formatBudget(limit) : formatMicros(remaining)}</strong><small>{remaining === undefined || remaining === null ? "monthly limit" : `remaining of ${formatBudget(limit)}`}</small></span>
+                </article>
+              );
+            })}
+            {!rows.length ? <div className="dashboardEmpty"><Activity aria-hidden="true" /><strong>No quota pools assigned</strong><p>Usage will appear when an access policy is bound to your account.</p></div> : null}
+          </div>
+          {isAdmin ? <button className="dashboardTextAction" type="button" onClick={onOpenUsage}>Open full usage ledger <ChevronRight aria-hidden="true" /></button> : null}
+        </section>
+
+        <section className="dashboardPanel activityPanel">
+          <DashboardPanelHeader eyebrow="traffic shape" title="Provider activity" meta={`${usage.providers.length} active`} />
+          <div className="activityDiagram">
+            {usage.providers.slice(0, 7).map((provider) => {
+              const service = services.find((candidate) => candidate.provider === provider.provider);
+              const width = Math.max(4, Math.round((provider.requestCount / providerMaximum) * 100));
+              return <div className="activityBar" key={provider.provider}><EntityName brandIcon={service?.brandIcon} icon={ServerCog} title={service?.name ?? provider.provider} subtitle={`${formatCount(provider.totalTokens)} tokens`} /><span className="activityTrack"><span style={{ width: `${width}%` }} /></span><strong>{formatCount(provider.requestCount)}</strong></div>;
+            })}
+            {!usage.providers.length ? <div className="dashboardEmpty"><BarChart3 aria-hidden="true" /><strong>No activity yet</strong><p>Provider traffic will build this diagram as requests pass through the gateway.</p></div> : null}
+          </div>
+        </section>
+
+        {isAdmin ? (
+          <section className="dashboardPanel operationsPanel">
+            <DashboardPanelHeader eyebrow="administration" title="Control plane" meta={`${attentionServices.length} signals`} action="Manage access" onAction={onOpenAccess} />
+            <div className="operationsDiagram">
+              <div><span>identities</span><strong>{users.length}</strong><small>{users.filter((user) => user.enabled).length} enabled</small></div>
+              <div><span>credentials</span><strong>{activeCredentials}</strong><small>{credentials.length} provisioned</small></div>
+              <div><span>tenants</span><strong>{overview?.tenantsTotal ?? tenants.length}</strong><small>{overview?.policiesTotal ?? policies.length} policies</small></div>
+              <div className={attentionServices.length ? "needsAttention" : "healthy"}><span>service alerts</span><strong>{attentionServices.length}</strong><small>{attentionServices.length ? "configuration required" : "all clear"}</small></div>
+            </div>
+            <div className="operationsFooter"><ShieldCheck aria-hidden="true" /><span><strong>Access boundary active</strong><small>Identity, policy, quota, then provider</small></span></div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function DashboardPanelHeader({ eyebrow, title, meta, action, onAction }: { eyebrow: string; title: string; meta: string; action?: string; onAction?: () => void }) {
+  return <header className="dashboardPanelHeader"><div><span>{eyebrow}</span><h2>{title}</h2></div>{action && onAction ? <button type="button" onClick={onAction}>{action}<ArrowUpRight aria-hidden="true" /></button> : <small>{meta}</small>}</header>;
+}
+
+function DashboardStat({ label, value, note }: { label: string; value: string; note: string }) {
+  return <div><span>{label}</span><strong>{value}</strong><small>{note}</small></div>;
+}
+
+function RadialMeter({ label, value, total, display, suffix = "", compact = false, tone }: { label: string; value: number; total: number; display?: string; suffix?: string; compact?: boolean; tone: "green" | "amber" | "blue" }) {
+  const percent = total > 0 ? Math.min(100, Math.max(0, (value / total) * 100)) : 0;
+  const shown = display ?? (suffix ? `${Math.round(value)}${suffix}` : `${formatCount(value)}/${formatCount(total)}`);
+  return <div className={`radialMeter ${compact ? "compact" : ""} ${tone}`} style={{ "--meter": `${percent}%` } as React.CSSProperties} aria-label={`${label}: ${shown}`}><div><strong>{shown}</strong><span>{label}</span></div></div>;
 }
 
 function CatalogScreen({ services, allServices, selected, policies, connections, query, setQuery, kind, setKind, kinds, canAdminister, onSelect, onSetConnection, onPlay, onAdd }: {
@@ -2385,11 +2611,12 @@ function ReadinessStatus({ readiness }: { readiness?: ProviderReadiness }) {
 }
 
 function viewTitle(view: View) {
-  return ({ catalog: "Catalog", playground: "Playground", policies: "Access", users: "Users", usage: "Usage" } as const)[view];
+  return ({ home: "Dashboard", catalog: "Catalog", playground: "Playground", policies: "Access", users: "Users", usage: "Usage" } as const)[view];
 }
 
 function viewSubtitle(view: View) {
   return {
+    home: "Services, quotas, and gateway posture",
     catalog: "Service access catalog",
     playground: "Run through the same access path",
     policies: "Policies, credentials, and principal bindings",
@@ -2446,6 +2673,11 @@ function statusLabel(kind: ReturnType<typeof statusKind>) {
 function isLocalDemoAllowed() {
   const params = new URLSearchParams(window.location.search);
   return params.has("demo") || ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
+}
+
+function localDemoRole(): AccessRole | null {
+  if (!["localhost", "127.0.0.1", "::1"].includes(window.location.hostname)) return null;
+  return new URLSearchParams(window.location.search).get("demo") === "user" ? "user" : null;
 }
 
 async function settled<T>(loader: () => Promise<T>): Promise<{ ok: true; value: T } | { ok: false; error: string }> {
@@ -2606,6 +2838,14 @@ function formatBudget(value: number | null | undefined) {
   if (value === undefined || value === null) return "unlimited";
   if (value === 0) return "blocked";
   return formatMicros(value);
+}
+
+function budgetPercent(row: AdminUsageRow) {
+  const limit = row.budget.limitMicros ?? row.monthlyBudgetMicros;
+  const spent = row.budget.spentMicros;
+  if (row.budget.ledger === "blocked" || limit === 0) return 100;
+  if (limit === undefined || limit === null || spent === undefined || spent === null) return null;
+  return Math.min(100, Math.max(0, (spent / limit) * 100));
 }
 
 function formatMicros(value: number | null | undefined) {

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -11,7 +11,7 @@
   --primary-hover: #31403b;
   --primary-100: #e8eee9;
   --primary-foreground: #ffffff;
-  --success: #16825d;
+  --success: #0f7050;
   --success-bg: #dff2e9;
   --danger: #b23827;
   --danger-bg: #fff1ef;
@@ -3153,4 +3153,466 @@ select:disabled {
   .userListHeader {
     grid-template-columns: 1fr;
   }
+}
+
+/* Role-aware control room */
+.dashboardCanvas {
+  display: grid;
+  gap: 12px;
+  margin: 12px;
+  color: var(--foreground-strong);
+}
+
+.dashboardHero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 230px;
+  overflow: hidden;
+  border: 1px solid #26312d;
+  background:
+    linear-gradient(rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    radial-gradient(circle at 82% 24%, rgb(35 172 118 / 0.2), transparent 32%),
+    #111815;
+  background-size: 24px 24px, 24px 24px, auto, auto;
+  color: #f4f7f2;
+  padding: 32px 36px;
+}
+
+.dashboardHero::after {
+  position: absolute;
+  right: -48px;
+  bottom: -102px;
+  width: 310px;
+  height: 310px;
+  border: 1px solid rgb(89 207 159 / 0.18);
+  border-radius: 50%;
+  box-shadow: 0 0 0 38px rgb(89 207 159 / 0.035), 0 0 0 76px rgb(89 207 159 / 0.025);
+  content: "";
+  pointer-events: none;
+}
+
+.dashboardHero.member {
+  background:
+    linear-gradient(rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    radial-gradient(circle at 78% 22%, rgb(89 134 255 / 0.2), transparent 32%),
+    #111815;
+  background-size: 24px 24px, 24px 24px, auto, auto;
+}
+
+.heroCopy {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  align-content: center;
+  justify-items: start;
+  max-width: 680px;
+}
+
+.heroEyebrow,
+.dashboardPanelHeader span,
+.dashboardStats span,
+.operationsDiagram span {
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.heroEyebrow {
+  color: #7ee0b7;
+}
+
+.dashboardHero.member .heroEyebrow {
+  color: #9ab7ff;
+}
+
+.heroCopy h2 {
+  max-width: 660px;
+  margin-top: 12px;
+  color: #fff;
+  font-family: "Avenir Next", ui-sans-serif, sans-serif;
+  font-size: clamp(25px, 3vw, 42px);
+  font-weight: 560;
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+}
+
+.heroCopy p {
+  max-width: 620px;
+  margin-top: 14px;
+  color: #abb8b2;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.heroActions {
+  display: flex;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.heroActions button {
+  min-height: 34px;
+  border-color: #e7eee9;
+  background: #e7eee9;
+  color: #111815;
+}
+
+.heroActions button svg,
+.dashboardPanelHeader button svg,
+.dashboardTextAction svg {
+  width: 13px;
+  height: 13px;
+}
+
+.heroActions .heroButtonSecondary {
+  border-color: #44514c;
+  background: transparent;
+  color: #dbe5df;
+}
+
+.heroActions .heroButtonSecondary:hover:not(:disabled) {
+  border-color: #6d7d75;
+  background: rgb(255 255 255 / 0.06);
+}
+
+.heroMeters {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  align-self: center;
+  gap: 18px;
+  padding-left: 34px;
+}
+
+.radialMeter {
+  --meter-color: #52d69e;
+  position: relative;
+  display: grid;
+  width: 92px;
+  height: 92px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(var(--meter-color) var(--meter), rgb(255 255 255 / 0.11) 0);
+}
+
+.radialMeter::after {
+  position: absolute;
+  inset: 6px;
+  border-radius: inherit;
+  background: #18211e;
+  content: "";
+}
+
+.radialMeter > div {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  gap: 1px;
+}
+
+.radialMeter strong {
+  color: #fff;
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.radialMeter span {
+  color: #91a19a;
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.radialMeter.amber { --meter-color: #f1b95d; }
+.radialMeter.blue { --meter-color: #7ea0ff; }
+
+.radialMeter.compact {
+  width: 48px;
+  height: 48px;
+  background: conic-gradient(var(--meter-color) var(--meter), #dfe5de 0);
+}
+
+.radialMeter.compact::after {
+  inset: 4px;
+  background: var(--background);
+}
+
+.radialMeter.compact strong {
+  color: var(--foreground-strong);
+  font-size: 9px;
+}
+
+.radialMeter.compact span {
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.dashboardStats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--border);
+  background: var(--background);
+}
+
+.dashboardStats > div {
+  display: grid;
+  gap: 3px;
+  border-right: 1px solid var(--border);
+  padding: 15px 18px;
+}
+
+.dashboardStats > div:last-child { border-right: 0; }
+.dashboardStats span { color: var(--muted); }
+
+.dashboardStats strong {
+  margin-top: 3px;
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 22px;
+  font-weight: 500;
+}
+
+.dashboardStats small {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.dashboardGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(340px, 0.85fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.dashboardPanel {
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--background);
+}
+
+.dashboardPanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 64px;
+  border-bottom: 1px solid var(--border);
+  padding: 11px 14px;
+}
+
+.dashboardPanelHeader > div {
+  display: grid;
+  gap: 3px;
+}
+
+.dashboardPanelHeader span { color: var(--success); }
+.dashboardPanelHeader h2 { font-size: 15px; }
+.dashboardPanelHeader small { color: var(--muted); font-size: 10px; }
+
+.dashboardPanelHeader button,
+.dashboardTextAction {
+  min-height: 26px;
+  border: 0;
+  background: transparent;
+  color: var(--foreground-strong);
+  padding: 4px 0;
+  font-size: 10px;
+}
+
+.dashboardPanelHeader button:hover:not(:disabled),
+.dashboardTextAction:hover:not(:disabled) {
+  border: 0;
+  background: transparent;
+  color: var(--success);
+}
+
+.serviceSpectrum {
+  display: flex;
+  height: 5px;
+  overflow: hidden;
+  background: #dde3dc;
+}
+
+.serviceSpectrumReady { background: var(--success); }
+.serviceSpectrumBlocked { background: #d6a453; }
+
+.dashboardServiceGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dashboardService {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  min-height: 66px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 9px 12px;
+  animation: dashboardReveal 340ms ease-out both;
+  animation-delay: var(--reveal);
+}
+
+.dashboardService:nth-child(even) { border-right: 0; }
+
+@keyframes dashboardReveal {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboardService { animation: none; }
+}
+
+.dashboardServiceMark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid var(--border);
+  background: #f3f5f0;
+}
+
+.dashboardServiceMark svg { width: 17px; height: 17px; }
+.dashboardService > span:nth-child(2) { display: grid; gap: 2px; min-width: 0; }
+.dashboardService > span:nth-child(2) strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.dashboardService > span:nth-child(2) small { overflow: hidden; color: var(--muted); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.dashboardService.attention { box-shadow: inset 2px 0 #d6a453; }
+
+.dashboardTextAction {
+  justify-content: flex-start;
+  margin: 6px 14px;
+}
+
+.panelIntro {
+  border-bottom: 1px solid var(--border);
+  padding: 11px 14px;
+  font-size: 10px;
+}
+
+.quotaList { display: grid; }
+
+.quotaRow {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 72px;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 14px;
+}
+
+.quotaIdentity,
+.quotaNumbers {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.quotaIdentity strong,
+.quotaNumbers strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.quotaIdentity small,
+.quotaNumbers small { color: var(--muted); font-size: 9px; }
+.quotaNumbers { justify-items: end; text-align: right; }
+.quotaNumbers strong { font-family: "DM Mono", ui-monospace, monospace; }
+
+.activityDiagram { display: grid; padding: 8px 14px 12px; }
+
+.activityBar {
+  display: grid;
+  grid-template-columns: minmax(128px, 0.8fr) minmax(100px, 1fr) 38px;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  border-bottom: 1px solid var(--border);
+}
+
+.activityBar:last-child { border-bottom: 0; }
+.activityBar > strong { font-family: "DM Mono", ui-monospace, monospace; font-size: 10px; font-weight: 500; text-align: right; }
+
+.activityTrack {
+  display: block;
+  height: 6px;
+  overflow: hidden;
+  background: #e2e7e0;
+}
+
+.activityTrack span { display: block; height: 100%; background: linear-gradient(90deg, #16825d, #53c99a); }
+
+.operationsDiagram {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.operationsDiagram > div {
+  display: grid;
+  gap: 3px;
+  min-height: 96px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 14px;
+}
+
+.operationsDiagram > div:nth-child(even) { border-right: 0; }
+.operationsDiagram span { color: var(--muted); }
+.operationsDiagram strong { font-family: "DM Mono", ui-monospace, monospace; font-size: 25px; font-weight: 500; }
+.operationsDiagram small { align-self: end; color: var(--muted); font-size: 9px; }
+.operationsDiagram .needsAttention { box-shadow: inset 3px 0 #d6a453; background: #fffaf0; }
+.operationsDiagram .healthy { box-shadow: inset 3px 0 var(--success); background: #f5fbf7; }
+
+.operationsFooter {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 13px 14px;
+  color: var(--success);
+}
+
+.operationsFooter svg { width: 19px; height: 19px; }
+.operationsFooter span { display: grid; gap: 2px; }
+.operationsFooter strong { color: var(--foreground-strong); font-size: 10px; }
+.operationsFooter small { color: var(--muted); font-size: 9px; }
+
+.dashboardEmpty {
+  display: grid;
+  grid-column: 1 / -1;
+  justify-items: center;
+  gap: 5px;
+  padding: 28px 16px;
+  text-align: center;
+}
+
+.dashboardEmpty svg { width: 22px; height: 22px; color: var(--light-slate); }
+.dashboardEmpty strong { font-size: 11px; }
+.dashboardEmpty p { max-width: 44ch; }
+
+@media (max-width: 1120px) {
+  .dashboardHero { grid-template-columns: 1fr; }
+  .heroMeters { justify-content: start; margin-top: 28px; padding-left: 0; }
+  .dashboardGrid { grid-template-columns: 1fr; }
+  .quotaPanel { grid-row: auto; }
+}
+
+@media (max-width: 760px) {
+  .dashboardCanvas { margin: 8px; }
+  .dashboardHero { padding: 25px 20px; }
+  .heroCopy h2 { font-size: 28px; }
+  .heroMeters { gap: 10px; overflow-x: auto; }
+  .radialMeter { width: 78px; height: 78px; }
+  .dashboardStats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dashboardStats > div:nth-child(2) { border-right: 0; }
+  .dashboardStats > div:nth-child(-n + 2) { border-bottom: 1px solid var(--border); }
+  .dashboardServiceGrid { grid-template-columns: 1fr; }
+  .dashboardService { border-right: 0; }
+  .activityBar { grid-template-columns: minmax(110px, 1fr) 1fr 34px; }
 }

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -94,7 +94,7 @@ async fn fetch(req: Request, env: Env, ctx: Context) -> Result<Response> {
         return redirect_to(&redirect_location(ROOT_REDIRECT_PATH, url.query()));
     }
     if req.method() == Method::Get && request_path == ROOT_REDIRECT_PATH {
-        return redirect_to(&redirect_location("/dashboard/catalog", url.query()));
+        return redirect_to(&redirect_location("/dashboard/home", url.query()));
     }
     if req.method() == Method::Get {
         if let Some(target) = legacy_interface_redirect(url.path()) {
@@ -143,6 +143,12 @@ async fn fetch(req: Request, env: Env, ctx: Context) -> Result<Response> {
 
     if req.method() == Method::Get && api_path == "/v1/entitlements" {
         return access_entitlements(req.headers(), &env)
+            .await
+            .and_then(with_cors);
+    }
+
+    if req.method() == Method::Get && api_path == "/v1/session/usage" {
+        return access_session_usage(req.headers(), &env)
             .await
             .and_then(with_cors);
     }
@@ -317,6 +323,7 @@ fn service_index() -> Result<Response> {
             "routes": "/v1/routes",
             "session": "/v1/session",
             "entitlements": "/v1/entitlements",
+            "sessionUsage": "/v1/session/usage",
             "me": "/v1/me",
             "usage": "/v1/usage",
             "models": "/v1/models",
@@ -4155,6 +4162,45 @@ async fn user_usage(headers: &Headers, env: &Env) -> Result<Response> {
     }))
 }
 
+async fn access_session_usage(headers: &Headers, env: &Env) -> Result<Response> {
+    let Some(session) = verified_access_session(headers, env).await? else {
+        return json_error(
+            "access_session_required",
+            "usage requires a verified Cloudflare Access session",
+            401,
+        );
+    };
+    let kv = match env.kv("POLICY_KV") {
+        Ok(kv) => kv,
+        Err(_) => {
+            return json_error(
+                "policy_store_unavailable",
+                POLICY_KV_ENTITLEMENTS_REQUIRED,
+                503,
+            );
+        }
+    };
+    let entries = list_session_policy_entries(&kv, env, &session).await?;
+    let mut policies = Vec::with_capacity(entries.len());
+    let mut usage = empty_usage_snapshot("durable_object");
+    for entry in entries {
+        if !entry.policy.enabled {
+            continue;
+        }
+        let policy_id = entry.policy_id;
+        let policy = entry.policy;
+        policies.push(
+            admin_usage_row(env, admin_policy_response(&policy_id, &policy_id, &policy)).await?,
+        );
+        merge_usage_snapshot(&mut usage, usage_snapshot(env, Some(&policy_id), 0).await?);
+    }
+    usage.events.clear();
+    Response::from_json(&serde_json::json!({
+        "policies": policies,
+        "usage": usage
+    }))
+}
+
 async fn inspect_proxy_key(headers: &Headers, env: &Env) -> Result<Response> {
     let auth = headers.get("authorization")?.unwrap_or_default();
     let token = auth.strip_prefix("Bearer ").unwrap_or("");
@@ -4606,6 +4652,66 @@ fn empty_usage_snapshot(ledger: &str) -> UsageSnapshot {
         providers: Vec::new(),
         events: Vec::new(),
     }
+}
+
+fn merge_usage_snapshot(target: &mut UsageSnapshot, source: UsageSnapshot) {
+    if source.ledger != "durable_object" {
+        target.ledger = source.ledger;
+    }
+    target.summary.request_count = target
+        .summary
+        .request_count
+        .saturating_add(source.summary.request_count);
+    target.summary.success_count = target
+        .summary
+        .success_count
+        .saturating_add(source.summary.success_count);
+    target.summary.error_count = target
+        .summary
+        .error_count
+        .saturating_add(source.summary.error_count);
+    target.summary.input_tokens = target
+        .summary
+        .input_tokens
+        .saturating_add(source.summary.input_tokens);
+    target.summary.output_tokens = target
+        .summary
+        .output_tokens
+        .saturating_add(source.summary.output_tokens);
+    target.summary.total_tokens = target
+        .summary
+        .total_tokens
+        .saturating_add(source.summary.total_tokens);
+    target.summary.actual_cost_micros = target
+        .summary
+        .actual_cost_micros
+        .saturating_add(source.summary.actual_cost_micros);
+    for provider in source.providers {
+        if let Some(existing) = target
+            .providers
+            .iter_mut()
+            .find(|existing| existing.provider == provider.provider)
+        {
+            existing.request_count = existing
+                .request_count
+                .saturating_add(provider.request_count);
+            existing.success_count = existing
+                .success_count
+                .saturating_add(provider.success_count);
+            existing.error_count = existing.error_count.saturating_add(provider.error_count);
+            existing.total_tokens = existing.total_tokens.saturating_add(provider.total_tokens);
+            existing.actual_cost_micros = existing
+                .actual_cost_micros
+                .saturating_add(provider.actual_cost_micros);
+        } else {
+            target.providers.push(provider);
+        }
+    }
+    target.providers.sort_by(|a, b| {
+        b.request_count
+            .cmp(&a.request_count)
+            .then_with(|| a.provider.cmp(&b.provider))
+    });
 }
 
 fn response_tenant_id(entry: &AdminKeyPolicyResponse) -> String {
@@ -14454,6 +14560,7 @@ fn cors_enabled_path(path: &str) -> bool {
             | "/v1/routes"
             | "/v1/session"
             | "/v1/entitlements"
+            | "/v1/session/usage"
             | "/v1/me"
             | "/v1/usage"
             | "/v1/models"
@@ -16556,6 +16663,71 @@ mod tests {
     }
 
     #[test]
+    fn session_usage_merges_effective_policy_totals_without_events() {
+        let mut target = UsageSnapshot {
+            ledger: "durable_object".to_string(),
+            summary: UsageSummary {
+                request_count: 2,
+                success_count: 2,
+                total_tokens: 30,
+                actual_cost_micros: 120,
+                ..UsageSummary::default()
+            },
+            providers: vec![ProviderUsageSummary {
+                provider: "openai".to_string(),
+                request_count: 2,
+                success_count: 2,
+                error_count: 0,
+                total_tokens: 30,
+                actual_cost_micros: 120,
+            }],
+            events: Vec::new(),
+        };
+        let source = UsageSnapshot {
+            ledger: "durable_object".to_string(),
+            summary: UsageSummary {
+                request_count: 4,
+                success_count: 3,
+                error_count: 1,
+                total_tokens: 90,
+                actual_cost_micros: 380,
+                ..UsageSummary::default()
+            },
+            providers: vec![
+                ProviderUsageSummary {
+                    provider: "anthropic".to_string(),
+                    request_count: 3,
+                    success_count: 2,
+                    error_count: 1,
+                    total_tokens: 70,
+                    actual_cost_micros: 300,
+                },
+                ProviderUsageSummary {
+                    provider: "openai".to_string(),
+                    request_count: 1,
+                    success_count: 1,
+                    error_count: 0,
+                    total_tokens: 20,
+                    actual_cost_micros: 80,
+                },
+            ],
+            events: Vec::new(),
+        };
+
+        merge_usage_snapshot(&mut target, source);
+
+        assert_eq!(target.summary.request_count, 6);
+        assert_eq!(target.summary.success_count, 5);
+        assert_eq!(target.summary.error_count, 1);
+        assert_eq!(target.summary.total_tokens, 120);
+        assert_eq!(target.summary.actual_cost_micros, 500);
+        assert_eq!(target.providers[0].provider, "anthropic");
+        assert_eq!(target.providers[1].provider, "openai");
+        assert_eq!(target.providers[1].request_count, 3);
+        assert!(target.events.is_empty());
+    }
+
+    #[test]
     fn cors_policy_allows_admin_and_anthropic_browser_clients() {
         assert_eq!(CORS_ALLOW_ORIGIN, "*");
         assert_eq!(CORS_ALLOW_METHODS, "GET,POST,PUT,OPTIONS");
@@ -16582,6 +16754,7 @@ mod tests {
         assert!(cors_enabled_path("/v1/routes"));
         assert!(cors_enabled_path("/v1/session"));
         assert!(cors_enabled_path("/v1/entitlements"));
+        assert!(cors_enabled_path("/v1/session/usage"));
         assert!(cors_enabled_path("/v1/me"));
         assert!(cors_enabled_path("/v1/usage"));
         assert!(cors_enabled_path("/v1/messages"));
@@ -16593,6 +16766,7 @@ mod tests {
     #[test]
     fn interface_routes_require_the_admin_shell() {
         assert!(!interface_path("/dashboard"));
+        assert!(interface_path("/dashboard/home"));
         assert!(interface_path("/dashboard/access"));
         assert!(interface_path("/dashboard/catalog"));
         assert!(interface_path("/dashboard/playground"));
@@ -16656,8 +16830,8 @@ mod tests {
             "/dashboard?demo"
         );
         assert_eq!(
-            redirect_location("/dashboard/catalog", Some("demo")),
-            "/dashboard/catalog?demo"
+            redirect_location("/dashboard/home", Some("demo")),
+            "/dashboard/home?demo"
         );
     }
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -68,10 +68,10 @@ These settings control who can pass Cloudflare Access;
 `CLAWROUTER_ACCESS_ADMIN_*` controls who is an admin inside ClawRouter.
 `CLAWROUTER_ACCESS_SERVICE_TOKEN_IDS` creates a separate Service Auth
 (`non_identity`) policy for automation. The default path-scoped Access
-destinations are `/dashboard/*`, `/v1/session`, `/v1/playground/*`,
+destinations are `/dashboard/*`, `/v1/session*`, `/v1/playground/*`,
 `/v1/admin/*`, and `/v1/oauth/callback`. This stays within Cloudflare's
 five-destination per-application limit while still protecting the console
-entrypoint and the Access-backed session, playground, admin, and OAuth callback
+entrypoint and the Access-backed session and quota usage, playground, admin, and OAuth callback
 APIs. `/v1/entitlements` still verifies the Access JWT inside the Worker, but is
 not a separate Access application destination. Override
 them with `CLAWROUTER_ACCESS_PATHS` only if the API contract changes. Do not add
@@ -254,7 +254,7 @@ the `cf-access-jwt-assertion` signature against the team certs endpoint before
 it trusts the email or role.
 
 The browser console is fail-closed in the Worker. `/` redirects to
-`/dashboard`, and `/dashboard` redirects to `/dashboard/catalog`; the default
+`/dashboard`, and `/dashboard` redirects to `/dashboard/home`; the default
 Access app protects `/dashboard/*`.
 Old top-level console paths such as `/playground`, `/admin`, `/account`,
 `/routes`, and `/console` redirect under `/dashboard`. Public and client-facing surfaces stay under
@@ -263,7 +263,7 @@ proxy endpoints.
 
 After Access is configured, an unauthenticated request to `/` should be handled
 by the Worker with a redirect to `/dashboard`, `/dashboard` should redirect to
-`/dashboard/catalog`, and `/dashboard/catalog` should be handled by Cloudflare
+`/dashboard/home`, and `/dashboard/home` should be handled by Cloudflare
 Access before it reaches the Worker. A raw `401` JSON response with
 `access_session_required` on `/dashboard/*` means the Access
 application is not protecting the console path or the Worker was deployed

--- a/scripts/provision-access.mjs
+++ b/scripts/provision-access.mjs
@@ -417,7 +417,7 @@ function destinationUris(app) {
 function defaultAccessPaths() {
   return [
     "/dashboard/*",
-    "/v1/session",
+    "/v1/session*",
     "/v1/playground/*",
     "/v1/admin/*",
     "/v1/oauth/callback",
@@ -513,7 +513,7 @@ function printPlan({ app, policies, teamDomain, aud, created, updated }) {
   console.log("");
   console.log("Expected live root check after redeploy:");
   console.log(`curl -sS -D - -o /dev/null https://${host}/`);
-  console.log("Root should 302 to /dashboard, /dashboard should 302 to /dashboard/catalog, and Cloudflare Access should challenge console, admin, playground, and OAuth callback paths.");
+  console.log("Root should 302 to /dashboard, /dashboard should 302 to /dashboard/home, and Cloudflare Access should challenge console, session usage, admin, playground, and OAuth callback paths.");
 }
 
 function syncGitHubVariable(repoName, name, value) {

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -13,8 +13,8 @@ const smokeKey = process.env.CLAWROUTER_SMOKE_KEY;
 
 await expectOk(`${baseUrl}/v1/health`, "health");
 await expectRedirect(`${baseUrl}/`, "root redirect", "/dashboard");
-await expectRedirectOrAccessGate(`${baseUrl}/dashboard`, "dashboard redirect", "/dashboard/catalog");
-await expectAccessGate(`${baseUrl}/dashboard/catalog`, "catalog access gate");
+await expectRedirectOrAccessGate(`${baseUrl}/dashboard`, "dashboard redirect", "/dashboard/home");
+await expectAccessGate(`${baseUrl}/dashboard/home`, "dashboard access gate");
 await expectRedirect(`${baseUrl}/catalog`, "legacy catalog redirect", "/dashboard/catalog");
 const providers = await expectOk(`${baseUrl}/v1/providers`, "providers");
 if (!Array.isArray(providers.providers) || providers.providers.length < 19) {
@@ -25,6 +25,7 @@ expectRouteCatalog(routes, "route catalog");
 const aliasedRoutes = await expectOk(`${baseUrl}/api/route`, "route catalog alias");
 expectRouteCatalog(aliasedRoutes, "route catalog alias");
 await expectAccessGate(`${baseUrl}/v1/session`, "session access gate");
+await expectAccessGate(`${baseUrl}/v1/session/usage`, "session usage access gate");
 await expectClientAuthGate(`${baseUrl}/v1/entitlements`, "entitlements Worker auth gate");
 await expectAccessGate(`${baseUrl}/v1/playground/v1/chat/completions`, "playground access gate");
 await expectAccessGate(`${baseUrl}/v1/oauth/callback`, "OAuth callback access gate");

--- a/test/provision-access.test.mjs
+++ b/test/provision-access.test.mjs
@@ -16,6 +16,7 @@ test("Access provisioning protects the browser OAuth callback by default", () =>
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /clawrouter\.example\.com\/dashboard\/\*/);
+  assert.match(result.stdout, /clawrouter\.example\.com\/v1\/session\*/);
   assert.match(result.stdout, /clawrouter\.example\.com\/v1\/admin\/\*/);
   assert.match(result.stdout, /clawrouter\.example\.com\/v1\/oauth\/callback/);
   assert.doesNotMatch(result.stdout, /clawrouter\.example\.com\/v1\/entitlements/);


### PR DESCRIPTION
## Summary

- add a role-aware dashboard landing page for Access users and administrators
- show granted services, readiness, shared quota pools, provider activity, and admin control-plane signals
- expose privacy-safe aggregate usage for effective Access-session policies without request-event details
- make the dashboard the canonical console landing route and protect session usage through Cloudflare Access

## Verification

- `pnpm check`
- `pnpm test:scripts`
- `pnpm --dir admin build`
- Chrome E2E: admin and user role previews, navigation, 768px responsive layout
- Lighthouse: accessibility 100, best practices 100
- autoreview: clean, no actionable findings

## Deployment

- pending merge and Cloudflare workflow deployment
