### PR TITLE
[codex] auto-refresh dashboard data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Automatically refresh dashboard data every 30 seconds and on tab focus without overwriting unsaved admin edits.
 - Merge overlapping model and manifest routes into one catalog entry per provider.
 - Add role-aware user and admin dashboards with service readiness, shared quota pools, traffic diagrams, and privacy-safe Access-session usage totals.
 - Gate the Cloudflare console by verified GitHub organization membership and support secure bulk provider-secret deployment.

--- a/admin/src/auto-refresh.ts
+++ b/admin/src/auto-refresh.ts
@@ -1,0 +1,23 @@
+export const AUTO_REFRESH_INTERVAL_MS = 30_000;
+
+type RefreshWindow = Pick<Window, "addEventListener" | "removeEventListener" | "setInterval" | "clearInterval">;
+type RefreshDocument = Pick<Document, "addEventListener" | "removeEventListener" | "visibilityState">;
+
+export function installAutoRefresh(
+  refresh: () => void,
+  windowTarget: RefreshWindow = window,
+  documentTarget: RefreshDocument = document,
+) {
+  const refreshWhenVisible = () => {
+    if (documentTarget.visibilityState === "visible") refresh();
+  };
+  const interval = windowTarget.setInterval(refreshWhenVisible, AUTO_REFRESH_INTERVAL_MS);
+  windowTarget.addEventListener("focus", refreshWhenVisible);
+  documentTarget.addEventListener("visibilitychange", refreshWhenVisible);
+
+  return () => {
+    windowTarget.clearInterval(interval);
+    windowTarget.removeEventListener("focus", refreshWhenVisible);
+    documentTarget.removeEventListener("visibilitychange", refreshWhenVisible);
+  };
+}

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import React, { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   BarChart3,
@@ -22,6 +22,7 @@ import {
   Users,
 } from "lucide-react";
 import providerIconManifest from "../../crates/edge/src/provider-icons.json";
+import { installAutoRefresh } from "./auto-refresh";
 import {
   accessFormFromUser,
   accessMap,
@@ -55,6 +56,7 @@ import {
 import "./style.css";
 
 type View = "home" | "catalog" | "playground" | "policies" | "users" | "usage";
+type RefreshOptions = { background?: boolean };
 
 const pathViews: Record<string, View> = {
   "/": "home",
@@ -573,6 +575,7 @@ function App() {
   const [selectedAssignmentRuleId, setSelectedAssignmentRuleId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
   const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
   const [status, setStatus] = useState(allowDemo ? "local demo data loaded" : "loading");
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(allowDemo ? Date.now() : null);
   const [demoMode, setDemoMode] = useState(allowDemo);
   const [issuedKey, setIssuedKey] = useState("");
   const [policyError, setPolicyError] = useState("");
@@ -590,6 +593,9 @@ function App() {
   });
   const [playgroundResult, setPlaygroundResult] = useState("Run a request to see the raw response.");
   const [requestMode, setRequestMode] = useState<"json" | "curl">("json");
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const refreshBackgroundRef = useRef(false);
+  const refreshRef = useRef<(options?: RefreshOptions) => Promise<void>>(async () => undefined);
 
   const accessByProvider = useMemo(() => accessMap(entitlements), [entitlements]);
   const services = useMemo(() => serviceItems(providers, routes, providerReadiness, accessByProvider), [accessByProvider, providerReadiness, providers, routes]);
@@ -609,6 +615,8 @@ function App() {
   const selectedModel = models.find((model) => model.id === playground.model) ?? models[0];
   const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === playground.serviceRoute) ?? serviceRoutes[0];
   const busy = status === "loading" || ["saving", "running", "revoking", "issuing", "enabling", "disabling", "connecting"].some((prefix) => status.startsWith(prefix));
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
   const statusTone = statusKind(status);
 
   useEffect(() => {
@@ -618,6 +626,17 @@ function App() {
     }
     void refresh();
   }, []);
+
+  useEffect(() => {
+    refreshRef.current = refresh;
+  });
+
+  useEffect(() => {
+    if (demoMode) return;
+    return installAutoRefresh(() => {
+      if (!busyRef.current) void refreshRef.current({ background: true });
+    });
+  }, [demoMode]);
 
   useEffect(() => {
     const onPopState = () => setView(initialViewFromPath());
@@ -648,10 +667,30 @@ function App() {
     }
   }, [playground.serviceRoute, serviceRoutes]);
 
-  async function refresh() {
+  function refresh(options: RefreshOptions = {}): Promise<void> {
+    if (refreshPromiseRef.current) {
+      if (!options.background && refreshBackgroundRef.current) {
+        return refreshPromiseRef.current.then(() => refresh(options));
+      }
+      return refreshPromiseRef.current;
+    }
+    refreshBackgroundRef.current = options.background ?? false;
+    const operation = refreshData(options).finally(() => {
+      if (refreshPromiseRef.current === operation) {
+        refreshPromiseRef.current = null;
+        refreshBackgroundRef.current = false;
+      }
+    });
+    refreshPromiseRef.current = operation;
+    return operation;
+  }
+
+  async function refreshData({ background = false }: RefreshOptions) {
     try {
-      setStatus("loading");
-      setPolicyDataLoaded(false);
+      if (!background) {
+        setStatus("loading");
+        setPolicyDataLoaded(false);
+      }
       const [sessionData, providerData, routeData] = await Promise.all([
         request<SessionResponse>(gatewayOrigin, "/v1/session"),
         request<ProviderResponse>(gatewayOrigin, "/v1/providers"),
@@ -693,30 +732,35 @@ function App() {
         setConnections(connectionData.connections);
         setUpstreamGrants(upstreamGrantData.grants);
         setAssignmentRules(assignmentRuleData.rules);
-        const refreshedPolicy = policyData.policies.find((policy) => policy.policyId === selectedPolicyId) ?? policyData.policies[0];
-        setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
-        setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
-        const refreshedCredential = credentialData.credentials.find((credential) => credential.credentialId === selectedCredentialId) ?? credentialData.credentials[0];
-        setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
-        setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? policyData.policies[0]?.policyId ?? "" });
-        const refreshedBinding = bindingData.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? bindingData.bindings[0];
-        setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
-        setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
-        const refreshedGrant = upstreamGrantData.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? upstreamGrantData.grants[0];
-        setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
-        setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerData.providers[0]?.id ?? "", tokenRef: providerData.providers[0]?.id ?? "" });
-        const refreshedRule = assignmentRuleData.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? assignmentRuleData.rules[0];
-        setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
-        setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
         setUsers(userData.users);
         setBindings(bindingData.bindings);
-        const refreshedUser = userData.users.find((user) => user.email === selectedUserEmail) ?? userData.users[0];
-        setSelectedUserEmail(refreshedUser?.email ?? "");
-        setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, bindingData.bindings) : defaultAccess);
+        if (!background) {
+          const refreshedPolicy = policyData.policies.find((policy) => policy.policyId === selectedPolicyId) ?? policyData.policies[0];
+          setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
+          setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
+          const refreshedCredential = credentialData.credentials.find((credential) => credential.credentialId === selectedCredentialId) ?? credentialData.credentials[0];
+          setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
+          setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? policyData.policies[0]?.policyId ?? "" });
+          const refreshedBinding = bindingData.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? bindingData.bindings[0];
+          setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
+          setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
+          const refreshedGrant = upstreamGrantData.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? upstreamGrantData.grants[0];
+          setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
+          setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerData.providers[0]?.id ?? "", tokenRef: providerData.providers[0]?.id ?? "" });
+          const refreshedRule = assignmentRuleData.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? assignmentRuleData.rules[0];
+          setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
+          setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
+          const refreshedUser = userData.users.find((user) => user.email === selectedUserEmail) ?? userData.users[0];
+          setSelectedUserEmail(refreshedUser?.email ?? "");
+          setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, bindingData.bindings) : defaultAccess);
+        }
         setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
-        const [overviewResult, tenantResult] = await Promise.all([
+        const [overviewResult, tenantResult, usageResult] = await Promise.all([
           settled(() => request<AdminOverview>(gatewayOrigin, "/v1/admin/overview")),
           settled(() => request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/tenants")),
+          background
+            ? settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/admin/usage"))
+            : Promise.resolve(null),
         ]);
         if (overviewResult.ok) {
           setAdminOverview(overviewResult.value);
@@ -730,11 +774,19 @@ function App() {
           setTenantSummaries(tenantSummaryFallback(policyData.policies, credentialData.credentials));
           refreshWarnings = [...refreshWarnings, `tenant summary unavailable: ${tenantResult.error}`];
         }
-        setUsageRows([]);
-        setUsageSnapshot(emptyUsageSnapshot);
-        setUsageLoaded(false);
+        if (usageResult?.ok) {
+          setUsageRows(usageResult.value.policies ?? usageResult.value.keys ?? []);
+          setUsageSnapshot(usageResult.value.usage);
+          setUsageLoaded(true);
+        } else if (usageResult) {
+          refreshWarnings = [...refreshWarnings, `usage ledger unavailable: ${usageResult.error}`];
+        } else {
+          setUsageRows([]);
+          setUsageSnapshot(emptyUsageSnapshot);
+          setUsageLoaded(false);
+        }
         setPolicyDataLoaded(true);
-        if (view === "usage") setUsageRefreshKey((current) => current + 1);
+        if (!background && view === "usage") setUsageRefreshKey((current) => current + 1);
       } else {
         const user = {
           email: sessionData.email ?? "access-user",
@@ -768,7 +820,8 @@ function App() {
         setAccessForm(accessFormFromUser(user, []));
       }
       setDemoMode(false);
-      setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : oauthCallbackStatus() ?? "connected");
+      setLastUpdatedAt(Date.now());
+      if (!background) setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : oauthCallbackStatus() ?? "connected");
     } catch (error) {
       const message = errorMessage(error);
       if (allowDemo) {
@@ -803,11 +856,12 @@ function App() {
         setSelectedUserEmail(demo.users[0]?.email ?? "");
         setAccessForm(demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
         setDemoMode(true);
+        setLastUpdatedAt(Date.now());
         setStatus("local demo data loaded");
         return;
       }
       setDemoMode(false);
-      setStatus(`load error: ${message}`);
+      if (!background) setStatus(`load error: ${message}`);
     }
   }
 
@@ -851,6 +905,7 @@ function App() {
     setUsageLoaded(true);
     setEntitlements(entitlements);
     setProviderReadiness(readinessMap(entitlements.providers.map((provider) => provider.readiness)));
+    setLastUpdatedAt(Date.now());
     setStatus("local user demo loaded");
     setDemoMode(true);
   }
@@ -1486,10 +1541,10 @@ function App() {
           </div>
           <div className="topActions">
             <span className={`status ${session.role === "admin" ? "active" : "neutral"}`}>{session.role}</span>
-            <button type="button" className="buttonSecondary" onClick={refresh} disabled={busy}>
-              <RefreshCw className="buttonIcon" aria-hidden="true" />
-              <span>Sync gateway</span>
-            </button>
+            <span className="refreshMeta" title="Automatically refreshes every 30 seconds and when this tab regains focus">
+              <span>Last updated</span>
+              {lastUpdatedAt ? <time dateTime={new Date(lastUpdatedAt).toISOString()}>{formatTimestamp(lastUpdatedAt)}</time> : <span>updating…</span>}
+            </span>
           </div>
         </header>
 

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -1857,6 +1857,24 @@ h2 {
   gap: 7px;
 }
 
+.refreshMeta {
+  display: grid;
+  justify-items: end;
+  gap: 1px;
+  color: var(--muted);
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 8px;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+.refreshMeta time,
+.refreshMeta > span:last-child {
+  color: var(--foreground);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+
 .buttonSecondary,
 .segmented button,
 .presetRow button {

--- a/admin/test/auto-refresh.test.mjs
+++ b/admin/test/auto-refresh.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AUTO_REFRESH_INTERVAL_MS, installAutoRefresh } from "../src/auto-refresh.ts";
+
+test("auto refresh runs on its interval and when a visible tab regains focus", () => {
+  const windowTarget = new FakeWindow();
+  const documentTarget = new FakeDocument();
+  let refreshes = 0;
+  const uninstall = installAutoRefresh(() => { refreshes += 1; }, windowTarget, documentTarget);
+
+  assert.equal(windowTarget.intervalMs, AUTO_REFRESH_INTERVAL_MS);
+  windowTarget.intervalHandler();
+  windowTarget.dispatchEvent(new Event("focus"));
+  documentTarget.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(refreshes, 3);
+
+  documentTarget.visibilityState = "hidden";
+  windowTarget.intervalHandler();
+  windowTarget.dispatchEvent(new Event("focus"));
+  assert.equal(refreshes, 3);
+
+  uninstall();
+  windowTarget.dispatchEvent(new Event("focus"));
+  assert.equal(refreshes, 3);
+  assert.equal(windowTarget.clearedInterval, 1);
+});
+
+class FakeWindow extends EventTarget {
+  intervalHandler = () => {};
+  intervalMs = 0;
+  clearedInterval = 0;
+
+  setInterval(handler, milliseconds) {
+    this.intervalHandler = handler;
+    this.intervalMs = milliseconds;
+    return 1;
+  }
+
+  clearInterval(interval) {
+    this.clearedInterval = interval;
+  }
+}
+
+class FakeDocument extends EventTarget {
+  visibilityState = "visible";
+}


### PR DESCRIPTION
## Summary

- replace the manual “Sync gateway” control with automatic refresh every 30 seconds
- refresh immediately when the visible tab regains focus
- show a compact last-updated timestamp
- preserve unsaved admin form edits and foreground action status during background refreshes

## Verification

- `pnpm --dir admin test`
- `pnpm --dir admin build`
- local Chrome UI check: no sync button, timestamp present, no horizontal overflow
- autoreview: clean after fixing the background/foreground status race

## Deployment

Deployed to production from `163cf59`; Cloudflare workflow `27925680170` and all 16 live-provider smoke checks passed.

## Remaining risk

Low. Background refresh is suspended while the page is hidden and while a foreground action is busy.
