### PR TITLE
feat: rebuild playground as multi-turn chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Rebuild the Playground as a multi-turn chat with a bottom model/service composer and per-turn request/response inspection.
 - Add default-on, policy-controlled 30-day request-content retention with visible user disclosure, per-user exemptions, token ownership, and admin inspection.
 - Collapse healthy gateway status into the header while retaining the full status row for work, warnings, and errors.
 - Automatically refresh dashboard data every 30 seconds and on tab focus without overwriting unsaved admin edits.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -213,7 +213,7 @@ Tables and provider rows are dense, left-aligned, and border-separated. Entity r
 
 ### Playground
 
-Playground is prompt-first. The main surface is a large composer for system and user prompts with compact controls for model, endpoint, tokens, temperature, and run. Response stays visible beside or below the composer. Raw JSON/curl request output is hidden in a disclosure by default and opened only when the user wants to inspect it. The playground is not a toy demo; it uses the same proxy-key policy path as production calls.
+Playground is conversation-first. The main surface is a multi-turn transcript with a bottom composer that owns model/service selection and send state. System instructions and generation controls stay in a compact inspector; selecting a turn reveals its route, latency, retention status, and exact request/response payloads. The playground is not a toy demo; it uses the same policy path and conversation context as production calls.
 
 ## 6. Do's and Don'ts
 

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -173,6 +173,11 @@ export interface PlaygroundForm {
   temperature: string;
 }
 
+export interface PlaygroundMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export interface CatalogModel {
   id: string;
   provider: string;
@@ -433,7 +438,7 @@ export function knownPolicyProviders(selected: string[], available: string[]) {
   return unique(selected.filter((provider) => known.has(provider))).sort();
 }
 
-export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["manifestProxy"][number]) {
+export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["manifestProxy"][number], conversation: PlaygroundMessage[] = []) {
   if (form.mode === "service") {
     const body = form.servicePayload.trim() ? JSON.parse(form.servicePayload) : {};
     return {
@@ -444,10 +449,50 @@ export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["ma
   }
   const maxTokens = optionalNumber(form.maxTokens);
   const temperature = optionalDecimal(form.temperature);
+  const messages = [...conversation, { role: "user" as const, content: form.prompt }];
   if (form.endpoint === "/v1/responses") {
-    return { model: form.model, input: form.prompt, instructions: form.system || undefined, max_output_tokens: maxTokens, temperature };
+    return { model: form.model, input: messages, instructions: form.system || undefined, max_output_tokens: maxTokens, temperature };
   }
-  return { model: form.model, messages: [...(form.system ? [{ role: "system", content: form.system }] : []), { role: "user", content: form.prompt }], max_tokens: maxTokens, temperature };
+  return { model: form.model, messages: [...(form.system ? [{ role: "system", content: form.system }] : []), ...messages], max_tokens: maxTokens, temperature };
+}
+
+export function playgroundResponseText(raw: string) {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (!value || typeof value !== "object") return raw;
+  const record = value as Record<string, unknown>;
+  if (typeof record.output_text === "string") return record.output_text;
+  if (typeof record.output === "string") return record.output;
+
+  const choices = Array.isArray(record.choices) ? record.choices : [];
+  const choice = choices[0] as Record<string, unknown> | undefined;
+  const message = choice?.message as Record<string, unknown> | undefined;
+  if (typeof message?.content === "string") return message.content;
+  if (typeof choice?.text === "string") return choice.text;
+
+  const content = Array.isArray(record.content) ? record.content : [];
+  const contentText = textFromContent(content);
+  if (contentText) return contentText;
+
+  const output = Array.isArray(record.output) ? record.output : [];
+  const outputText = output.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    return textFromContent(Array.isArray((item as Record<string, unknown>).content) ? (item as Record<string, unknown>).content as unknown[] : []) || [];
+  }).join("\n");
+  return outputText || raw;
+}
+
+function textFromContent(content: unknown[]) {
+  return content.flatMap((item) => {
+    if (typeof item === "string") return [item];
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    return typeof record.text === "string" ? [record.text] : [];
+  }).join("\n");
 }
 
 export function playgroundServicePreset(route?: RouteCatalog["manifestProxy"][number]) {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1,10 +1,13 @@
 import React, { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
+  ArrowUp,
   BarChart3,
   Activity,
   ArrowUpRight,
+  Bot,
   Boxes,
+  Bug,
   CheckCircle2,
   ChevronRight,
   CircleSlash2,
@@ -12,12 +15,14 @@ import {
   KeyRound,
   LayoutDashboard,
   LogIn,
+  MessageSquare,
   Play,
   Plus,
   RefreshCw,
   Route,
   Search,
   ServerCog,
+  SlidersHorizontal,
   ShieldCheck,
   Users,
 } from "lucide-react";
@@ -53,6 +58,7 @@ import {
   serviceOutcome,
   tenantSummaryFallback,
   unique,
+  playgroundResponseText,
 } from "./domain";
 import "./style.css";
 
@@ -510,6 +516,31 @@ interface PlaygroundForm {
   temperature: string;
 }
 
+interface PlaygroundTurn {
+  id: string;
+  mode: PlaygroundForm["mode"];
+  prompt: string;
+  response: string;
+  rawResponse: string;
+  request: string;
+  provider: string;
+  model: string;
+  endpoint: string;
+  status: number | null;
+  durationMs: number;
+  retention: string;
+  error?: string;
+}
+
+interface PlaygroundHttpResponse {
+  ok: boolean;
+  raw: string;
+  status: number;
+  statusText: string;
+  contentType: string;
+  retention: string;
+}
+
 const demoDisabledProviderIds = new Set(["aws-bedrock", "cloudflare-ai-gateway"]);
 const demoMissingConfigProviderIds = new Set(["azure-openai"]);
 const demo = demoData();
@@ -622,7 +653,8 @@ function App() {
     maxTokens: "128",
     temperature: "0.7",
   });
-  const [playgroundResult, setPlaygroundResult] = useState("Run a request to see the raw response.");
+  const [playgroundTurns, setPlaygroundTurns] = useState<PlaygroundTurn[]>([]);
+  const [selectedPlaygroundTurnId, setSelectedPlaygroundTurnId] = useState("");
   const [requestMode, setRequestMode] = useState<"json" | "curl">("json");
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
   const refreshBackgroundRef = useRef(false);
@@ -1387,16 +1419,34 @@ function App() {
 
   async function runPlayground(event: FormEvent) {
     event.preventDefault();
+    const startedAt = performance.now();
+    const prompt = playground.mode === "model" ? playground.prompt.trim() : playground.servicePayload.trim();
+    const conversation = playground.mode === "model"
+      ? playgroundTurns.filter((turn) => turn.mode === "model" && !turn.error).flatMap((turn) => [
+        { role: "user" as const, content: turn.prompt },
+        { role: "assistant" as const, content: turn.response },
+      ])
+      : [];
+    const provider = playground.mode === "model" ? selectedModel?.provider ?? "unknown" : selectedServiceRoute?.provider ?? "unknown";
+    const model = playground.mode === "model" ? selectedModel?.id ?? playground.model : selectedServiceRoute?.endpoint ?? playground.serviceRoute;
+    const endpoint = playgroundAccessEndpoint(playground, selectedServiceRoute);
+    let requestPreview = "";
     try {
+      if (!prompt) throw new Error(playground.mode === "model" ? "Enter a message." : "Enter a JSON request body.");
       setPlaygroundError("");
       setStatus("running playground");
       const guard = playgroundBlocker(playground, selectedModel, selectedServiceRoute, accessByProvider, providerReadiness);
       if (guard) throw new Error(guard);
-      const payload = playgroundPayload(playground, selectedServiceRoute);
+      const payload = playgroundPayload(playground, selectedServiceRoute, conversation);
+      requestPreview = JSON.stringify(payload, null, 2);
       if (demoMode) {
-        setPlaygroundResult(JSON.stringify(playground.mode === "model"
+        const raw = JSON.stringify(playground.mode === "model"
           ? { provider: selectedModel?.provider, model: selectedModel?.id, output: "Hello from ClawRouter demo mode." }
-          : { provider: selectedServiceRoute?.provider, route: selectedServiceRoute?.route, output: "Service proxy demo response." }, null, 2));
+          : { provider: selectedServiceRoute?.provider, route: selectedServiceRoute?.route, output: "Service proxy demo response." }, null, 2);
+        const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw, request: requestPreview, provider, model, endpoint, status: 200, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: "demo" });
+        setPlaygroundTurns((current) => [...current, turn]);
+        setSelectedPlaygroundTurnId(turn.id);
+        if (playground.mode === "model") setPlayground((current) => ({ ...current, prompt: "" }));
         setStatus("playground ready");
         return;
       }
@@ -1406,12 +1456,25 @@ function App() {
         headers: { "content-type": "application/json" },
         body: JSON.stringify(payload),
       });
-      setPlaygroundResult(result);
+      const responseError = result.ok ? undefined : playgroundResponseText(result.raw) || `Request failed with HTTP ${result.status}`;
+      const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw: result.raw, request: requestPreview, provider, model, endpoint, status: result.status, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: result.retention, error: responseError });
+      setPlaygroundTurns((current) => [...current, turn]);
+      setSelectedPlaygroundTurnId(turn.id);
+      if (responseError) {
+        setPlaygroundError(responseError);
+        setStatus(responseError);
+        return;
+      }
+      if (playground.mode === "model") setPlayground((current) => ({ ...current, prompt: "" }));
       setStatus("playground ready");
     } catch (error) {
       const message = errorMessage(error);
+      const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw: message, request: requestPreview, provider, model, endpoint, status: null, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: "unknown", error: message });
+      if (prompt) {
+        setPlaygroundTurns((current) => [...current, turn]);
+        setSelectedPlaygroundTurnId(turn.id);
+      }
       setPlaygroundError(message);
-      setPlaygroundResult(message);
       setStatus(message);
     }
   }
@@ -1664,9 +1727,17 @@ function App() {
             readinessByProvider={providerReadiness}
             requestMode={requestMode}
             setRequestMode={setRequestMode}
-            result={playgroundResult}
+            turns={playgroundTurns}
+            selectedTurnId={selectedPlaygroundTurnId}
+            setSelectedTurnId={setSelectedPlaygroundTurnId}
             error={playgroundError}
             onRun={runPlayground}
+            onNewConversation={() => {
+              setPlaygroundTurns([]);
+              setSelectedPlaygroundTurnId("");
+              setPlaygroundError("");
+              setPlayground((current) => ({ ...current, prompt: "" }));
+            }}
             busy={busy}
           />
         ) : null}
@@ -2025,7 +2096,7 @@ function GrantChips({ names }: { names: string[] }) {
   );
 }
 
-function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, selectedServiceRoute, accessByProvider, readinessByProvider, requestMode, setRequestMode, result, error, onRun, busy }: {
+function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, selectedServiceRoute, accessByProvider, readinessByProvider, requestMode, setRequestMode, turns, selectedTurnId, setSelectedTurnId, error, onRun, onNewConversation, busy }: {
   form: PlaygroundForm;
   setForm: (form: PlaygroundForm) => void;
   models: CatalogModel[];
@@ -2036,90 +2107,167 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
   readinessByProvider: Record<string, ProviderReadiness>;
   requestMode: "json" | "curl";
   setRequestMode: (mode: "json" | "curl") => void;
-  result: string;
+  turns: PlaygroundTurn[];
+  selectedTurnId: string;
+  setSelectedTurnId: (id: string) => void;
   error: string;
   onRun: (event: FormEvent) => void;
+  onNewConversation: () => void;
   busy: boolean;
 }) {
-  const request = playgroundRequestPreview(form, requestMode, selectedServiceRoute);
+  const transcript = useRef<HTMLDivElement>(null);
   const blocker = playgroundBlocker(form, selected, selectedServiceRoute, accessByProvider, readinessByProvider);
   const selectedProvider = form.mode === "model" ? selected?.provider : selectedServiceRoute?.provider;
   const selectedAccess = selectedProvider ? accessByProvider.get(selectedProvider) : undefined;
   const selectedReadiness = selectedProvider ? readinessByProvider[selectedProvider] : undefined;
   const methods = selectedServiceRoute?.methods.length ? selectedServiceRoute.methods : ["POST"];
+  const selectedTurn = turns.find((turn) => turn.id === selectedTurnId);
+  const currentRequest = playgroundRequestPreview(form, requestMode, selectedServiceRoute);
+
+  useEffect(() => {
+    const element = transcript.current;
+    element?.scrollTo({ top: element.scrollHeight, behavior: turns.length > 1 ? "smooth" : "auto" });
+  }, [busy, turns.length]);
+
+  function selectTarget(value: string) {
+    if (value.startsWith("model:")) {
+      setForm({ ...form, mode: "model", model: value.slice(6) });
+      return;
+    }
+    const route = serviceRoutes.find((item) => routeKey(item) === value.slice(8));
+    setForm({ ...form, mode: "service", ...playgroundServicePreset(route) });
+  }
+
+  const targetValue = form.mode === "model" ? `model:${form.model}` : `service:${form.serviceRoute}`;
   return (
-    <form className="playgroundLayout" onSubmit={onRun}>
-      <aside className="playgroundSettings">
-        <PanelTitle icon={ServerCog} title="Request setup" meta={form.mode === "model" ? "model invocation" : "service proxy"} />
-        <div className="playgroundToolbar">
-          {form.mode === "model" ? (
-            <>
-              <label><span>Model</span><select value={form.model} onChange={(event) => setForm({ ...form, model: event.target.value })}>{models.map((model) => <option key={`${model.provider}:${model.id}`} value={model.id}>{model.id}</option>)}</select></label>
-              <label><span>Endpoint</span><select value={form.endpoint} onChange={(event) => setForm({ ...form, endpoint: event.target.value as PlaygroundForm["endpoint"] })}><option value="/v1/chat/completions">chat completions</option><option value="/v1/responses">responses</option></select></label>
-              <div className="playgroundSettingPair">
-                <label><span>Max tokens</span><input value={form.maxTokens} onChange={(event) => setForm({ ...form, maxTokens: event.target.value })} /></label>
-                <label><span>Temperature</span><input value={form.temperature} onChange={(event) => setForm({ ...form, temperature: event.target.value })} /></label>
+    <form className="playgroundLayout chatPlayground" onSubmit={onRun}>
+      <section className="chatWorkspace">
+        <header className="chatHeader">
+          <div>
+            <span className="conversationKicker"><MessageSquare aria-hidden="true" /> Live conversation</span>
+            <strong>{form.mode === "model" ? selected?.id ?? "Select a model" : `${selectedServiceRoute?.provider ?? "service"} / ${selectedServiceRoute?.endpoint ?? "route"}`}</strong>
+          </div>
+          <button type="button" className="buttonSecondary" onClick={onNewConversation}><Plus className="buttonIcon" aria-hidden="true" /> New chat</button>
+        </header>
+
+        <div className="chatTranscript" ref={transcript} aria-live="polite">
+          {!turns.length ? (
+            <div className="chatEmpty">
+              <span><Bot aria-hidden="true" /></span>
+              <h2>Test the route as a conversation.</h2>
+              <p>Choose any granted model or service, send a message, then click a response to inspect the exact gateway exchange.</p>
+              <div className="promptSuggestions">
+                {["Explain this service in two sentences.", "Return a concise JSON example.", "What can you help me test?"].map((prompt) => (
+                  <button key={prompt} type="button" onClick={() => setForm({ ...form, mode: "model", prompt })}>{prompt}</button>
+                ))}
               </div>
-            </>
-          ) : (
-            <>
-              <label><span>Service route</span><select value={form.serviceRoute} onChange={(event) => {
-                const route = serviceRoutes.find((item) => routeKey(item) === event.target.value);
-                setForm({ ...form, ...playgroundServicePreset(route) });
-              }}>{serviceRoutes.map((route) => <option key={routeKey(route)} value={routeKey(route)}>{route.provider} / {route.endpoint}</option>)}</select></label>
-              <label><span>Method</span><select value={form.serviceMethod} onChange={(event) => setForm({ ...form, serviceMethod: event.target.value })}>{methods.map((method) => <option key={method} value={method}>{method}</option>)}</select></label>
-              {selectedServiceRoute?.pathParams?.length ? <label><span>{selectedServiceRoute.pathParams.join(" / ")}</span><input value={form.servicePath} onChange={(event) => setForm({ ...form, servicePath: event.target.value })} placeholder="route path value" /></label> : null}
-            </>
-          )}
+            </div>
+          ) : turns.map((turn) => (
+            <article key={turn.id} className={`chatExchange ${selectedTurnId === turn.id ? "selected" : ""}`}>
+              <button type="button" className="chatMessage chatMessageUser" onClick={() => setSelectedTurnId(turn.id)} aria-label="Inspect user message">
+                <span className="messageRole">You</span>
+                <span className="messageBody">{turn.prompt}</span>
+              </button>
+              <button type="button" className={`chatMessage chatMessageAssistant ${turn.error ? "errored" : ""}`} onClick={() => setSelectedTurnId(turn.id)} aria-label="Inspect assistant response">
+                <span className="assistantMark"><Bot aria-hidden="true" /></span>
+                <span className="messageContent">
+                  <span className="messageRole">{turn.error ? "Gateway error" : turn.provider}</span>
+                  <span className="messageBody">{turn.response}</span>
+                  <span className="messageMeta">{turn.status ?? "failed"} · {turn.durationMs} ms · click to inspect</span>
+                </span>
+              </button>
+            </article>
+          ))}
+          {busy ? <div className="chatThinking"><span /><span /><span /><em>Gateway is responding</em></div> : null}
         </div>
-        {blocker ? <InlineNote>{blocker}</InlineNote> : null}
-        <dl className="facts">
-          <dt>provider</dt><dd>{selectedProvider ?? "none"}</dd>
-          <dt>readiness</dt><dd>{readinessLabel(selectedReadiness)}</dd>
-          <dt>access</dt><dd>{selectedAccess ? (selectedAccess.allowed ? selectedAccess.policies.join(", ") || "session" : "not granted") : "unknown"}</dd>
-          <dt>endpoint</dt><dd>{playgroundAccessEndpoint(form, selectedServiceRoute)}</dd>
-        </dl>
-      </aside>
-      <section className="promptPane">
-        <div className="playgroundHeader">
-          <div className="modeTabs" role="tablist" aria-label="playground mode">
-            <button type="button" className={form.mode === "model" ? "active" : ""} onClick={() => setForm({ ...form, mode: "model" })}>Model</button>
-            <button type="button" className={form.mode === "service" ? "active" : ""} onClick={() => setForm({ ...form, mode: "service", ...playgroundServicePreset(selectedServiceRoute) })}>Service</button>
+
+        <div className="composerDock">
+          {error && !turns.length ? <InlineError message={error} /> : null}
+          {blocker ? <InlineNote>{blocker}</InlineNote> : null}
+          <div className="composerShell">
+            <textarea
+              aria-label={form.mode === "model" ? "Message" : "JSON request body"}
+              value={form.mode === "model" ? form.prompt : form.servicePayload}
+              onChange={(event) => setForm(form.mode === "model" ? { ...form, prompt: event.target.value } : { ...form, servicePayload: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  event.currentTarget.form?.requestSubmit();
+                }
+              }}
+              placeholder={form.mode === "model" ? "Message the model…" : "Enter the service JSON body…"}
+              rows={2}
+            />
+            <div className="composerControls">
+              <select aria-label="Model or service" value={targetValue} onChange={(event) => selectTarget(event.target.value)}>
+                <optgroup label="Models">
+                  {models.map((model) => <option key={`${model.provider}:${model.id}`} value={`model:${model.id}`}>{model.id}</option>)}
+                </optgroup>
+                <optgroup label="Services">
+                  {serviceRoutes.map((route) => <option key={routeKey(route)} value={`service:${routeKey(route)}`}>{route.provider} / {route.endpoint}</option>)}
+                </optgroup>
+              </select>
+              <span className="composerStatus"><span className={`connectionDot ${selectedReadiness?.executable ? "ready" : ""}`} />{readinessLabel(selectedReadiness)}</span>
+              <button type="button" className="composerInspect" onClick={() => setSelectedTurnId(selectedTurnId === "setup" ? "" : "setup")}><SlidersHorizontal aria-hidden="true" /><span>Controls</span></button>
+              <button type="submit" className="composerSend" disabled={busy || Boolean(blocker)} title={blocker ?? "Send message"}><ArrowUp aria-hidden="true" /><span className="srOnly">Send</span></button>
+            </div>
           </div>
-          <button type="submit" disabled={busy || Boolean(blocker)} title={blocker ?? undefined}><Play className="buttonIcon" aria-hidden="true" /><span>Run request</span></button>
+          <p className="composerHint">Enter to send · Shift+Enter for a new line · requests use your active access policy</p>
         </div>
-        {error ? <InlineError message={error} /> : null}
-        <div className="runtimeStrip">
-          <ReadinessStatus readiness={selectedReadiness} />
-          <span>{selectedAccess ? (selectedAccess.allowed ? `allowed by ${selectedAccess.policies.join(", ") || "session"}` : "not granted") : "access unknown"}</span>
-          <span>{selectedProvider ?? "no provider"}</span>
-        </div>
-        <div className="playgroundCanvas">
-          {form.mode === "model" ? (
-            <div className="promptComposer">
-              <label><span>System instructions</span><textarea className="systemPrompt" value={form.system} onChange={(event) => setForm({ ...form, system: event.target.value })} /></label>
-              <label><span>User prompt</span><textarea className="mainPrompt" value={form.prompt} onChange={(event) => setForm({ ...form, prompt: event.target.value })} /></label>
-            </div>
-          ) : (
-            <div className="promptComposer">
-              <label><span>JSON body</span><textarea className="mainPrompt servicePayload" value={form.servicePayload} onChange={(event) => setForm({ ...form, servicePayload: event.target.value })} /></label>
-            </div>
-          )}
-          <section className="responsePane">
-            <div className="splitHeader">
-              <PanelTitle icon={ChevronRight} title="Response" meta="raw response" />
-            </div>
-            <pre>{result}</pre>
-          </section>
-        </div>
-        <details className="requestDrawer">
-          <summary><span><ServerCog className="buttonIcon" aria-hidden="true" />Inspect request</span><strong>{requestMode}</strong></summary>
-          <div className="requestDrawerToolbar">
-            <div className="segmented"><button type="button" className={requestMode === "json" ? "active" : ""} onClick={() => setRequestMode("json")}>JSON</button><button type="button" className={requestMode === "curl" ? "active" : ""} onClick={() => setRequestMode("curl")}>curl</button></div>
-          </div>
-          <pre>{request}</pre>
-        </details>
       </section>
+
+      <aside className="playgroundInspector">
+        {selectedTurn ? (
+          <>
+            <div className="inspectorTopline">
+              <PanelTitle icon={Bug} title="Turn inspector" meta={`${selectedTurn.status ?? "failed"} · ${selectedTurn.durationMs} ms`} />
+              <button type="button" className="iconButton" onClick={() => setSelectedTurnId("")} aria-label="Close turn inspector">×</button>
+            </div>
+            <dl className="facts chatFacts">
+              <dt>provider</dt><dd>{selectedTurn.provider}</dd>
+              <dt>model / route</dt><dd>{selectedTurn.model}</dd>
+              <dt>endpoint</dt><dd>{selectedTurn.endpoint}</dd>
+              <dt>retention</dt><dd>{selectedTurn.retention}</dd>
+            </dl>
+            <div className="inspectorTabs segmented">
+              <button type="button" className={requestMode === "json" ? "active" : ""} onClick={() => setRequestMode("json")}>Request</button>
+              <button type="button" className={requestMode === "curl" ? "active" : ""} onClick={() => setRequestMode("curl")}>Response</button>
+            </div>
+            <pre className="debugPayload">{requestMode === "json" ? selectedTurn.request : selectedTurn.rawResponse}</pre>
+          </>
+        ) : (
+          <>
+            <PanelTitle icon={SlidersHorizontal} title="Conversation controls" meta={form.mode === "model" ? "model invocation" : "service proxy"} />
+            <div className="playgroundToolbar">
+              {form.mode === "model" ? (
+                <>
+                  <label><span>Endpoint</span><select value={form.endpoint} onChange={(event) => setForm({ ...form, endpoint: event.target.value as PlaygroundForm["endpoint"] })}><option value="/v1/chat/completions">chat completions</option><option value="/v1/responses">responses</option></select></label>
+                  <label><span>System instructions</span><textarea className="systemPrompt" value={form.system} onChange={(event) => setForm({ ...form, system: event.target.value })} /></label>
+                  <div className="playgroundSettingPair">
+                    <label><span>Max tokens</span><input inputMode="numeric" value={form.maxTokens} onChange={(event) => setForm({ ...form, maxTokens: event.target.value })} /></label>
+                    <label><span>Temperature</span><input inputMode="decimal" value={form.temperature} onChange={(event) => setForm({ ...form, temperature: event.target.value })} /></label>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <label><span>Method</span><select value={form.serviceMethod} onChange={(event) => setForm({ ...form, serviceMethod: event.target.value })}>{methods.map((method) => <option key={method} value={method}>{method}</option>)}</select></label>
+                  {selectedServiceRoute?.pathParams?.length ? <label><span>{selectedServiceRoute.pathParams.join(" / ")}</span><input value={form.servicePath} onChange={(event) => setForm({ ...form, servicePath: event.target.value })} placeholder="route path value" /></label> : null}
+                </>
+              )}
+            </div>
+            <dl className="facts chatFacts">
+              <dt>provider</dt><dd>{selectedProvider ?? "none"}</dd>
+              <dt>readiness</dt><dd>{readinessLabel(selectedReadiness)}</dd>
+              <dt>access</dt><dd>{selectedAccess ? (selectedAccess.allowed ? selectedAccess.policies.join(", ") || "session" : "not granted") : "unknown"}</dd>
+              <dt>endpoint</dt><dd>{playgroundAccessEndpoint(form, selectedServiceRoute)}</dd>
+            </dl>
+            <details className="requestDrawer">
+              <summary><span><ServerCog className="buttonIcon" aria-hidden="true" /> Preview request</span></summary>
+              <pre>{currentRequest}</pre>
+            </details>
+          </>
+        )}
+      </aside>
     </form>
   );
 }
@@ -2815,23 +2963,45 @@ async function request<T>(baseUrl: string, path: string, init: RequestInit = {})
   return response.json() as Promise<T>;
 }
 
-async function playgroundRequest(baseUrl: string, path: string, init: RequestInit = {}): Promise<string> {
+async function playgroundRequest(baseUrl: string, path: string, init: RequestInit = {}): Promise<PlaygroundHttpResponse> {
   const headers = new Headers(init.headers);
   const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers });
   const contentType = response.headers.get("content-type") ?? "";
+  const retention = response.headers.get("x-clawrouter-content-retention") ?? "unknown";
   const body = await response.arrayBuffer();
   const text = isTextualResponse(contentType) ? new TextDecoder().decode(body) : "";
-  if (!response.ok) throw new Error(text.trim() || `${path} failed with ${response.status}`);
-  if (response.status === 204 || body.byteLength === 0) return `HTTP ${response.status} ${response.statusText || "No Content"}`.trim();
+  let raw = "";
+  if (response.status === 204 || body.byteLength === 0) raw = `HTTP ${response.status} ${response.statusText || "No Content"}`.trim();
   if (contentType.includes("application/json") || contentType.includes("+json")) {
     try {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      raw = JSON.stringify(JSON.parse(text), null, 2);
     } catch {
-      return text;
+      raw = text;
     }
+  } else if (text) {
+    raw = text;
+  } else if (!raw) {
+    raw = `HTTP ${response.status} ${response.statusText || "OK"}\n${contentType || "binary"} response (${body.byteLength} bytes)`;
   }
-  if (text) return text;
-  return `HTTP ${response.status} ${response.statusText || "OK"}\n${contentType || "binary"} response (${body.byteLength} bytes)`;
+  return { ok: response.ok, raw, status: response.status, statusText: response.statusText, contentType, retention };
+}
+
+function createPlaygroundTurn(input: Omit<PlaygroundTurn, "id" | "response" | "rawResponse"> & { raw: string }): PlaygroundTurn {
+  return {
+    id: crypto.randomUUID(),
+    mode: input.mode,
+    prompt: input.prompt,
+    response: input.error ?? playgroundResponseText(input.raw),
+    rawResponse: input.raw,
+    request: input.request,
+    provider: input.provider,
+    model: input.model,
+    endpoint: input.endpoint,
+    status: input.status,
+    durationMs: input.durationMs,
+    retention: input.retention,
+    error: input.error,
+  };
 }
 
 function isTextualResponse(contentType: string) {

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -3678,3 +3678,448 @@ select:disabled {
   .dashboardService { border-right: 0; }
   .activityBar { grid-template-columns: minmax(110px, 1fr) 1fr 34px; }
 }
+
+/* Chat-first playground */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+.chatPlayground {
+  grid-template-columns: minmax(0, 1fr) 340px;
+  height: calc(100vh - var(--header-height) - 24px);
+  min-height: 620px;
+  overflow: hidden;
+}
+
+.chatWorkspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  background:
+    linear-gradient(#f8faf6e8, #f8faf6e8),
+    linear-gradient(90deg, transparent 39px, #e7ebe4 40px),
+    linear-gradient(transparent 39px, #e7ebe4 40px);
+  background-size: auto, 40px 40px, 40px 40px;
+}
+
+.chatHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 62px;
+  border-bottom: 1px solid var(--border);
+  background: rgb(251 252 248 / 0.96);
+  padding: 10px 18px;
+}
+
+.chatHeader > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.chatHeader strong {
+  overflow: hidden;
+  color: var(--foreground-strong);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversationKicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--success);
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.conversationKicker svg { width: 12px; height: 12px; }
+
+.chatTranscript {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 28px max(22px, calc((100% - 780px) / 2)) 36px;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.chatEmpty {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  max-width: 620px;
+  margin: clamp(40px, 11vh, 110px) auto 0;
+  text-align: center;
+}
+
+.chatEmpty > span {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid #b8c8be;
+  background: #edf5ef;
+  color: var(--success);
+}
+
+.chatEmpty > span svg { width: 22px; height: 22px; }
+.chatEmpty h2 { font-size: 20px; font-weight: 650; }
+.chatEmpty p { max-width: 58ch; font-size: 12px; }
+
+.promptSuggestions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  width: 100%;
+  margin-top: 12px;
+}
+
+.promptSuggestions button {
+  align-items: flex-start;
+  min-height: 66px;
+  border-color: var(--border);
+  border-radius: 6px;
+  background: rgb(251 252 248 / 0.88);
+  color: var(--foreground);
+  padding: 10px;
+  text-align: left;
+}
+
+.promptSuggestions button:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: white;
+  color: var(--foreground-strong);
+}
+
+.chatExchange {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.chatMessage {
+  width: fit-content;
+  max-width: min(88%, 720px);
+  min-height: 0;
+  border: 0;
+  background: transparent;
+  color: var(--foreground-strong);
+  padding: 0;
+  text-align: left;
+  white-space: normal;
+}
+
+.chatMessage:hover:not(:disabled) { border-color: transparent; background: transparent; }
+
+.chatMessageUser {
+  display: grid;
+  justify-self: end;
+  gap: 4px;
+  border: 1px solid #cdd6cf;
+  border-radius: 14px 14px 3px 14px;
+  background: #edf1ec;
+  padding: 10px 13px;
+}
+
+.chatMessageUser:hover:not(:disabled) { border-color: #aebbb2; background: #e8eee9; }
+
+.chatMessageAssistant {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+}
+
+.chatMessageAssistant:hover:not(:disabled) .messageBody { color: var(--success); }
+.chatMessageAssistant.errored .messageBody { color: var(--danger); }
+
+.assistantMark {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid #b8c8be;
+  background: #edf5ef;
+  color: var(--success);
+}
+
+.assistantMark svg { width: 15px; height: 15px; }
+
+.messageContent {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.messageRole {
+  color: var(--muted);
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.messageBody {
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  font-weight: 450;
+  line-height: 1.62;
+  white-space: pre-wrap;
+}
+
+.messageMeta {
+  color: var(--light-slate);
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.chatExchange.selected .chatMessageAssistant { box-shadow: -2px 0 0 var(--success); padding-left: 10px; }
+
+.chatThinking {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 38px;
+  color: var(--muted);
+}
+
+.chatThinking span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--success);
+  animation: chatPulse 1s ease-in-out infinite;
+}
+
+.chatThinking span:nth-child(2) { animation-delay: 120ms; }
+.chatThinking span:nth-child(3) { animation-delay: 240ms; }
+.chatThinking em { margin-left: 5px; font-size: 10px; font-style: normal; }
+
+@keyframes chatPulse {
+  0%, 70%, 100% { opacity: 0.3; transform: translateY(0); }
+  35% { opacity: 1; transform: translateY(-2px); }
+}
+
+.composerDock {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: 7px;
+  border-top: 1px solid var(--border);
+  background: linear-gradient(180deg, rgb(248 250 246 / 0.86), #f8faf6 22%);
+  padding: 14px max(22px, calc((100% - 780px) / 2)) 12px;
+}
+
+.composerDock > .inlineNote,
+.composerDock > .inlineError { border-radius: 6px; }
+
+.composerShell {
+  overflow: hidden;
+  border: 1px solid #aeb9b1;
+  border-radius: 16px;
+  background: white;
+  box-shadow: 0 7px 20px rgb(24 32 30 / 0.08);
+}
+
+.composerShell:focus-within { border-color: var(--success); box-shadow: 0 0 0 2px rgb(15 112 80 / 0.09), 0 7px 20px rgb(24 32 30 / 0.08); }
+
+.composerShell textarea {
+  min-height: 62px;
+  max-height: 180px;
+  resize: none;
+  border: 0;
+  border-radius: 0;
+  background: white;
+  padding: 13px 15px 6px;
+  font-size: 13px;
+  line-height: 1.45;
+  box-shadow: none;
+}
+
+.composerShell textarea:hover,
+.composerShell textarea:focus-visible { border: 0; outline: 0; box-shadow: none; }
+
+.composerControls {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 6px 8px 8px;
+}
+
+.composerControls select {
+  width: auto;
+  max-width: min(48%, 300px);
+  min-height: 28px;
+  border: 0;
+  border-radius: 8px;
+  background: #f1f3ef;
+  padding: 4px 26px 4px 9px;
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.composerStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  font-family: "DM Mono", ui-monospace, monospace;
+  font-size: 9px;
+}
+
+.composerStatus .connectionDot.ready { background: var(--success); box-shadow: 0 0 0 2px var(--success-bg); }
+
+.composerInspect {
+  min-height: 27px;
+  margin-left: auto;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  padding: 4px 7px;
+  font-size: 10px;
+}
+
+.composerInspect svg { width: 13px; height: 13px; }
+.composerInspect:hover:not(:disabled) { border: 0; background: #f1f3ef; color: var(--foreground-strong); }
+
+.composerSend {
+  width: 30px;
+  height: 30px;
+  min-height: 30px;
+  border-radius: 50%;
+  padding: 0;
+}
+
+.composerSend svg { width: 15px; height: 15px; }
+.composerHint { padding-left: 4px; font-size: 9px; }
+
+.playgroundInspector {
+  display: grid;
+  align-content: start;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  border-left: 1px solid var(--border);
+  background: var(--background);
+}
+
+.playgroundInspector > .panelTitle,
+.inspectorTopline {
+  min-height: 62px;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 13px;
+}
+
+.inspectorTopline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.iconButton {
+  width: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  border-color: var(--border);
+  background: white;
+  color: var(--muted);
+  padding: 0;
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.iconButton:hover:not(:disabled) { border-color: var(--border-strong); background: #f1f3ef; color: var(--foreground-strong); }
+
+.playgroundInspector .playgroundToolbar {
+  grid-template-columns: 1fr;
+  gap: 12px;
+  padding: 13px;
+}
+
+.playgroundInspector .systemPrompt { min-height: 118px; }
+.playgroundInspector .chatFacts { margin: 13px; }
+.playgroundInspector .requestDrawer { border-top: 1px solid var(--border); }
+.playgroundInspector .requestDrawer pre { max-height: 360px; border-top: 1px solid var(--border); }
+
+.inspectorTabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  margin: 0 13px 10px;
+  background: #f1f3ef;
+  padding: 2px;
+}
+
+.inspectorTabs button {
+  min-height: 27px;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  color: var(--muted);
+}
+
+.inspectorTabs button.active { background: white; color: var(--foreground-strong); }
+
+.debugPayload {
+  max-height: none;
+  margin: 0 13px 13px;
+  border: 1px solid #2d3834;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 1080px) {
+  .chatPlayground {
+    grid-template-columns: minmax(0, 1fr) 290px;
+  }
+
+  .chatTranscript,
+  .composerDock { padding-inline: 18px; }
+
+  .promptSuggestions { grid-template-columns: 1fr; max-width: 420px; }
+}
+
+@media (max-width: 820px) {
+  .chatPlayground {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .chatWorkspace { min-height: 680px; }
+  .chatTranscript { max-height: 560px; }
+  .playgroundInspector { border-top: 1px solid var(--border); border-left: 0; }
+}
+
+@media (max-width: 560px) {
+  .chatHeader { padding-inline: 12px; }
+  .chatTranscript { padding: 22px 12px 28px; }
+  .composerDock { padding: 10px 10px 12px; }
+  .composerStatus { display: none; }
+  .composerControls select { max-width: 56%; }
+  .composerInspect span { display: none; }
+  .chatMessage { max-width: 94%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chatThinking span { animation: none; }
+}

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -10,6 +10,7 @@ import {
   playgroundAccessEndpoint,
   playgroundBlocker,
   playgroundPayload,
+  playgroundResponseText,
   playgroundServicePreset,
   policyUsageFallback,
   reconcileDirectUserBindings,
@@ -142,6 +143,26 @@ test("playground payloads preserve model and service semantics", () => {
     body: { detail: true },
   });
   assert.equal(playgroundAccessEndpoint(form, route), "/v1/playground/proxy/replicate/prediction");
+});
+
+test("playground model requests include the current conversation", () => {
+  assert.deepEqual(playgroundPayload(modelForm(), undefined, [
+    { role: "user", content: "first" },
+    { role: "assistant", content: "answer" },
+  ]).messages, [
+    { role: "system", content: "be concise" },
+    { role: "user", content: "first" },
+    { role: "assistant", content: "answer" },
+    { role: "user", content: "hello" },
+  ]);
+});
+
+test("playground responses show assistant text while preserving arbitrary responses", () => {
+  assert.equal(playgroundResponseText('{"choices":[{"message":{"content":"hello"}}]}'), "hello");
+  assert.equal(playgroundResponseText('{"content":[{"type":"text","text":"hi from anthropic"}]}'), "hi from anthropic");
+  assert.equal(playgroundResponseText('{"output":[{"content":[{"type":"output_text","text":"response text"}]}]}'), "response text");
+  assert.equal(playgroundResponseText('{"query":"result"}'), '{"query":"result"}');
+  assert.equal(playgroundResponseText("plain text"), "plain text");
 });
 
 test("service route presets replace stale body, method, and path values", () => {


### PR DESCRIPTION
## Summary

- rebuild Playground around a multi-turn conversation transcript and bottom composer
- unify model and service selection while retaining route-specific payloads
- add per-turn request/response inspection with status, latency, endpoint, and retention metadata
- keep system instructions and generation controls in a dedicated inspector

## Verification

- `pnpm --dir admin check`
- `pnpm --dir admin test`
- `pnpm --dir admin build`
- `cargo test --workspace`
- `pnpm test:scripts`
- structured autoreview: clean, no accepted/actionable findings
- existing-Chrome E2E: initial send, Enter-to-send, multi-turn context, model/service switching, inspector tabs, responsive layout

## Deployment

- pending merge and production workflow

## Remaining risk

- live provider behavior will be verified after production deployment
