### PR TITLE
fix: bulk provider readiness lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Collapse provider-readiness connection checks into one authority lookup so cold catalog requests no longer fan out across provider Durable Objects.
 - Replace the Rust/Wasm data plane and provider compiler with a modular TypeScript Worker while preserving Durable Object storage and public API contracts.
 - Add a persistent Light/Dark console toggle, refine interactive states and page alignment, and simplify the signed-in identity footer.
 - Normalize current OpenAI reasoning-model token limits and omit unsupported Playground temperature values.

--- a/scripts/smoke-deployed.mjs
+++ b/scripts/smoke-deployed.mjs
@@ -88,13 +88,13 @@ async function expectOk(url, name) {
 }
 
 async function expectAuthenticatedOk(url, name, token) {
-  const response = await fetch(url, {
-    headers: { authorization: `Bearer ${token}` },
-  });
-  if (!response.ok) {
-    throw new Error(`${name} failed with ${response.status}`);
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const response = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+    if (response.ok) return response.json();
+    if (response.status < 500 || attempt === 3) throw new Error(`${name} failed with ${response.status}`);
+    await new Promise((resolve) => setTimeout(resolve, 1_000 * (attempt + 1)));
   }
-  return response.json();
+  throw new Error(`${name} failed after retries`);
 }
 
 async function expectRedirect(url, name, location) {

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -47,6 +47,9 @@ try {
   const inspectionBody = await inspection.json();
   assert.equal(inspection.status, 200, JSON.stringify(inspectionBody));
   assert.equal(inspectionBody.verification, "verified", "KV-only credential migrates into authority on first use");
+  const clientCatalog = await fetch(`${base}/v1/catalog`, { headers: { authorization: `Bearer ${proxyKey}` } });
+  assert.equal(clientCatalog.status, 200);
+  assert.deepEqual((await clientCatalog.json()).providers.map((provider) => provider.id), ["firecrawl", "replicate"]);
   const mismatch = await fetch(`${base}/v1/proxy/firecrawl/scrape`, { method: "POST", headers: { authorization: `Bearer ${proxyKey}`, "content-type": "application/json" }, body: JSON.stringify({ body: { model: "openai/gpt-5.5", url: "https://example.com" } }) });
   assert.equal(mismatch.status, 400);
   assert.equal((await mismatch.json()).error.code, "model_provider_mismatch");

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,6 +1,6 @@
 import { authorizeAdmin } from "./access";
 import {
-  authorityCall, listBindings, listCredentials, listPolicies, listUsers,
+  authorityCall, listBindings, listCredentials, listPolicies, listUsers, resolveConnections,
 } from "./authority";
 import {
   listAssignmentRules, normalizeAssignmentEvidence, reconcileUserAssignments,
@@ -121,10 +121,9 @@ async function credentialResponses(env: Env) {
 }
 
 async function connections(env: Env): Promise<ProviderConnection[]> {
-  return Promise.all(snapshot.providers.map(async (provider) => {
-    const result = await authorityCall<{ connections: ProviderConnection[] }>(env, "/connections/resolve", { providerIds: [provider.id] }, connectionObject(provider.id));
-    return result.connections[0] ?? { providerId: provider.id, enabled: true, label: null };
-  }));
+  const stored = await resolveConnections(env, snapshot.providers.map((provider) => provider.id));
+  const byId = new Map(stored.map((connection) => [connection.providerId, connection]));
+  return snapshot.providers.map((provider) => byId.get(provider.id) ?? { providerId: provider.id, enabled: true, label: null });
 }
 
 async function putBinding(request: Request, env: Env): Promise<Response> {
@@ -188,7 +187,7 @@ async function credentialMutation(request: Request, env: Env, rest: string): Pro
 async function putConnection(request: Request, env: Env, encodedId: string): Promise<Response> {
   const id = decodeURIComponent(encodedId), provider = snapshot.providers.find((item) => item.id === id); if (!provider) throw new HttpError(404, "unknown_provider", "provider does not exist");
   const body = await readJson<Partial<ProviderConnection>>(request), connection: ProviderConnection = { providerId: id, enabled: body.enabled ?? true, label: body.label ?? null };
-  await authorityCall(env, "/connections/put", connection, connectionObject(id)); await env.POLICY_KV.put(`connections/${id}`, JSON.stringify(connection)); return privateJson(connection);
+  await authorityCall(env, "/connections/put", connection); await env.POLICY_KV.put(`connections/${id}`, JSON.stringify(connection)); return privateJson(connection);
 }
 
 async function upstreamGrantMutation(request: Request, env: Env, rest: string): Promise<Response> {
@@ -304,6 +303,5 @@ function grantResponse(key: string, grant: UpstreamGrant) { const parts = key.sp
 function assignmentResponse(ruleId: string, rule: AssignmentRule) { return { ruleId, ...rule, generatedGroup: `assignment.${ruleId}` }; }
 function assignmentRuleKey(id: string) { return `assignment/rules/${id}`; }
 function bindingKvKey(binding: PolicyBinding) { return `access/bindings/${binding.principalType}/${encodeURIComponent(binding.principalId)}/${binding.policyId}`; }
-function connectionObject(id: string) { return `provider-connection:${encodeURIComponent(id)}`; }
 function normalizeGroups(values: string[]) { return [...new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean))].sort(); }
 function sum(values: Array<number | null | undefined>) { return values.reduce<number>((total, value) => total + (value ?? 0), 0); }

--- a/worker/authority.ts
+++ b/worker/authority.ts
@@ -304,12 +304,16 @@ export async function resolveBindings(env: Env, principals: Principal[]): Promis
   await authorityCall(env, "/initialize", seeds);
   return sortBindings([...result.bindings, ...seeds.flatMap((seed) => seed.bindings)]);
 }
+export async function resolveConnections(env: Env, providerIds: string[]): Promise<ProviderConnection[]> {
+  const ids = [...new Set(providerIds)];
+  const result = await authorityCall<{ connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
+  const seeded = (await Promise.all(result.missingProviderIds.map((id) => env.POLICY_KV.get<ProviderConnection>(`connections/${id}`, "json")))).filter(Boolean) as ProviderConnection[];
+  if (seeded.length) await authorityCall(env, "/connections/initialize", seeded);
+  return [...result.connections, ...seeded];
+}
+
 export async function resolveConnection(env: Env, providerId: string): Promise<ProviderConnection | null> {
-  const result = await authorityCall<{ connections: ProviderConnection[] }>(env, "/connections/resolve", { providerIds: [providerId] }, `provider-connection:${encodeURIComponent(providerId)}`);
-  if (result.connections[0]) return result.connections[0];
-  const connection = await env.POLICY_KV.get<ProviderConnection>(`connections/${providerId}`, "json");
-  if (connection) await authorityCall(env, "/connections/initialize", [connection], `provider-connection:${encodeURIComponent(providerId)}`);
-  return connection;
+  return (await resolveConnections(env, [providerId]))[0] ?? null;
 }
 
 async function listKvJson<T>(env: Env, prefix: string): Promise<Array<[string, T]>> {

--- a/worker/providers.ts
+++ b/worker/providers.ts
@@ -1,5 +1,5 @@
 import snapshotJson from "./generated/provider-snapshot.json";
-import { resolveConnection } from "./authority";
+import { resolveConnection, resolveConnections } from "./authority";
 import type {
   AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, Env,
   ProviderConnection, ProviderHealth, ProviderSnapshot, UpstreamGrant,
@@ -109,12 +109,11 @@ export function routeCatalog() {
 }
 
 export async function providerReadiness(env: Env): Promise<Readiness[]> {
-  const grants = await listGrantRecords(env);
-  const health = await listHealth(env);
-  return Promise.all(snapshot.providers.map(async (provider) => {
-    const connection = await connectionFor(env, provider.id);
-    return readinessFor(provider, env, grants, connection, health.get(provider.id));
-  }));
+  const [grants, health, storedConnections] = await Promise.all([
+    listGrantRecords(env), listHealth(env), resolveConnections(env, snapshot.providers.map((provider) => provider.id)),
+  ]);
+  const connections = new Map(storedConnections.map((connection) => [connection.providerId, connection]));
+  return snapshot.providers.map((provider) => readinessFor(provider, env, grants, connections.get(provider.id) ?? { providerId: provider.id, enabled: true }, health.get(provider.id)));
 }
 
 export async function readinessForIdentity(env: Env, auth: AuthorizedIdentity): Promise<Readiness[]> {


### PR DESCRIPTION
## Summary

- resolve all provider connection states through one authority call instead of one Durable Object per provider
- lazily seed the bulk authority from existing KV compatibility records and keep admin mutations synchronized
- retry credential-scoped catalog smoke on bounded post-deploy 5xx responses

## Production diagnosis

- initial TypeScript deployment completed, then the immediate catalog smoke received HTTP 503
- authenticated reproduction with a short-lived 16-provider credential succeeded after roughly 4.7 seconds, confirming cold authority fan-out rather than catalog correctness
- diagnostic credentials and policies were revoked after reproduction

## Verification

- `pnpm check`
- `pnpm worker:e2e`
- autoreview clean

## Deployment

- pending merge and production workflow rerun
