### PR TITLE
fix: make content provisioning idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make repeated content-retention provisioning tolerate an existing lifecycle rule.
 - Rebuild the Playground as a multi-turn chat with a bottom model/service composer and per-turn request/response inspection.
 - Add default-on, policy-controlled 30-day request-content retention with visible user disclosure, per-user exemptions, token ownership, and admin inspection.
 - Collapse healthy gateway status into the header while retaining the full status row for work, warnings, and errors.

--- a/scripts/provision-content-storage.mjs
+++ b/scripts/provision-content-storage.mjs
@@ -1,21 +1,25 @@
 import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const bucket = process.env.CLAWROUTER_CONTENT_BUCKET ?? "clawrouter-content";
 
-runAllowExists(["r2", "bucket", "create", bucket]);
-runAllowExists([
-  "r2",
-  "bucket",
-  "lifecycle",
-  "add",
-  bucket,
-  "request-content-v1-30-days",
-  "v1/",
-  "--expire-days",
-  "30",
-  "-y",
-]);
-console.log(`CONTENT_ARCHIVE=${bucket} retention=30d`);
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  runAllowExists(["r2", "bucket", "create", bucket]);
+  runAllowExists([
+    "r2",
+    "bucket",
+    "lifecycle",
+    "add",
+    bucket,
+    "request-content-v1-30-days",
+    "v1/",
+    "--expire-days",
+    "30",
+    "-y",
+  ]);
+  console.log(`CONTENT_ARCHIVE=${bucket} retention=30d`);
+}
 
 function runAllowExists(args) {
   const result = spawnSync("pnpm", ["exec", "wrangler", ...args], {
@@ -26,9 +30,13 @@ function runAllowExists(args) {
     process.stdout.write(output);
     return;
   }
-  if (/already exists|already has|duplicate/i.test(output)) {
+  if (isAlreadyConfigured(output)) {
     console.log(`${args.join(" ")} already configured`);
     return;
   }
   throw new Error(output || `wrangler ${args.join(" ")} failed`);
+}
+
+export function isAlreadyConfigured(output) {
+  return /already exists|already has|duplicate|rule ids must be unique/i.test(output);
 }

--- a/test/provision-content-storage.test.mjs
+++ b/test/provision-content-storage.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isAlreadyConfigured } from "../scripts/provision-content-storage.mjs";
+
+test("content provisioning treats an existing lifecycle rule as configured", () => {
+  assert.equal(isAlreadyConfigured("Invalid Lifecycle Configuration: Rule IDs must be unique. [code: 10061]"), true);
+  assert.equal(isAlreadyConfigured("bucket already exists"), true);
+  assert.equal(isAlreadyConfigured("Authentication error [code: 10000]"), false);
+});


### PR DESCRIPTION
## Summary

- make R2 lifecycle provisioning tolerate the existing rule returned by Cloudflare
- avoid provisioning side effects when importing the helper for tests
- add regression coverage for duplicate lifecycle IDs while preserving auth failures

## Verification

- `node --test test/provision-content-storage.test.mjs`
- `pnpm test:scripts`
- structured autoreview: clean, no accepted/actionable findings
- production evidence: first authorized run created the bucket and lifecycle; repeat run reproduced Cloudflare code 10061

## Deployment

- pending merge, then rerun exact `main` deployment

## Remaining risk

- none known
