### PR TITLE
feat: add proxied user Gravatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Show proxied Gravatar thumbnails for signed-in users without exposing email hashes or user network metadata to the browser.
 - Make repeated content-retention provisioning tolerate an existing lifecycle rule.
 - Resolve configured model aliases in OpenAI-compatible Playground requests instead of forwarding manifest placeholders.
 - Rebuild the Playground as a multi-turn chat with a bottom model/service composer and per-turn request/response inspection.

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1628,7 +1628,7 @@ function App() {
           ) : null}
         </nav>
         <div className="tenantSwitch">
-          <span className="contextIcon"><ShieldCheck aria-hidden="true" /></span>
+          <UserAvatar email={session.email} />
           <div>
             <span>Active context</span>
             <strong>{session.email ?? "not signed in"}</strong>
@@ -1831,6 +1831,21 @@ function App() {
         {view === "usage" && session.role === "admin" ? <UsageScreen keys={keys} credentials={credentials} services={services} overview={adminOverview} tenants={tenantSummaries} usageRows={usageRows} usage={usageSnapshot} usageLoaded={usageLoaded} /> : null}
       </section>
     </main>
+  );
+}
+
+function UserAvatar({ email }: { email?: string | null }) {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(false);
+  }, [email]);
+
+  return (
+    <span className={`contextIcon${loaded ? " contextIconLoaded" : ""}`}>
+      <ShieldCheck aria-hidden="true" />
+      {email ? <img src="/v1/session/avatar" alt="" loading="lazy" decoding="async" onLoad={() => setLoaded(true)} onError={() => setLoaded(false)} /> : null}
+    </span>
   );
 }
 

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -1781,7 +1781,9 @@ h2 {
 }
 
 .contextIcon {
+  position: relative;
   display: grid !important;
+  overflow: hidden;
   width: 30px;
   height: 30px;
   place-items: center;
@@ -1793,6 +1795,21 @@ h2 {
 .contextIcon svg {
   width: 14px;
   height: 14px;
+}
+
+.contextIcon img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 140ms ease-out;
+}
+
+.contextIconLoaded img {
+  opacity: 1;
 }
 
 .tenantSwitch strong {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -144,6 +144,12 @@ async fn fetch(req: Request, env: Env, ctx: Context) -> Result<Response> {
             .and_then(with_cors);
     }
 
+    if req.method() == Method::Get && api_path == "/v1/session/avatar" {
+        return session_avatar(req.headers(), &env)
+            .await
+            .and_then(with_cors);
+    }
+
     if req.method() == Method::Get && api_path == "/v1/entitlements" {
         return access_entitlements(req.headers(), &env)
             .await
@@ -2889,6 +2895,63 @@ async fn session_profile(headers: &Headers, env: &Env) -> Result<Response> {
         "subject": null,
         "tenantId": null
     }))
+}
+
+async fn session_avatar(headers: &Headers, env: &Env) -> Result<Response> {
+    let Some(session) = verified_access_session(headers, env).await? else {
+        return json_error(
+            "access_session_required",
+            "avatar access requires a verified Cloudflare Access session",
+            401,
+        );
+    };
+    let request = Request::new(&gravatar_avatar_url(&session.email), Method::Get)?;
+    let mut upstream = match Fetch::Request(request).send().await {
+        Ok(response) => response,
+        Err(_) => return private_avatar_error(502),
+    };
+    if upstream.status_code() != 200 {
+        return private_avatar_error(404);
+    }
+    let content_type = upstream
+        .headers()
+        .get("content-type")?
+        .and_then(|value| value.split(';').next().map(str::trim).map(str::to_string));
+    let Some(content_type) = content_type.filter(|value| {
+        matches!(
+            value.as_str(),
+            "image/gif" | "image/jpeg" | "image/png" | "image/webp"
+        )
+    }) else {
+        return private_avatar_error(502);
+    };
+    let bytes = upstream.bytes().await?;
+    if bytes.len() > 1024 * 1024 {
+        return private_avatar_error(502);
+    }
+    let mut response = Response::from_bytes(bytes)?;
+    response.headers_mut().set("content-type", &content_type)?;
+    response
+        .headers_mut()
+        .set("cache-control", "private, no-store, max-age=0")?;
+    response.headers_mut().set(
+        "vary",
+        "cf-access-jwt-assertion, cf-access-authenticated-user-email",
+    )?;
+    Ok(response)
+}
+
+fn gravatar_avatar_url(email: &str) -> String {
+    let hash = sha256_hex(&email.trim().to_ascii_lowercase());
+    format!("https://www.gravatar.com/avatar/{hash}?s=60&d=identicon&r=g")
+}
+
+fn private_avatar_error(status: u16) -> Result<Response> {
+    let mut response = Response::empty()?.with_status(status);
+    response
+        .headers_mut()
+        .set("cache-control", "private, no-store, max-age=0")?;
+    Ok(response)
 }
 
 async fn access_entitlements(headers: &Headers, env: &Env) -> Result<Response> {
@@ -16255,6 +16318,20 @@ mod tests {
             "policy_generation_mismatch"
         );
         assert_eq!(policy.request_cost_micros, Some(10));
+    }
+
+    #[test]
+    fn gravatar_avatar_urls_hash_normalized_emails() {
+        let url = gravatar_avatar_url("  Person@Example.COM ");
+        assert_eq!(
+            url,
+            format!(
+                "https://www.gravatar.com/avatar/{}?s=60&d=identicon&r=g",
+                sha256_hex("person@example.com")
+            )
+        );
+        assert!(!url.contains("Person"));
+        assert!(!url.contains("example.com"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- show signed-in user thumbnails in the sidebar identity context
- proxy Gravatar through an authenticated same-origin Worker endpoint
- keep email hashes and user network metadata out of browser-facing requests
- preserve the existing shield while images load or fail

## Verification

- `cargo test -p clawrouter-edge` (123 passed)
- `pnpm --dir admin check`
- `pnpm --dir admin test` (17 passed)
- `pnpm --dir admin build`
- rendered Chrome QA at desktop width
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests 'cargo test -p clawrouter-edge'` (clean)

## Deployment

- deployed to production by workflow run 27932553541 (attempt 2)
- full 16-provider live smoke passed
- authenticated Chrome verification: avatar endpoint 200, 60x60 image loaded, rendered in active context

## Risk

- Gravatar receives the normalized email hash from the Worker; the browser receives only a same-origin raster image
- avatar responses are authenticated, MIME-limited, size-limited, and not cached
