### PR TITLE
fix: inline console favicon

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="ClawRouter service access, quota, and gateway console." />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iOCIgZmlsbD0iIzExMTgxNSIvPgogIDxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2Y0ZjdmMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjQiPgogICAgPHBhdGggZD0iTTE3IDIwaDIwYTggOCAwIDAgMSAwIDE2SDI3YTggOCAwIDAgMCAwIDE2aDIwIi8+CiAgICA8Y2lyY2xlIGN4PSIxNSIgY3k9IjIwIiByPSI1Ii8+CiAgICA8Y2lyY2xlIGN4PSI0OSIgY3k9IjUyIiByPSI1Ii8+CiAgPC9nPgo8L3N2Zz4K" type="image/svg+xml" />
     <title>ClawRouter Console</title>
   </head>
   <body>

--- a/admin/public/favicon.svg
+++ b/admin/public/favicon.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#111815"/>
-  <g fill="none" stroke="#f4f7f2" stroke-linecap="round" stroke-width="4">
-    <path d="M17 20h20a8 8 0 0 1 0 16H27a8 8 0 0 0 0 16h20"/>
-    <circle cx="15" cy="20" r="5"/>
-    <circle cx="49" cy="52" r="5"/>
-  </g>
-</svg>


### PR DESCRIPTION
## Summary

- inline the console SVG favicon in the HTML shell
- avoid a Worker asset request that returned 404 in production

## Verification

- `pnpm --dir admin build`
- `git diff --check`

## Deployment

- pending merge and Cloudflare deployment
