### PR TITLE
[codex] compact dashboard status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Collapse healthy gateway status into the header while retaining the full status row for work, warnings, and errors.
 - Automatically refresh dashboard data every 30 seconds and on tab focus without overwriting unsaved admin edits.
 - Merge overlapping model and manifest routes into one catalog entry per provider.
 - Add role-aware user and admin dashboards with service readiness, shared quota pools, traffic diagrams, and privacy-safe Access-session usage totals.

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import providerIconManifest from "../../crates/edge/src/provider-icons.json";
 import { installAutoRefresh } from "./auto-refresh";
+import { consoleStatusPresentation } from "./status-display";
 import {
   accessFormFromUser,
   accessMap,
@@ -614,10 +615,11 @@ function App() {
   const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
   const selectedModel = models.find((model) => model.id === playground.model) ?? models[0];
   const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === playground.serviceRoute) ?? serviceRoutes[0];
-  const busy = status === "loading" || ["saving", "running", "revoking", "issuing", "enabling", "disabling", "connecting"].some((prefix) => status.startsWith(prefix));
+  const statusPresentation = consoleStatusPresentation(status, demoMode);
+  const busy = statusPresentation.tone === "pending";
   const busyRef = useRef(busy);
   busyRef.current = busy;
-  const statusTone = statusKind(status);
+  const statusTone = statusPresentation.tone;
 
   useEffect(() => {
     if (localDemoRole() === "user") {
@@ -1541,14 +1543,17 @@ function App() {
           </div>
           <div className="topActions">
             <span className={`status ${session.role === "admin" ? "active" : "neutral"}`}>{session.role}</span>
-            <span className="refreshMeta" title="Automatically refreshes every 30 seconds and when this tab regains focus">
-              <span>Last updated</span>
-              {lastUpdatedAt ? <time dateTime={new Date(lastUpdatedAt).toISOString()}>{formatTimestamp(lastUpdatedAt)}</time> : <span>updating…</span>}
+            <span className={`connectionMeta connectionMeta-${statusTone}`} title="Automatically refreshes every 30 seconds and when this tab regains focus">
+              <span className="connectionDot" aria-hidden="true" />
+              <strong>{statusPresentation.label}</strong>
+              <span className="connectionSeparator" aria-hidden="true">·</span>
+              <span>Updated</span>
+              {lastUpdatedAt ? <time dateTime={new Date(lastUpdatedAt).toISOString()}>{formatTimestamp(lastUpdatedAt)}</time> : <span>pending</span>}
             </span>
           </div>
         </header>
 
-        <div className={`statusBar statusBar-${statusTone}`} role="status" aria-live="polite"><strong>{statusLabel(statusTone)}</strong><span>{status}</span>{demoMode ? <em>demo</em> : null}</div>
+        {statusPresentation.showBar ? <div className={`statusBar statusBar-${statusTone}`} role="status" aria-live="polite"><strong>{statusPresentation.label}</strong><span>{status}</span>{demoMode ? <em>demo</em> : null}</div> : null}
 
         {view === "home" ? (
           <DashboardScreen
@@ -2706,13 +2711,6 @@ function kindIcon(kind: string): IconComponent {
   return Boxes;
 }
 
-function statusKind(status: string) {
-  if (status.includes("error") || status.includes("failed") || status.includes("select") || status.includes("invalid") || status.includes("must") || status.includes("returned") || status.includes("paste")) return "error";
-  if (status === "loading" || status.startsWith("saving") || status.startsWith("running") || status.startsWith("revoking") || status.startsWith("connecting")) return "pending";
-  if (status.includes("loaded") || status.includes("saved") || status.includes("connected") || status.includes("ready") || status.includes("revoked")) return "success";
-  return "neutral";
-}
-
 function oauthCallbackStatus() {
   const params = new URLSearchParams(window.location.search);
   const outcome = params.get("oauth");
@@ -2720,10 +2718,6 @@ function oauthCallbackStatus() {
   if (outcome === "connected") return `${provider} connected`;
   if (outcome === "failed") return `${provider} OAuth failed`;
   return null;
-}
-
-function statusLabel(kind: ReturnType<typeof statusKind>) {
-  return kind === "success" ? "ready" : kind === "pending" ? "working" : kind === "error" ? "needs attention" : "standby";
 }
 
 function isLocalDemoAllowed() {

--- a/admin/src/status-display.ts
+++ b/admin/src/status-display.ts
@@ -1,0 +1,17 @@
+export type ConsoleStatusTone = "error" | "neutral" | "pending" | "success";
+
+export function consoleStatusPresentation(status: string, demoMode: boolean) {
+  const tone = consoleStatusTone(status);
+  return {
+    tone,
+    label: demoMode ? "Demo" : tone === "success" ? "Connected" : tone === "pending" ? "Working" : tone === "error" ? "Needs attention" : "Degraded",
+    showBar: tone !== "success",
+  } as const;
+}
+
+function consoleStatusTone(status: string): ConsoleStatusTone {
+  if (status.includes("error") || status.includes("failed") || status.includes("select") || status.includes("invalid") || status.includes("must") || status.includes("returned") || status.includes("paste")) return "error";
+  if (status === "loading" || ["saving", "running", "revoking", "issuing", "enabling", "disabling", "connecting", "reconciling", "refreshing"].some((prefix) => status.startsWith(prefix))) return "pending";
+  if (status.includes("loaded") || status.includes("saved") || status.includes("connected") || status.includes("ready") || status.includes("issued") || status.includes("revoked") || status.includes("reconciled") || status.includes("refreshed") || status.startsWith("enabled ") || status.startsWith("disabled ")) return "success";
+  return "neutral";
+}

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -1857,23 +1857,43 @@ h2 {
   gap: 7px;
 }
 
-.refreshMeta {
-  display: grid;
-  justify-items: end;
-  gap: 1px;
+.connectionMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--muted);
   font-family: "DM Mono", ui-monospace, monospace;
-  font-size: 8px;
+  font-size: 9px;
   line-height: 1.15;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.refreshMeta time,
-.refreshMeta > span:last-child {
+.connectionMeta strong,
+.connectionMeta time,
+.connectionMeta > span:last-child {
   color: var(--foreground);
   font-size: 9px;
   font-variant-numeric: tabular-nums;
 }
+
+.connectionMeta strong {
+  font-weight: 700;
+}
+
+.connectionDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  box-shadow: 0 0 0 2px #f1f5f9;
+}
+
+.connectionMeta-success .connectionDot { background: var(--success); box-shadow: 0 0 0 2px var(--success-bg); }
+.connectionMeta-pending .connectionDot,
+.connectionMeta-neutral .connectionDot { background: var(--warning); box-shadow: 0 0 0 2px var(--warning-bg); }
+.connectionMeta-error .connectionDot { background: var(--danger); box-shadow: 0 0 0 2px var(--danger-bg); }
+.connectionSeparator { color: var(--border-strong); }
 
 .buttonSecondary,
 .segmented button,

--- a/admin/test/status-display.test.mjs
+++ b/admin/test/status-display.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { consoleStatusPresentation } from "../src/status-display.ts";
+
+test("healthy status is compact while actionable states retain the status bar", () => {
+  assert.deepEqual(consoleStatusPresentation("connected", false), {
+    tone: "success",
+    label: "Connected",
+    showBar: false,
+  });
+  assert.equal(consoleStatusPresentation("saved policy", false).showBar, false);
+  assert.equal(consoleStatusPresentation("issued credential", false).showBar, false);
+  assert.equal(consoleStatusPresentation("enabled openai", false).showBar, false);
+  assert.equal(consoleStatusPresentation("disabled openai", false).showBar, false);
+  assert.equal(consoleStatusPresentation("local demo data loaded", true).label, "Demo");
+
+  assert.deepEqual(consoleStatusPresentation("loading", false), {
+    tone: "pending",
+    label: "Working",
+    showBar: true,
+  });
+  for (const status of ["issuing credential", "reconciling assignments", "refreshing upstream grant"]) {
+    assert.equal(consoleStatusPresentation(status, false).tone, "pending", status);
+  }
+
+  assert.deepEqual(consoleStatusPresentation("entitlements unavailable", false), {
+    tone: "neutral",
+    label: "Degraded",
+    showBar: true,
+  });
+  assert.equal(consoleStatusPresentation("saved user; refresh failed", false).label, "Needs attention");
+});


### PR DESCRIPTION
## Summary

- combine gateway health and refresh time into one compact header status
- remove the full-width status row while the gateway is healthy
- retain the full-width live status row for active work, warnings, and errors
- classify all existing admin completion states so successful actions never appear degraded

## Verification

- `pnpm --dir admin test`
- `pnpm --dir admin build`
- existing-profile Chrome UI check: healthy row absent, compact status present, no horizontal overflow
- autoreview: accepted and fixed successful issuance and provider-toggle status findings; final run clean

## Deployment

Deployed to production from `3e95c04`; Cloudflare workflow `27926521515` and all 16 live-provider smoke checks passed.

## Remaining risk

Low. Presentation-only change; the underlying connection and refresh behavior is unchanged.
