### PR TITLE
feat: refresh model catalog and playground picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add current flagship model catalogs, including GPT-5.5, Claude Opus 4.8, Gemini 3.5 Flash, and GLM-5.2, with a provider-first Playground picker.
 - Show proxied Gravatar thumbnails for signed-in users without exposing email hashes or user network metadata to the browser.
 - Make repeated content-retention provisioning tolerate an existing lifecycle rule.
 - Resolve configured model aliases in OpenAI-compatible Playground requests instead of forwarding manifest placeholders.

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -13,6 +13,7 @@ export interface RouteCatalog {
     pathParams?: string[];
     requestFormat?: string;
     sampleModel?: string | null;
+    models?: Array<{ id: string; capabilities: string[] }>;
     streaming?: boolean | null;
   }>;
 }
@@ -495,8 +496,8 @@ function textFromContent(content: unknown[]) {
   }).join("\n");
 }
 
-export function playgroundServicePreset(route?: RouteCatalog["manifestProxy"][number]) {
-  const model = route?.sampleModel ?? `${route?.provider ?? "provider"}/default`;
+export function playgroundServicePreset(route?: RouteCatalog["manifestProxy"][number], selectedModel?: string) {
+  const model = selectedModel ?? route?.sampleModel ?? `${route?.provider ?? "provider"}/default`;
   const format = route?.requestFormat ?? `${route?.provider ?? ""}.${route?.endpoint ?? ""}`;
   let body: unknown = {};
 

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -140,6 +140,7 @@ interface RouteCatalog {
     pathParams?: string[];
     requestFormat?: string;
     sampleModel?: string | null;
+    models?: Array<{ id: string; capabilities: string[] }>;
     streaming?: boolean | null;
   }>;
 }
@@ -2144,16 +2145,45 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
     element?.scrollTo({ top: element.scrollHeight, behavior: turns.length > 1 ? "smooth" : "auto" });
   }, [busy, turns.length]);
 
+  const providerIds = Array.from(new Set([
+    ...models.map((model) => model.provider),
+    ...serviceRoutes.map((route) => route.provider),
+  ])).sort((left, right) => providerName(left, readinessByProvider).localeCompare(providerName(right, readinessByProvider)));
+  const activeProvider = selectedProvider ?? providerIds[0] ?? "";
+  const providerModels = models.filter((model) => model.provider === activeProvider);
+  const providerRoutes = serviceRoutes.filter((route) => route.provider === activeProvider);
+  const serviceModelTargets = providerModels.length ? [] : serviceModelOptions(providerRoutes);
+  const routeTargets = providerModels.length || serviceModelTargets.length ? [] : providerRoutes;
+  const selectedServiceModel = serviceModelFromForm(form, selectedServiceRoute);
+  const targetValue = form.mode === "model"
+    ? `model:${form.model}`
+    : serviceModelTargets.find((target) => routeKey(target.route) === form.serviceRoute && target.model === selectedServiceModel)?.value
+      ?? `service:${form.serviceRoute}`;
+
+  function selectProvider(provider: string) {
+    const model = models.find((item) => item.provider === provider);
+    if (model) {
+      setForm({ ...form, mode: "model", model: model.id });
+      return;
+    }
+    const routes = serviceRoutes.filter((item) => item.provider === provider);
+    const target = serviceModelOptions(routes)[0];
+    setForm({ ...form, mode: "service", ...playgroundServicePreset(target?.route ?? routes[0], target?.model) });
+  }
+
   function selectTarget(value: string) {
     if (value.startsWith("model:")) {
       setForm({ ...form, mode: "model", model: value.slice(6) });
       return;
     }
+    const modelTarget = serviceModelTargets.find((target) => target.value === value);
+    if (modelTarget) {
+      setForm({ ...form, mode: "service", ...playgroundServicePreset(modelTarget.route, modelTarget.model) });
+      return;
+    }
     const route = serviceRoutes.find((item) => routeKey(item) === value.slice(8));
     setForm({ ...form, mode: "service", ...playgroundServicePreset(route) });
   }
-
-  const targetValue = form.mode === "model" ? `model:${form.model}` : `service:${form.serviceRoute}`;
   return (
     <form className="playgroundLayout chatPlayground" onSubmit={onRun}>
       <section className="chatWorkspace">
@@ -2214,13 +2244,13 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
               rows={2}
             />
             <div className="composerControls">
-              <select aria-label="Model or service" value={targetValue} onChange={(event) => selectTarget(event.target.value)}>
-                <optgroup label="Models">
-                  {models.map((model) => <option key={`${model.provider}:${model.id}`} value={`model:${model.id}`}>{model.id}</option>)}
-                </optgroup>
-                <optgroup label="Services">
-                  {serviceRoutes.map((route) => <option key={routeKey(route)} value={`service:${routeKey(route)}`}>{route.provider} / {route.endpoint}</option>)}
-                </optgroup>
+              <select className="providerPicker" aria-label="Provider" value={activeProvider} onChange={(event) => selectProvider(event.target.value)}>
+                {providerIds.map((provider) => <option key={provider} value={provider}>{providerName(provider, readinessByProvider)}</option>)}
+              </select>
+              <select className="modelPicker" aria-label="Model or route" value={targetValue} onChange={(event) => selectTarget(event.target.value)}>
+                {providerModels.map((model) => <option key={model.id} value={`model:${model.id}`}>{shortModelName(model.id, activeProvider)}</option>)}
+                {serviceModelTargets.map((target) => <option key={target.value} value={target.value}>{shortModelName(target.model, activeProvider)}</option>)}
+                {routeTargets.map((route) => <option key={routeKey(route)} value={`service:${routeKey(route)}`}>{route.endpoint.replaceAll("_", " ")}</option>)}
               </select>
               <span className="composerStatus"><span className={`connectionDot ${selectedReadiness?.executable ? "ready" : ""}`} />{readinessLabel(selectedReadiness)}</span>
               <button type="button" className="composerInspect" onClick={() => setSelectedTurnId(selectedTurnId === "setup" ? "" : "setup")}><SlidersHorizontal aria-hidden="true" /><span>Controls</span></button>
@@ -3210,7 +3240,47 @@ function effectiveProviderCount(providerIds: string[], services: ServiceItem[], 
 }
 
 function catalogModels(routes: RouteCatalog): CatalogModel[] {
-  return routes.openaiCompatible.flatMap((route) => route.models.map((model) => ({ id: model.id, provider: route.provider, capabilities: model.capabilities })));
+  return routes.openaiCompatible.flatMap((route) => route.models
+    .filter((model) => model.capabilities.some((capability) => capability === "llm.chat" || capability === "llm.responses"))
+    .map((model) => ({ id: model.id, provider: route.provider, capabilities: model.capabilities })));
+}
+
+function providerName(provider: string, readinessByProvider: Record<string, ProviderReadiness>) {
+  return readinessByProvider[provider]?.displayName ?? provider.split("-").map((part) => part[0]?.toUpperCase() + part.slice(1)).join(" ");
+}
+
+function shortModelName(model: string, provider: string) {
+  const prefix = `${provider}/`;
+  return model.startsWith(prefix) ? model.slice(prefix.length) : model;
+}
+
+function serviceModelOptions(routes: RouteCatalog["manifestProxy"]) {
+  const seen = new Set<string>();
+  return [...routes].sort((left, right) => serviceRouteRank(left) - serviceRouteRank(right)).flatMap((route) => (route.models ?? []).flatMap((model) => {
+    if (seen.has(model.id)) return [];
+    seen.add(model.id);
+    return [{
+      model: model.id,
+      route,
+      value: `service-model:${routeKey(route)}:${model.id}`,
+    }];
+  }));
+}
+
+function serviceRouteRank(route: RouteCatalog["manifestProxy"][number]) {
+  if (["messages", "chat", "chat_completions", "generate_content", "responses"].includes(route.endpoint)) return 0;
+  if (route.streaming) return 2;
+  return 1;
+}
+
+function serviceModelFromForm(form: PlaygroundForm, route?: RouteCatalog["manifestProxy"][number]) {
+  if (route?.pathParams?.includes("model")) return form.servicePath;
+  try {
+    const body = JSON.parse(form.servicePayload) as { model?: unknown };
+    return typeof body.model === "string" ? body.model : "";
+  } catch {
+    return "";
+  }
 }
 
 function groupedProviders(providers: ProviderRow[], query: string) {

--- a/admin/src/style.css
+++ b/admin/src/style.css
@@ -3981,7 +3981,6 @@ select:disabled {
 
 .composerControls select {
   width: auto;
-  max-width: min(48%, 300px);
   min-height: 28px;
   border: 0;
   border-radius: 8px;
@@ -3989,6 +3988,17 @@ select:disabled {
   padding: 4px 26px 4px 9px;
   font-size: 10px;
   font-weight: 650;
+}
+
+.composerControls .providerPicker {
+  flex: 0 1 150px;
+  max-width: 34%;
+  background: #e4e9e2;
+}
+
+.composerControls .modelPicker {
+  flex: 1 1 210px;
+  max-width: 330px;
 }
 
 .composerStatus {
@@ -4132,7 +4142,8 @@ select:disabled {
   .chatTranscript { padding: 22px 12px 28px; }
   .composerDock { padding: 10px 10px 12px; }
   .composerStatus { display: none; }
-  .composerControls select { max-width: 56%; }
+  .composerControls .providerPicker { max-width: 38%; }
+  .composerControls .modelPicker { max-width: 46%; }
   .composerInspect span { display: none; }
   .chatMessage { max-width: 94%; }
 }

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -199,6 +199,9 @@ test("service route presets replace stale body, method, and path values", () => 
   assert.deepEqual(JSON.parse(preset.servicePayload), {
     contents: [{ parts: [{ text: "Reply with ok." }] }],
   });
+
+  const latestPreset = playgroundServicePreset(google, "google/gemini-3.5-flash");
+  assert.equal(latestPreset.servicePath, "google/gemini-3.5-flash");
 });
 
 test("service route presets cover every bundled request format family", () => {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -505,6 +505,22 @@ fn route_catalog(snapshot: &ProviderSnapshot) -> Value {
                         .iter()
                         .any(|capability| endpoint_capabilities.contains(&capability.as_str()))
                 });
+                let models = provider
+                    .models
+                    .iter()
+                    .filter(|model| {
+                        model
+                            .capabilities
+                            .iter()
+                            .any(|capability| endpoint_capabilities.contains(&capability.as_str()))
+                    })
+                    .map(|model| {
+                        serde_json::json!({
+                            "id": &model.id,
+                            "capabilities": &model.capabilities
+                        })
+                    })
+                    .collect::<Vec<_>>();
                 serde_json::json!({
                     "provider": provider.id,
                     "endpoint": endpoint.id,
@@ -513,6 +529,7 @@ fn route_catalog(snapshot: &ProviderSnapshot) -> Value {
                     "pathParams": &endpoint.path_params,
                     "requestFormat": &endpoint.request_format,
                     "sampleModel": sample_model.map(|model| model.id.as_str()),
+                    "models": models,
                     "streaming": &endpoint.streaming
                 })
             })
@@ -15221,18 +15238,19 @@ mod tests {
             .iter()
             .find(|provider| provider.id == "anthropic")
             .unwrap();
-        let mut body = serde_json::json!({"model": "anthropic/default", "max_tokens": 1024});
+        let mut body =
+            serde_json::json!({"model": "anthropic/claude-opus-4-8", "max_tokens": 1024});
         let original = body.clone();
         let selected = select_native_model(anthropic, &body).unwrap();
         assert_eq!(body, original);
-        assert_eq!(selected.model, "anthropic/default");
-        assert_eq!(selected.upstream_model, "claude-sonnet-4-5-20250929");
+        assert_eq!(selected.model, "anthropic/claude-opus-4-8");
+        assert_eq!(selected.upstream_model, "claude-opus-4-8");
         let selection = normalize_native_model(anthropic, &mut body).unwrap();
-        assert_eq!(selection.model, "anthropic/default");
-        assert_eq!(body["model"], "claude-sonnet-4-5-20250929");
+        assert_eq!(selection.model, "anthropic/claude-opus-4-8");
+        assert_eq!(body["model"], "claude-opus-4-8");
         assert_eq!(
             selection.pricing.unwrap().input_micros_per_million,
-            3_000_000
+            5_000_000
         );
     }
 
@@ -15362,14 +15380,14 @@ mod tests {
         anthropic.readiness.executable_endpoints = vec!["messages".to_string()];
         let models = anthropic_models_value(&snapshot, &[anthropic]);
         assert_eq!(models["has_more"], false);
-        assert_eq!(models["first_id"], "anthropic/default");
-        assert_eq!(models["last_id"], "anthropic/default");
-        assert_eq!(models["data"][0]["id"], "anthropic/default");
+        assert_eq!(models["first_id"], "anthropic/claude-opus-4-8");
+        assert_eq!(models["last_id"], "anthropic/claude-haiku-4-5");
+        assert_eq!(models["data"][0]["id"], "anthropic/claude-opus-4-8");
         assert_eq!(models["data"][0]["type"], "model");
         assert_eq!(models["data"][0]["created_at"], "1970-01-01T00:00:00Z");
         assert!(models["data"][0]["capabilities"].is_null());
-        assert_eq!(models["data"][0]["max_input_tokens"], 200_000);
-        assert_eq!(models["data"][0]["max_tokens"], 64_000);
+        assert_eq!(models["data"][0]["max_input_tokens"], 1_000_000);
+        assert_eq!(models["data"][0]["max_tokens"], 128_000);
         assert!(models["data"][0].get("owned_by").is_none());
     }
 
@@ -16132,6 +16150,19 @@ mod tests {
                 && route.get("route").and_then(Value::as_str) == Some("/v1/proxy/tavily/search")
                 && route.get("requestFormat").and_then(Value::as_str) == Some("tavily.search")
                 && route.get("sampleModel").and_then(Value::as_str) == Some("tavily/search")
+        }));
+        assert!(manifest_routes.iter().any(|route| {
+            route.get("provider").and_then(Value::as_str) == Some("anthropic")
+                && route.get("endpoint").and_then(Value::as_str) == Some("messages")
+                && route
+                    .get("models")
+                    .and_then(Value::as_array)
+                    .is_some_and(|models| {
+                        models.iter().any(|model| {
+                            model.get("id").and_then(Value::as_str)
+                                == Some("anthropic/claude-opus-4-8")
+                        })
+                    })
         }));
         assert!(manifest_routes.iter().any(|route| {
             route.get("provider").and_then(Value::as_str) == Some("firecrawl")
@@ -18207,7 +18238,7 @@ mod tests {
             method: Some("POST".to_string()),
             path_params: Map::from_iter([(
                 "model".to_string(),
-                Value::String("google/gemini-default".to_string()),
+                Value::String("google/gemini-3.5-flash".to_string()),
             )]),
             body: Some(serde_json::json!({
                 "contents": [{"parts": [{"text": "hello"}]}]
@@ -18217,19 +18248,19 @@ mod tests {
 
         let selection =
             normalize_manifest_path_model(provider, endpoint, &mut proxy, |_| None).unwrap();
-        assert_eq!(selection.model, "google/gemini-default");
-        assert_eq!(selection.upstream_model, "gemini-2.5-flash");
+        assert_eq!(selection.model, "google/gemini-3.5-flash");
+        assert_eq!(selection.upstream_model, "gemini-3.5-flash");
         assert_eq!(
             selection.pricing_ref.as_deref(),
-            Some("google-gemini-2-5-flash-standard-2026-06-21")
+            Some("google-gemini-3-5-flash-standard-2026-06-22")
         );
         assert_eq!(
             proxy.path_params.get("model").and_then(Value::as_str),
-            Some("gemini-2.5-flash")
+            Some("gemini-3.5-flash")
         );
         assert_eq!(
             manifest_upstream_url(provider, endpoint, &proxy, None, None, None, None).unwrap(),
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent"
         );
     }
 

--- a/providers/anthropic.provider.yaml
+++ b/providers/anthropic.provider.yaml
@@ -49,18 +49,46 @@ endpoints:
     timeoutMs: 120000
 models:
   entries:
-    - id: anthropic/default
-      upstream: claude-sonnet-4-5-20250929
+    - id: anthropic/claude-opus-4-8
+      upstream: claude-opus-4-8
       capabilities: [llm.messages, llm.count_tokens]
-      pricingRef: anthropic-claude-sonnet-4-5-standard-2026-06-19
+      pricingRef: anthropic-claude-opus-4-8-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-05-27"
+        effectiveAt: "2026-06-22"
+        source: https://platform.claude.com/docs/en/about-claude/pricing
+        inputMicrosPerMillion: 5000000
+        cachedInputMicrosPerMillion: 500000
+        cacheWrite5mInputMicrosPerMillion: 6250000
+        cacheWrite1hInputMicrosPerMillion: 10000000
+        outputMicrosPerMillion: 25000000
+        maxInputTokens: 1000000
+        defaultMaxOutputTokens: 128000
+    - id: anthropic/claude-sonnet-4-6
+      upstream: claude-sonnet-4-6
+      capabilities: [llm.messages, llm.count_tokens]
+      pricingRef: anthropic-claude-sonnet-4-6-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
         source: https://platform.claude.com/docs/en/about-claude/pricing
         inputMicrosPerMillion: 3000000
         cachedInputMicrosPerMillion: 300000
         cacheWrite5mInputMicrosPerMillion: 3750000
         cacheWrite1hInputMicrosPerMillion: 6000000
         outputMicrosPerMillion: 15000000
+        maxInputTokens: 1000000
+        defaultMaxOutputTokens: 64000
+    - id: anthropic/claude-haiku-4-5
+      upstream: claude-haiku-4-5
+      capabilities: [llm.messages, llm.count_tokens]
+      pricingRef: anthropic-claude-haiku-4-5-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://platform.claude.com/docs/en/about-claude/pricing
+        inputMicrosPerMillion: 1000000
+        cachedInputMicrosPerMillion: 100000
+        cacheWrite5mInputMicrosPerMillion: 1250000
+        cacheWrite1hInputMicrosPerMillion: 2000000
+        outputMicrosPerMillion: 5000000
         maxInputTokens: 200000
         defaultMaxOutputTokens: 64000
 billing:

--- a/providers/cohere.provider.yaml
+++ b/providers/cohere.provider.yaml
@@ -45,11 +45,14 @@ endpoints:
     timeoutMs: 120000
 models:
   entries:
-    - id: cohere/default
-      upstream: cohere
-      capabilities: [llm.chat, llm.embeddings]
-      pricingRef: cohere-default
+    - id: cohere/command-a-plus-05-2026
+      upstream: command-a-plus-05-2026
+      capabilities: [llm.chat]
+      pricingRef: cohere-command-a-plus-05-2026
+    - id: cohere/embed-v4.0
+      upstream: embed-v4.0
+      capabilities: [llm.embeddings]
+      pricingRef: cohere-embed-v4-0
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]
-

--- a/providers/deepseek.provider.yaml
+++ b/providers/deepseek.provider.yaml
@@ -37,12 +37,24 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: deepseek/default
+    - id: deepseek/deepseek-v4-pro
+      upstream: deepseek-v4-pro
+      capabilities: [llm.chat]
+      pricingRef: deepseek-v4-pro-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://api-docs.deepseek.com/quick_start/pricing
+        inputMicrosPerMillion: 435000
+        cachedInputMicrosPerMillion: 3625
+        outputMicrosPerMillion: 870000
+        maxInputTokens: 1000000
+        defaultMaxOutputTokens: 384000
+    - id: deepseek/deepseek-v4-flash
       upstream: deepseek-v4-flash
       capabilities: [llm.chat]
-      pricingRef: deepseek-v4-flash-standard-2026-06-21
+      pricingRef: deepseek-v4-flash-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-06-21"
+        effectiveAt: "2026-06-22"
         source: https://api-docs.deepseek.com/quick_start/pricing
         inputMicrosPerMillion: 140000
         cachedInputMicrosPerMillion: 2800

--- a/providers/fireworks.provider.yaml
+++ b/providers/fireworks.provider.yaml
@@ -37,10 +37,22 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: fireworks/default
+    - id: fireworks/glm-5.2
+      upstream: accounts/fireworks/models/glm-5p2
+      capabilities: [llm.chat]
+      pricingRef: fireworks-glm-5p2-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://fireworks.ai/blog/glm-5p2
+        inputMicrosPerMillion: 1400000
+        cachedInputMicrosPerMillion: 260000
+        outputMicrosPerMillion: 4400000
+        maxInputTokens: 1048576
+        defaultMaxOutputTokens: 131072
+    - id: fireworks/gpt-oss-120b
       upstream: accounts/fireworks/models/gpt-oss-120b
       capabilities: [llm.chat]
-      pricingRef: fireworks-default
+      pricingRef: fireworks-gpt-oss-120b
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/providers/google-gemini.provider.yaml
+++ b/providers/google-gemini.provider.yaml
@@ -46,16 +46,16 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: google/gemini-default
-      upstream: gemini-2.5-flash
+    - id: google/gemini-3.5-flash
+      upstream: gemini-3.5-flash
       capabilities: [llm.generate, llm.stream]
-      pricingRef: google-gemini-2-5-flash-standard-2026-06-21
+      pricingRef: google-gemini-3-5-flash-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-06-21"
-        source: https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash
-        inputMicrosPerMillion: 300000
-        cachedInputMicrosPerMillion: 30000
-        outputMicrosPerMillion: 2500000
+        effectiveAt: "2026-06-22"
+        source: https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash
+        inputMicrosPerMillion: 1500000
+        cachedInputMicrosPerMillion: 150000
+        outputMicrosPerMillion: 9000000
         maxInputTokens: 1048576
         defaultMaxOutputTokens: 65536
 billing:

--- a/providers/groq.provider.yaml
+++ b/providers/groq.provider.yaml
@@ -37,17 +37,18 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: groq/default
-      upstream: llama-3.1-8b-instant
+    - id: groq/gpt-oss-120b
+      upstream: openai/gpt-oss-120b
       capabilities: [llm.chat]
-      pricingRef: groq-llama-3-1-8b-instant-standard-2026-06-21
+      pricingRef: groq-gpt-oss-120b-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-06-21"
-        source: https://groq.com/pricing
-        inputMicrosPerMillion: 50000
-        outputMicrosPerMillion: 80000
+        effectiveAt: "2026-06-22"
+        source: https://console.groq.com/docs/model/openai/gpt-oss-120b
+        inputMicrosPerMillion: 150000
+        cachedInputMicrosPerMillion: 75000
+        outputMicrosPerMillion: 600000
         maxInputTokens: 131072
-        defaultMaxOutputTokens: 131072
+        defaultMaxOutputTokens: 65536
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/providers/huggingface.provider.yaml
+++ b/providers/huggingface.provider.yaml
@@ -37,8 +37,8 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: huggingface/default
-      upstream: meta-llama/Llama-3.1-8B-Instruct
+    - id: huggingface/gpt-oss-120b-fastest
+      upstream: openai/gpt-oss-120b:fastest
       capabilities: [llm.chat]
       pricingRef: huggingface-router-dynamic
 billing:

--- a/providers/minimax.provider.yaml
+++ b/providers/minimax.provider.yaml
@@ -37,23 +37,18 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: minimax/MiniMax-M3
-      upstream: MiniMax-M3
+    - id: minimax/MiniMax-M2.7
+      upstream: MiniMax-M2.7
       capabilities: [llm.chat]
-      pricingRef: minimax-m3-standard-2026-06-21
+      pricingRef: minimax-m2-7-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-06-21"
+        effectiveAt: "2026-06-22"
         source: https://platform.minimax.io/docs/guides/pricing-paygo
         inputMicrosPerMillion: 300000
         cachedInputMicrosPerMillion: 60000
         outputMicrosPerMillion: 1200000
-        maxInputTokens: 1000000
-        defaultMaxOutputTokens: 128000
-        longContext:
-          thresholdInputTokens: 512000
-          inputMicrosPerMillion: 600000
-          cachedInputMicrosPerMillion: 120000
-          outputMicrosPerMillion: 2400000
+        maxInputTokens: 204800
+        defaultMaxOutputTokens: 131072
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/providers/mistral.provider.yaml
+++ b/providers/mistral.provider.yaml
@@ -45,10 +45,28 @@ endpoints:
     timeoutMs: 120000
 models:
   entries:
-    - id: mistral/default
-      upstream: mistral-small-latest
+    - id: mistral/mistral-medium-3-5
+      upstream: mistral-medium-3-5
       capabilities: [llm.chat]
-      pricingRef: mistral-default
+      pricingRef: mistral-medium-3-5-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
+        inputMicrosPerMillion: 1500000
+        outputMicrosPerMillion: 7500000
+        maxInputTokens: 262144
+        defaultMaxOutputTokens: 65536
+    - id: mistral/mistral-small-2603
+      upstream: mistral-small-2603
+      capabilities: [llm.chat]
+      pricingRef: mistral-small-4-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://docs.mistral.ai/getting-started/models/
+        inputMicrosPerMillion: 150000
+        outputMicrosPerMillion: 600000
+        maxInputTokens: 262144
+        defaultMaxOutputTokens: 65536
     - id: mistral/mistral-embed
       upstream: mistral-embed
       capabilities: [llm.embeddings]

--- a/providers/openai.provider.yaml
+++ b/providers/openai.provider.yaml
@@ -81,6 +81,23 @@ endpoints:
     timeoutMs: 120000
 models:
   entries:
+    - id: openai/gpt-5.5
+      upstream: gpt-5.5
+      capabilities: [llm.responses, llm.chat]
+      pricingRef: openai-gpt-5.5-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://developers.openai.com/api/docs/models/gpt-5.5/
+        inputMicrosPerMillion: 5000000
+        cachedInputMicrosPerMillion: 500000
+        outputMicrosPerMillion: 30000000
+        maxInputTokens: 1050000
+        defaultMaxOutputTokens: 128000
+        longContext:
+          thresholdInputTokens: 272000
+          inputMicrosPerMillion: 10000000
+          cachedInputMicrosPerMillion: 1000000
+          outputMicrosPerMillion: 45000000
     - id: openai/gpt-4.1-mini
       upstream: gpt-4.1-mini
       capabilities: [llm.responses, llm.chat]

--- a/providers/perplexity.provider.yaml
+++ b/providers/perplexity.provider.yaml
@@ -37,11 +37,17 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: perplexity/default
-      upstream: sonar
+    - id: perplexity/sonar-pro
+      upstream: sonar-pro
       capabilities: [llm.chat]
-      pricingRef: perplexity-default
+      pricingRef: perplexity-sonar-pro-standard-2026-06-22
+      pricing:
+        effectiveAt: "2026-06-22"
+        source: https://docs.perplexity.ai/docs/sonar/models/sonar-pro
+        inputMicrosPerMillion: 3000000
+        outputMicrosPerMillion: 15000000
+        maxInputTokens: 200000
+        defaultMaxOutputTokens: 8192
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]
-

--- a/providers/together.provider.yaml
+++ b/providers/together.provider.yaml
@@ -37,17 +37,18 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: together/default
-      upstream: Qwen/Qwen2.5-7B-Instruct-Turbo
+    - id: together/glm-5.2
+      upstream: zai-org/GLM-5.2
       capabilities: [llm.chat]
-      pricingRef: together-qwen-2-5-7b-instruct-turbo-2026-06-21
+      pricingRef: together-glm-5-2-standard-2026-06-22
       pricing:
-        effectiveAt: "2026-06-21"
-        source: https://www.together.ai/pricing
-        inputMicrosPerMillion: 300000
-        outputMicrosPerMillion: 300000
-        maxInputTokens: 32768
-        defaultMaxOutputTokens: 8192
+        effectiveAt: "2026-06-22"
+        source: https://docs.together.ai/docs/serverless/models
+        inputMicrosPerMillion: 1400000
+        cachedInputMicrosPerMillion: 260000
+        outputMicrosPerMillion: 4400000
+        maxInputTokens: 262144
+        defaultMaxOutputTokens: 131072
 billing:
   meter: clawrouter.tokens
   dimensions: [provider, model, key, service, subject]

--- a/providers/xai.provider.yaml
+++ b/providers/xai.provider.yaml
@@ -37,7 +37,7 @@ endpoints:
     timeoutMs: 600000
 models:
   entries:
-    - id: xai/default
+    - id: xai/grok-4.3
       upstream: grok-4.3
       capabilities: [llm.chat]
       pricingRef: xai-grok-4-3-standard-2026-06-21

--- a/test/provider-smoke-plan.test.mjs
+++ b/test/provider-smoke-plan.test.mjs
@@ -27,7 +27,7 @@ test("bundled OpenAI smoke target uses the catalog default model", () => {
   const provider = buildProviderSmokePlan(compileProviderSnapshot(), {}).providers.find(
     (entry) => entry.id === "openai",
   );
-  assert.equal(provider.target.body.model, "openai/gpt-4.1-mini");
+  assert.equal(provider.target.body.model, "openai/gpt-5.5");
 });
 
 test("Firecrawl uses keyless mode without a configured API key", () => {
@@ -50,22 +50,22 @@ test("Anthropic count_tokens smoke omits messages-only max_tokens", () => {
   assert.equal(provider.target.kind, "manifest_proxy");
   assert.equal(provider.target.endpoint, "count_tokens");
   assert.equal(provider.target.envelope.body.max_tokens, undefined);
-  assert.equal(provider.target.envelope.body.model, "claude-sonnet-4-5-20250929");
+  assert.equal(provider.target.envelope.body.model, "claude-opus-4-8");
 });
 
 test("newly budgeted provider defaults compile with dated pricing", () => {
   const snapshot = compileProviderSnapshot();
   const expectations = {
-    deepseek: [140000, 280000],
-    "google-gemini": [300000, 2500000],
-    groq: [50000, 80000],
-    minimax: [300000, 1200000],
-    together: [300000, 300000],
-    xai: [1250000, 2500000],
+    deepseek: ["2026-06-22", 435000, 870000],
+    "google-gemini": ["2026-06-22", 1500000, 9000000],
+    groq: ["2026-06-22", 150000, 600000],
+    minimax: ["2026-06-22", 300000, 1200000],
+    together: ["2026-06-22", 1400000, 4400000],
+    xai: ["2026-06-21", 1250000, 2500000],
   };
-  for (const [providerId, [input, output]] of Object.entries(expectations)) {
+  for (const [providerId, [effectiveAt, input, output]] of Object.entries(expectations)) {
     const model = snapshot.providers.find((provider) => provider.id === providerId).models[0];
-    assert.equal(model.pricing.effectiveAt, "2026-06-21");
+    assert.equal(model.pricing.effectiveAt, effectiveAt);
     assert.equal(model.pricing.inputMicrosPerMillion, input);
     assert.equal(model.pricing.outputMicrosPerMillion, output);
   }
@@ -86,9 +86,9 @@ test("newly budgeted provider defaults compile with dated pricing", () => {
 test("live provider defaults compile to current upstream models and transports", () => {
   const snapshot = compileProviderSnapshot();
   const upstreams = {
-    "google-gemini": "gemini-2.5-flash",
-    groq: "llama-3.1-8b-instant",
-    huggingface: "meta-llama/Llama-3.1-8B-Instruct",
+    "google-gemini": "gemini-3.5-flash",
+    groq: "openai/gpt-oss-120b",
+    huggingface: "openai/gpt-oss-120b:fastest",
     xai: "grok-4.3",
   };
   for (const [providerId, upstream] of Object.entries(upstreams)) {
@@ -99,7 +99,7 @@ test("live provider defaults compile to current upstream models and transports",
     (provider) => provider.id === "huggingface",
   );
   assert.equal(huggingface.target.kind, "openai_chat");
-  assert.equal(huggingface.target.body.model, "huggingface/default");
+  assert.equal(huggingface.target.body.model, "huggingface/gpt-oss-120b-fastest");
 });
 
 test("gateway failures do not overwrite provider health", async () => {


### PR DESCRIPTION
## Summary

- refresh configured flagship model IDs and list pricing from provider documentation
- expose native-format provider models in the route catalog
- split the Playground picker into provider and model/route controls

## Verification

- `pnpm check`
- `pnpm provider:compile`
- `pnpm provider:smoke-plan`
- rendered Chrome demo verification
- autoreview clean (`gpt-5.5`)

## Deployment

- deployed with [Cloudflare run 27934470034](https://github.com/openclaw/clawrouter/actions/runs/27934470034)

## Remaining risk

- 16 configured providers returned HTTP 200 through both the deployment smoke and authenticated production Playground; four unconfigured providers remain explicitly blocked
