### PR TITLE
fix: normalize current OpenAI reasoning requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize current OpenAI reasoning-model token limits and omit unsupported Playground temperature values.
 - Add current flagship model catalogs, including GPT-5.5, Claude Opus 4.8, Gemini 3.5 Flash, and GLM-5.2, with a provider-first Playground picker.
 - Show proxied Gravatar thumbnails for signed-in users without exposing email hashes or user network metadata to the browser.
 - Make repeated content-retention provisioning tolerate an existing lifecycle rule.

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -185,6 +185,10 @@ export interface CatalogModel {
   capabilities: string[];
 }
 
+export function preferredPlaygroundEndpoint(model: CatalogModel): PlaygroundForm["endpoint"] {
+  return model.capabilities.includes("llm.responses") ? "/v1/responses" : "/v1/chat/completions";
+}
+
 export function readinessMap(readiness: ProviderReadiness[]) {
   return Object.fromEntries(readiness.map((item) => [item.id, item]));
 }

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -449,12 +449,16 @@ export function playgroundPayload(form: PlaygroundForm, route?: RouteCatalog["ma
     };
   }
   const maxTokens = optionalNumber(form.maxTokens);
-  const temperature = optionalDecimal(form.temperature);
+  const temperature = playgroundSupportsTemperature(form.model) ? optionalDecimal(form.temperature) : undefined;
   const messages = [...conversation, { role: "user" as const, content: form.prompt }];
   if (form.endpoint === "/v1/responses") {
     return { model: form.model, input: messages, instructions: form.system || undefined, max_output_tokens: maxTokens, temperature };
   }
   return { model: form.model, messages: [...(form.system ? [{ role: "system", content: form.system }] : []), ...messages], max_tokens: maxTokens, temperature };
+}
+
+export function playgroundSupportsTemperature(model: string) {
+  return !/^openai\/gpt-5\.(?:4|5)(?:$|-)/.test(model);
 }
 
 export function playgroundResponseText(raw: string) {

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -47,6 +47,7 @@ import {
   playgroundBlockedForService,
   playgroundBlocker,
   playgroundPayload,
+  preferredPlaygroundEndpoint,
   playgroundServicePreset,
   playgroundSupportsTemperature,
   policyCoversProvider,
@@ -2164,7 +2165,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
   function selectProvider(provider: string) {
     const model = models.find((item) => item.provider === provider);
     if (model) {
-      setForm({ ...form, mode: "model", model: model.id });
+      setForm({ ...form, mode: "model", model: model.id, endpoint: preferredPlaygroundEndpoint(model) });
       return;
     }
     const routes = serviceRoutes.filter((item) => item.provider === provider);
@@ -2174,7 +2175,8 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
 
   function selectTarget(value: string) {
     if (value.startsWith("model:")) {
-      setForm({ ...form, mode: "model", model: value.slice(6) });
+      const model = models.find((item) => item.id === value.slice(6));
+      setForm({ ...form, mode: "model", model: value.slice(6), ...(model ? { endpoint: preferredPlaygroundEndpoint(model) } : {}) });
       return;
     }
     const modelTarget = serviceModelTargets.find((target) => target.value === value);
@@ -2287,7 +2289,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
             <div className="playgroundToolbar">
               {form.mode === "model" ? (
                 <>
-                  <label><span>Endpoint</span><select value={form.endpoint} onChange={(event) => setForm({ ...form, endpoint: event.target.value as PlaygroundForm["endpoint"] })}><option value="/v1/chat/completions">chat completions</option><option value="/v1/responses">responses</option></select></label>
+                  <label><span>Endpoint</span><select value={form.endpoint} onChange={(event) => setForm({ ...form, endpoint: event.target.value as PlaygroundForm["endpoint"] })}>{selected?.capabilities.includes("llm.chat") ? <option value="/v1/chat/completions">chat completions</option> : null}{selected?.capabilities.includes("llm.responses") ? <option value="/v1/responses">responses</option> : null}</select></label>
                   <label><span>System instructions</span><textarea className="systemPrompt" value={form.system} onChange={(event) => setForm({ ...form, system: event.target.value })} /></label>
                   <div className="playgroundSettingPair">
                     <label><span>Max tokens</span><input inputMode="numeric" value={form.maxTokens} onChange={(event) => setForm({ ...form, maxTokens: event.target.value })} /></label>

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -48,6 +48,7 @@ import {
   playgroundBlocker,
   playgroundPayload,
   playgroundServicePreset,
+  playgroundSupportsTemperature,
   policyCoversProvider,
   policyUsageFallback,
   readinessLabel,
@@ -2290,7 +2291,7 @@ function PlaygroundScreen({ form, setForm, models, selected, serviceRoutes, sele
                   <label><span>System instructions</span><textarea className="systemPrompt" value={form.system} onChange={(event) => setForm({ ...form, system: event.target.value })} /></label>
                   <div className="playgroundSettingPair">
                     <label><span>Max tokens</span><input inputMode="numeric" value={form.maxTokens} onChange={(event) => setForm({ ...form, maxTokens: event.target.value })} /></label>
-                    <label><span>Temperature</span><input inputMode="decimal" value={form.temperature} onChange={(event) => setForm({ ...form, temperature: event.target.value })} /></label>
+                    <label><span>Temperature</span><input inputMode="decimal" value={playgroundSupportsTemperature(form.model) ? form.temperature : ""} disabled={!playgroundSupportsTemperature(form.model)} placeholder={playgroundSupportsTemperature(form.model) ? undefined : "not supported"} onChange={(event) => setForm({ ...form, temperature: event.target.value })} /></label>
                   </div>
                 </>
               ) : (

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -12,6 +12,7 @@ import {
   playgroundPayload,
   playgroundResponseText,
   playgroundServicePreset,
+  playgroundSupportsTemperature,
   policyUsageFallback,
   reconcileDirectUserBindings,
   readinessTone,
@@ -155,6 +156,14 @@ test("playground model requests include the current conversation", () => {
     { role: "assistant", content: "answer" },
     { role: "user", content: "hello" },
   ]);
+});
+
+test("playground omits unsupported temperature for current OpenAI reasoning models", () => {
+  assert.equal(playgroundSupportsTemperature("openai/gpt-5.5"), false);
+  assert.equal(playgroundSupportsTemperature("openai/gpt-5.4"), false);
+  assert.equal(playgroundSupportsTemperature("openai/gpt-4.1-mini"), true);
+  const payload = playgroundPayload({ ...modelForm(), model: "openai/gpt-5.5", temperature: "0.7" });
+  assert.equal(payload.temperature, undefined);
 });
 
 test("playground responses show assistant text while preserving arbitrary responses", () => {

--- a/admin/test/domain.test.mjs
+++ b/admin/test/domain.test.mjs
@@ -10,6 +10,7 @@ import {
   playgroundAccessEndpoint,
   playgroundBlocker,
   playgroundPayload,
+  preferredPlaygroundEndpoint,
   playgroundResponseText,
   playgroundServicePreset,
   playgroundSupportsTemperature,
@@ -164,6 +165,11 @@ test("playground omits unsupported temperature for current OpenAI reasoning mode
   assert.equal(playgroundSupportsTemperature("openai/gpt-4.1-mini"), true);
   const payload = playgroundPayload({ ...modelForm(), model: "openai/gpt-5.5", temperature: "0.7" });
   assert.equal(payload.temperature, undefined);
+});
+
+test("playground model switches choose an endpoint the model supports", () => {
+  assert.equal(preferredPlaygroundEndpoint({ id: "openai/gpt-5.5", provider: "openai", capabilities: ["llm.chat", "llm.responses"] }), "/v1/responses");
+  assert.equal(preferredPlaygroundEndpoint({ id: "groq/gpt-oss-120b", provider: "groq", capabilities: ["llm.chat"] }), "/v1/chat/completions");
 });
 
 test("playground responses show assistant text while preserving arbitrary responses", () => {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -15611,6 +15611,26 @@ mod tests {
     }
 
     #[test]
+    fn openai_reasoning_chat_requests_use_completion_token_limit() {
+        let snapshot = provider_snapshot().unwrap();
+        let provider = snapshot
+            .providers
+            .iter()
+            .find(|provider| provider.id == "openai")
+            .unwrap();
+        let mut body = serde_json::json!({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "reply with ok"}],
+            "max_tokens": 16
+        });
+
+        normalize_openai_proxy_body(provider, "/v1/chat/completions", "gpt-5.5", None, &mut body);
+
+        assert!(body.get("max_tokens").is_none());
+        assert_eq!(body["max_completion_tokens"], 16);
+    }
+
+    #[test]
     fn azure_manifest_chat_requests_use_completion_token_limit() {
         let snapshot = provider_snapshot().unwrap();
         let provider = snapshot

--- a/providers/openai.provider.yaml
+++ b/providers/openai.provider.yaml
@@ -50,6 +50,12 @@ adapter:
   stream: openai_sse
   error: openai_error
   passthroughHeaders: [OpenAI-Organization, OpenAI-Project]
+  requestTransforms:
+    renameFields:
+      - from: max_tokens
+        to: max_completion_tokens
+        paths: [/v1/chat/completions]
+        upstreams: [gpt-5.5, gpt-5.4]
 capabilities:
   - id: llm.responses
     endpoint: responses


### PR DESCRIPTION
## Summary

- translate legacy Chat Completions token limits for GPT-5.4 and GPT-5.5
- omit and disable unsupported Playground temperature controls for those models
- cover both compatibility rules with regression tests

## Verification

- `pnpm --dir admin test`
- `pnpm --dir admin check`
- `cargo test -p clawrouter-edge openai_reasoning_chat_requests_use_completion_token_limit`
- `pnpm test:scripts`
- production Playground reproduction of both upstream 400 responses
- autoreview clean (`gpt-5.5`)

## Deployment

- deployed with [Cloudflare run 27934470034](https://github.com/openclaw/clawrouter/actions/runs/27934470034)
