### PR TITLE
refactor(admin): split console controller domains

### DIFF
--- a/admin/src/app-shell.tsx
+++ b/admin/src/app-shell.tsx
@@ -1,7 +1,20 @@
-export function AppShell({ controller }: { controller: ReturnType<typeof useConsoleController> }) {
+export function AppShell() {
   const [theme, setTheme] = React.useState(initialTheme);
   React.useEffect(() => { applyTheme(theme); }, [theme]);
-  const { view, setView, gatewayOrigin, allowDemo, session, setSession, providers, setProviders, routes, setRoutes, keys, setKeys, credentials, setCredentials, connections, setConnections, upstreamGrants, setUpstreamGrants, assignmentRules, setAssignmentRules, policyDataLoaded, setPolicyDataLoaded, users, setUsers, bindings, setBindings, adminOverview, setAdminOverview, tenantSummaries, setTenantSummaries, usageRows, setUsageRows, usageSnapshot, setUsageSnapshot, usageLoaded, setUsageLoaded, usageRefreshKey, setUsageRefreshKey, entitlements, setEntitlements, providerReadiness, setProviderReadiness, policyForm, setPolicyForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, upstreamGrantForm, setUpstreamGrantForm, assignmentRuleForm, setAssignmentRuleForm, accessTab, setAccessTab, accessForm, setAccessForm, query, setQuery, kind, setKind, selectedServiceId, setSelectedServiceId, selectedPolicyId, setSelectedPolicyId, selectedCredentialId, setSelectedCredentialId, selectedBindingKey, setSelectedBindingKey, selectedUpstreamGrantKey, setSelectedUpstreamGrantKey, selectedAssignmentRuleId, setSelectedAssignmentRuleId, selectedUserEmail, setSelectedUserEmail, status, setStatus, lastUpdatedAt, setLastUpdatedAt, demoMode, setDemoMode, issuedKey, setIssuedKey, policyError, setPolicyError, userError, setUserError, playgroundError, setPlaygroundError, playground, setPlayground, playgroundTurns, setPlaygroundTurns, selectedPlaygroundTurnId, setSelectedPlaygroundTurnId, requestMode, setRequestMode, refreshPromiseRef, refreshBackgroundRef, refreshRef, accessByProvider, services, models, serviceRoutes, kinds, filteredServices, selectedService, selectedPolicy, selectedCredential, selectedBinding, selectedUpstreamGrant, selectedAssignmentRule, selectedUser, selectedModel, selectedServiceRoute, statusPresentation, busy, busyRef, statusTone, refresh, refreshData, loadUserDemo, savePolicy, issueCredential, revokeCredential, saveBinding, saveUpstreamGrant, revokeUpstreamGrant, refreshUpstreamGrant, authorizeUpstreamGrant, saveAssignmentRule, reconcileAssignments, setProviderConnection, refreshUsageLedger, saveUser, revoke, runPlayground, editPolicy, startNewPolicy, startNewUser, editBinding, editUpstreamGrant, startNewUpstreamGrant, editAssignmentRule, startNewAssignmentRule, applyPreset, togglePolicyProvider, setPolicyProviderGroup, applyDemoKeys, applyDemoCredentials, navigateTo } = controller;
+  const { session: shell, catalog, access, usage, playground: playgroundDomain } = useConsole();
+  const { view, value: session, status, lastUpdatedAt, demoMode, statusPresentation, busy, statusTone, navigateTo } = shell;
+  const { providers, providerReadiness, accessByProvider, services, models, serviceRoutes, query, setQuery, kind, setKind, kinds, filteredServices, selectedService, setSelectedServiceId } = catalog;
+  const { policies, credentials: credentialState, connections: connectionState, bindings: bindingState, upstream, assignments, users: userState, tab } = access;
+  const { items: keys, selected: selectedPolicy, selectedId: selectedPolicyId, form: policyForm, setForm: setPolicyForm, error: policyError, save: savePolicy, revoke, edit: editPolicy, startNew: startNewPolicy, applyPreset, toggleProvider: togglePolicyProvider, setProviderGroup: setPolicyProviderGroup } = policies;
+  const { items: credentials, selected: selectedCredential, form: credentialForm, setForm: setCredentialForm, issuedKey, issue: issueCredential, revoke: revokeCredential, setSelectedId: setSelectedCredentialId, setIssuedKey } = credentialState;
+  const { items: connections, setEnabled: setProviderConnection } = connectionState;
+  const { items: bindings, selected: selectedBinding, form: bindingForm, setForm: setBindingForm, save: saveBinding, edit: editBinding, startNew: startNewBinding } = bindingState;
+  const { items: upstreamGrants, selected: selectedUpstreamGrant, form: upstreamGrantForm, setForm: setUpstreamGrantForm, save: saveUpstreamGrant, revoke: revokeUpstreamGrant, refresh: refreshUpstreamGrant, authorize: authorizeUpstreamGrant, edit: editUpstreamGrant, startNew: startNewUpstreamGrant } = upstream;
+  const { items: assignmentRules, selected: selectedAssignmentRule, form: assignmentRuleForm, setForm: setAssignmentRuleForm, save: saveAssignmentRule, reconcile: reconcileAssignments, edit: editAssignmentRule, startNew: startNewAssignmentRule } = assignments;
+  const { items: users, selected: selectedUser, setSelectedEmail: setSelectedUserEmail, form: accessForm, setForm: setAccessForm, error: userError, save: saveUser, startNew: startNewUser } = userState;
+  const { value: accessTab, set: setAccessTab } = tab;
+  const { adminOverview, tenantSummaries, rows: usageRows, snapshot: usageSnapshot, loaded: usageLoaded } = usage;
+  const { form: playground, setForm: setPlayground, turns: playgroundTurns, selectedTurnId: selectedPlaygroundTurnId, setSelectedTurnId: setSelectedPlaygroundTurnId, requestMode, setRequestMode, error: playgroundError, selectedModel, selectedServiceRoute, run: runPlayground, resetConversation } = playgroundDomain;
   return (
     <main className="appShell">
       <aside className="sidebar">
@@ -138,12 +151,7 @@ export function AppShell({ controller }: { controller: ReturnType<typeof useCons
             setSelectedTurnId={setSelectedPlaygroundTurnId}
             error={playgroundError}
             onRun={runPlayground}
-            onNewConversation={() => {
-              setPlaygroundTurns([]);
-              setSelectedPlaygroundTurnId("");
-              setPlaygroundError("");
-              setPlayground((current) => ({ ...current, prompt: "" }));
-            }}
+            onNewConversation={resetConversation}
             busy={busy}
           />
         ) : null}
@@ -193,10 +201,7 @@ export function AppShell({ controller }: { controller: ReturnType<typeof useCons
               setIssuedKey("");
             }}
             onEditBinding={editBinding}
-            onNewBinding={() => {
-              setSelectedBindingKey("");
-              setBindingForm({ ...defaultBinding, policyId: selectedPolicyId || keys[0]?.policyId || "" });
-            }}
+            onNewBinding={startNewBinding}
             onEditUpstreamGrant={editUpstreamGrant}
             onNewUpstreamGrant={startNewUpstreamGrant}
             onEditAssignmentRule={editAssignmentRule}
@@ -247,6 +252,6 @@ import { DashboardScreen, CatalogScreen, UserAvatar } from "./screens/dashboard-
 import { PlaygroundScreen } from "./screens/playground";
 import { PoliciesScreen } from "./screens/access";
 import { UsageScreen, UsersScreen } from "./screens/users-usage";
-import { applyTheme, defaultBinding, initialTheme, navItems } from "./ui-config";
+import { applyTheme, initialTheme, navItems } from "./ui-config";
 import { formatTimestamp } from "./ui-helpers";
-import { useConsoleController } from "./use-console-controller";
+import { useConsole } from "./console-controller-context";

--- a/admin/src/console-controller-context.tsx
+++ b/admin/src/console-controller-context.tsx
@@ -1,0 +1,15 @@
+import { createContext, type ReactNode, useContext } from "react";
+import { type ConsoleController, useConsoleController } from "./use-console-controller";
+
+const ConsoleControllerContext = createContext<ConsoleController | null>(null);
+
+export function ConsoleControllerProvider({ children }: { children: ReactNode }) {
+  const controller = useConsoleController();
+  return <ConsoleControllerContext.Provider value={controller}>{children}</ConsoleControllerContext.Provider>;
+}
+
+export function useConsole() {
+  const controller = useContext(ConsoleControllerContext);
+  if (!controller) throw new Error("useConsole must be used inside ConsoleControllerProvider");
+  return controller;
+}

--- a/admin/src/hooks/use-access-admin.ts
+++ b/admin/src/hooks/use-access-admin.ts
@@ -1,0 +1,642 @@
+import { type FormEvent, useState } from "react";
+import {
+  accessFormFromUser,
+  bindingFormFromBinding,
+  bindingKey,
+  currencyInput,
+  errorMessage,
+  knownPolicyProviders,
+  optionalCurrencyMicros,
+  optionalNumber,
+  parseGroups,
+  reconcileDirectUserBindings,
+  unique,
+} from "../domain";
+import {
+  defaultAccess,
+  defaultAssignmentRule,
+  defaultBinding,
+  defaultCredential,
+  defaultPolicy,
+  defaultUpstreamGrant,
+  demo,
+  initialAccessTab,
+  rolePresets,
+} from "../ui-config";
+import {
+  assignmentRuleFormFromRule,
+  demoGrantFromForm,
+  demoRuleFromForm,
+  generateSecret,
+  parseCredentialBundle,
+  policyFormFromPolicy,
+  request,
+  sha256Hex,
+  upstreamGrantFormFromGrant,
+} from "../ui-helpers";
+import type {
+  AccessPolicy,
+  AccessTab,
+  AccessUser,
+  AssignmentRule,
+  AssignmentRuleForm,
+  BindingForm,
+  CredentialForm,
+  PolicyBinding,
+  PolicyForm,
+  ProviderConnection,
+  ProviderReadiness,
+  ProviderRow,
+  ProxyCredential,
+  RouteCatalog,
+  SessionResponse,
+  UpstreamGrant,
+  UpstreamGrantForm,
+} from "../ui-types";
+
+interface AccessAdminDependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  session: SessionResponse;
+  demoMode: boolean;
+  providers: ProviderRow[];
+  routes: RouteCatalog;
+  setStatus: (status: string) => void;
+  setProviderReadiness: React.Dispatch<React.SetStateAction<Record<string, ProviderReadiness>>>;
+  refresh: () => Promise<void>;
+  syncDemoAdmin: (policies: AccessPolicy[], credentials: ProxyCredential[], providers: ProviderRow[], routes: RouteCatalog, syncRows?: boolean) => void;
+}
+
+interface AdminRecords {
+  policies: AccessPolicy[];
+  credentials: ProxyCredential[];
+  connections: ProviderConnection[];
+  users: AccessUser[];
+  bindings: PolicyBinding[];
+  grants: UpstreamGrant[];
+  rules: AssignmentRule[];
+}
+
+export function useAccessAdmin(dependencies: AccessAdminDependencies) {
+  const { allowDemo, gatewayOrigin, session, demoMode, providers, routes, setStatus, setProviderReadiness, refresh, syncDemoAdmin } = dependencies;
+  const [keys, setKeys] = useState<AccessPolicy[]>(allowDemo ? demo.keys : []);
+  const [credentials, setCredentials] = useState<ProxyCredential[]>(allowDemo ? demo.credentials : []);
+  const [connections, setConnections] = useState<ProviderConnection[]>(allowDemo ? demo.connections : []);
+  const [upstreamGrants, setUpstreamGrants] = useState<UpstreamGrant[]>(allowDemo ? demo.upstreamGrants : []);
+  const [assignmentRules, setAssignmentRules] = useState<AssignmentRule[]>(allowDemo ? demo.assignmentRules : []);
+  const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
+  const [bindings, setBindings] = useState<PolicyBinding[]>(allowDemo ? demo.bindings : []);
+  const [loaded, setLoaded] = useState(allowDemo);
+  const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
+  const [credentialForm, setCredentialForm] = useState<CredentialForm>(allowDemo && demo.keys[0] ? { credentialId: "", policyId: demo.keys[0].policyId, principalId: "" } : defaultCredential);
+  const [bindingForm, setBindingForm] = useState<BindingForm>(allowDemo && demo.keys[0] ? { ...defaultBinding, policyId: demo.keys[0].policyId } : defaultBinding);
+  const [upstreamGrantForm, setUpstreamGrantForm] = useState<UpstreamGrantForm>(allowDemo && demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
+  const [assignmentRuleForm, setAssignmentRuleForm] = useState<AssignmentRuleForm>(allowDemo && demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
+  const [accessTab, setAccessTab] = useState<AccessTab>(initialAccessTab);
+  const [accessForm, setAccessForm] = useState(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
+  const [selectedPolicyId, setSelectedPolicyId] = useState(allowDemo ? demo.keys[0]?.policyId ?? "" : "");
+  const [selectedCredentialId, setSelectedCredentialId] = useState(allowDemo ? demo.credentials[0]?.credentialId ?? "" : "");
+  const [selectedBindingKey, setSelectedBindingKey] = useState(allowDemo ? bindingKey(demo.bindings[0]) : "");
+  const [selectedUpstreamGrantKey, setSelectedUpstreamGrantKey] = useState(allowDemo ? demo.upstreamGrants[0]?.key ?? "" : "");
+  const [selectedAssignmentRuleId, setSelectedAssignmentRuleId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
+  const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
+  const [issuedKey, setIssuedKey] = useState("");
+  const [policyError, setPolicyError] = useState("");
+  const [userError, setUserError] = useState("");
+  const selectedPolicy = keys.find((key) => key.policyId === selectedPolicyId);
+  const selectedCredential = credentials.find((credential) => credential.credentialId === selectedCredentialId);
+  const selectedBinding = bindings.find((binding) => bindingKey(binding) === selectedBindingKey);
+  const selectedUpstreamGrant = upstreamGrants.find((grant) => grant.key === selectedUpstreamGrantKey);
+  const selectedAssignmentRule = assignmentRules.find((rule) => rule.ruleId === selectedAssignmentRuleId);
+  const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
+
+  function hydrateAdmin(records: AdminRecords, background: boolean, sessionData: SessionResponse, providerRows: ProviderRow[]) {
+    setKeys(records.policies);
+    setCredentials(records.credentials);
+    setConnections(records.connections);
+    setUpstreamGrants(records.grants);
+    setAssignmentRules(records.rules);
+    setUsers(records.users);
+    setBindings(records.bindings);
+    setLoaded(true);
+    if (background) return;
+    const refreshedPolicy = records.policies.find((policy) => policy.policyId === selectedPolicyId) ?? records.policies[0];
+    setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
+    setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
+    const refreshedCredential = records.credentials.find((credential) => credential.credentialId === selectedCredentialId) ?? records.credentials[0];
+    setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
+    setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? records.policies[0]?.policyId ?? "", principalId: "" });
+    const refreshedBinding = records.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? records.bindings[0];
+    setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
+    setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
+    const refreshedGrant = records.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? records.grants[0];
+    setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
+    setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerRows[0]?.id ?? "", tokenRef: providerRows[0]?.id ?? "" });
+    const refreshedRule = records.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? records.rules[0];
+    setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
+    setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
+    const refreshedUser = records.users.find((user) => user.email === selectedUserEmail) ?? records.users[0];
+    setSelectedUserEmail(refreshedUser?.email ?? "");
+    setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, records.bindings) : defaultAccess);
+  }
+
+  function hydrateUser(user: AccessUser) {
+    setKeys([]);
+    setCredentials([]);
+    setConnections([]);
+    setUpstreamGrants([]);
+    setAssignmentRules([]);
+    setLoaded(false);
+    setUsers([user]);
+    setBindings([]);
+    setSelectedUserEmail(user.email);
+    setAccessForm(accessFormFromUser(user, []));
+  }
+
+  function hydrateDemo() {
+    hydrateAdmin({ policies: demo.keys, credentials: demo.credentials, connections: demo.connections, users: demo.users, bindings: demo.bindings, grants: demo.upstreamGrants, rules: demo.assignmentRules }, false, demo.session, demo.providers);
+  }
+
+  async function savePolicy(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      setStatus("saving policy");
+      const policyProviders = knownPolicyProviders(policyForm.providers, providers.map((provider) => provider.id));
+      if (!policyForm.allProviders && !policyProviders.length) throw new Error("select at least one service");
+      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.policyId)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
+      const existingPolicy = keys.some((key) => key.policyId === policyForm.policyId);
+      if (existingPolicy && selectedPolicyId !== policyForm.policyId) throw new Error("policy id already exists; select it from the policy list to edit it");
+      const next: AccessPolicy = {
+        policyId: policyForm.policyId,
+        enabled: policyForm.enabled,
+        providers: policyForm.allProviders ? [] : policyProviders,
+        tenantId: policyForm.tenantId || "default",
+        tokenRole: policyForm.tokenRole || null,
+        monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,
+        requestCostMicros: optionalNumber(policyForm.requestCostMicros) ?? null,
+        retainRequestContent: policyForm.retainRequestContent,
+      };
+      if (demoMode) {
+        applyDemoKeys((current) => [next, ...current.filter((key) => key.policyId !== next.policyId)]);
+        setSelectedPolicyId(next.policyId);
+        setStatus("saved policy");
+        return;
+      }
+      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyForm.policyId)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...next, allProviders: policyForm.allProviders }),
+      });
+      await refresh();
+      setSelectedPolicyId(next.policyId);
+      setPolicyForm(policyFormFromPolicy(next));
+      setStatus("saved policy");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function issueCredential(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const policyId = credentialForm.policyId || selectedPolicyId;
+      if (!keys.some((policy) => policy.policyId === policyId)) throw new Error("select a policy for this credential");
+      const credentialId = credentialForm.credentialId.trim() || `${policyId}_${Date.now().toString(36)}`;
+      if (!/^[A-Za-z0-9_]{4,}$/.test(credentialId)) throw new Error("credential id must use 4 or more letters, numbers, or underscores");
+      if (credentials.some((credential) => credential.credentialId === credentialId)) throw new Error("credential id already exists");
+      setStatus("issuing credential");
+      const secret = generateSecret();
+      const revealedKey = `clawrouter-live-${credentialId}-${secret}`;
+      const principalId = credentialForm.principalId.trim().toLowerCase() || null;
+      if (principalId && !principalId.includes("@")) throw new Error("owner must be a valid user email");
+      const next: ProxyCredential = { credentialId, policyId, enabled: true, principalId };
+      if (demoMode) {
+        applyDemoCredentials((current) => [next, ...current]);
+      } else {
+        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}`, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: true, policyId, principalId, secretSha256: await sha256Hex(secret) }),
+        });
+        setIssuedKey(revealedKey);
+        try {
+          await refresh();
+        } catch (caught) {
+          const message = errorMessage(caught);
+          setSelectedCredentialId(credentialId);
+          setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
+          setPolicyError(`credential issued, but refresh failed: ${message}`);
+          setStatus("issued credential; refresh failed");
+          return;
+        }
+      }
+      setSelectedCredentialId(credentialId);
+      setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
+      setIssuedKey(revealedKey);
+      setStatus("issued credential");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function revokeCredential(credentialId: string) {
+    try {
+      setStatus(`revoking ${credentialId}`);
+      if (demoMode) applyDemoCredentials((current) => current.map((credential) => credential.credentialId === credentialId ? { ...credential, enabled: false } : credential));
+      else {
+        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}/revoke`, { method: "POST" });
+        await refresh();
+      }
+      setIssuedKey("");
+      setStatus(`revoked ${credentialId}`);
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function saveBinding(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const principalId = bindingForm.principalId.trim().toLowerCase();
+      if (!principalId) throw new Error("principal is required");
+      if (!bindingForm.policyId) throw new Error("select a policy");
+      const next: PolicyBinding = { policyId: bindingForm.policyId, principalType: bindingForm.principalType, principalId, enabled: bindingForm.enabled, priority: optionalNumber(bindingForm.priority) ?? 100 };
+      setStatus("saving binding");
+      if (demoMode) setBindings((current) => [next, ...current.filter((binding) => bindingKey(binding) !== bindingKey(next))]);
+      else {
+        await request<PolicyBinding>(gatewayOrigin, "/v1/admin/policy-bindings", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
+        await refresh();
+      }
+      setSelectedBindingKey(bindingKey(next));
+      setBindingForm(bindingFormFromBinding(next));
+      setStatus("saved binding");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function saveUpstreamGrant(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const scopeId = upstreamGrantForm.scopeId.trim();
+      const tokenRef = upstreamGrantForm.tokenRef.trim();
+      const provider = upstreamGrantForm.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      const credentialBundle = parseCredentialBundle(upstreamGrantForm.credentialBundle);
+      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() || Object.keys(credentialBundle).length : upstreamGrantForm.accessToken.trim();
+      if (!selectedUpstreamGrant && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
+      const body = {
+        version: 1,
+        enabled: upstreamGrantForm.enabled,
+        kind: upstreamGrantForm.kind,
+        provider,
+        label: upstreamGrantForm.label.trim() || undefined,
+        tokenType: selectedUpstreamGrant?.tokenType ?? "Bearer",
+        expiresAt: upstreamGrantForm.expiresAt.trim() || undefined,
+        scopes: selectedUpstreamGrant?.scopes ?? [],
+        accountId: upstreamGrantForm.accountId.trim() || undefined,
+        subscription: selectedUpstreamGrant?.subscription ?? undefined,
+        ...(upstreamGrantForm.credential.trim() ? { credential: upstreamGrantForm.credential.trim() } : {}),
+        ...(Object.keys(credentialBundle).length ? { credentials: credentialBundle } : {}),
+        ...(upstreamGrantForm.accessToken.trim() ? { accessToken: upstreamGrantForm.accessToken.trim() } : {}),
+        ...(upstreamGrantForm.refreshToken.trim() ? { refreshToken: upstreamGrantForm.refreshToken.trim() } : {}),
+      };
+      const path = `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}`;
+      setStatus("saving upstream grant");
+      let saved: UpstreamGrant;
+      if (demoMode) {
+        saved = demoGrantFromForm(upstreamGrantForm, selectedUpstreamGrant);
+        setUpstreamGrants((current) => [saved, ...current.filter((grant) => grant.key !== saved.key)]);
+      } else {
+        saved = await request<UpstreamGrant>(gatewayOrigin, path, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+        await refresh();
+      }
+      setSelectedUpstreamGrantKey(saved.key);
+      setUpstreamGrantForm(upstreamGrantFormFromGrant(saved));
+      setStatus("saved upstream grant");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function revokeUpstreamGrant(grant: UpstreamGrant) {
+    try {
+      setPolicyError("");
+      setStatus("revoking upstream grant");
+      let revoked: UpstreamGrant;
+      if (demoMode) {
+        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
+        setUpstreamGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
+      } else {
+        revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" });
+        await refresh();
+      }
+      setSelectedUpstreamGrantKey(revoked.key);
+      setUpstreamGrantForm(upstreamGrantFormFromGrant(revoked));
+      setStatus("revoked upstream grant");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function refreshUpstreamGrant(grant: UpstreamGrant) {
+    try {
+      setPolicyError("");
+      setStatus("refreshing upstream grant");
+      if (!demoMode) {
+        const refreshed = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/refresh`, { method: "POST" });
+        await refresh();
+        setSelectedUpstreamGrantKey(refreshed.key);
+        setUpstreamGrantForm(upstreamGrantFormFromGrant(refreshed));
+      }
+      setStatus("refreshed upstream grant");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function authorizeUpstreamGrant() {
+    try {
+      setPolicyError("");
+      const scopeId = upstreamGrantForm.scopeId.trim();
+      const tokenRef = upstreamGrantForm.tokenRef.trim();
+      const provider = upstreamGrantForm.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      if (!providers.find((item) => item.id === provider)?.auth?.authorization) throw new Error("selected provider does not support browser OAuth");
+      setStatus("connecting upstream grant");
+      if (demoMode) {
+        setStatus("browser OAuth unavailable in local demo");
+        return;
+      }
+      const result = await request<{ authorizationUrl: string }>(gatewayOrigin, `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}/authorize`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider }),
+      });
+      window.location.assign(result.authorizationUrl);
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function saveAssignmentRule(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const ruleId = assignmentRuleForm.ruleId.trim();
+      if (!/^[a-z0-9_]{4,48}$/.test(ruleId)) throw new Error("rule id must use 4-48 lowercase letters, numbers, or underscores");
+      if (!assignmentRuleForm.subject.trim()) throw new Error("rule subject is required");
+      const body = {
+        version: 1,
+        enabled: assignmentRuleForm.enabled,
+        kind: assignmentRuleForm.kind,
+        subject: assignmentRuleForm.subject.trim(),
+        groups: parseGroups(assignmentRuleForm.groups),
+        policyIds: assignmentRuleForm.policyIds,
+        priority: optionalNumber(assignmentRuleForm.priority) ?? 100,
+        revokeOnLoss: assignmentRuleForm.revokeOnLoss,
+        provenance: assignmentRuleForm.provenance.trim(),
+      };
+      setStatus("saving assignment rule");
+      let saved: AssignmentRule;
+      if (demoMode) {
+        saved = demoRuleFromForm(assignmentRuleForm);
+        setAssignmentRules((current) => [saved, ...current.filter((rule) => rule.ruleId !== saved.ruleId)]);
+      } else {
+        saved = await request<AssignmentRule>(gatewayOrigin, `/v1/admin/assignment-rules/${encodeURIComponent(ruleId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+        await refresh();
+      }
+      setSelectedAssignmentRuleId(saved.ruleId);
+      setAssignmentRuleForm(assignmentRuleFormFromRule(saved));
+      setStatus("saved assignment rule");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function reconcileAssignments() {
+    try {
+      setPolicyError("");
+      setStatus("reconciling assignments");
+      if (!demoMode) {
+        await request<{ results: unknown[] }>(gatewayOrigin, "/v1/admin/assignment-rules/reconcile", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ all: true }) });
+        await refresh();
+      }
+      setStatus("reconciled assignments");
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  async function setProviderConnection(providerId: string, enabled: boolean) {
+    try {
+      setStatus(`${enabled ? "enabling" : "disabling"} ${providerId}`);
+      const current = connections.find((connection) => connection.providerId === providerId);
+      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null };
+      if (demoMode) {
+        setConnections((items) => [next, ...items.filter((item) => item.providerId !== providerId)]);
+        setProviderReadiness((items) => {
+          const readiness = items[providerId];
+          return readiness ? { ...items, [providerId]: { ...readiness, connectionEnabled: enabled, executable: enabled && readiness.configPresent && (!readiness.oauthGrantRequired || readiness.oauthGrantCount > 0), status: enabled ? (readiness.verified ? "verified" : "unverified") : "disabled" } } : items;
+        });
+      } else {
+        await request<ProviderConnection>(gatewayOrigin, `/v1/admin/connections/${encodeURIComponent(providerId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
+        await refresh();
+      }
+      setStatus(`${enabled ? "enabled" : "disabled"} ${providerId}`);
+    } catch (caught) {
+      setStatus(errorMessage(caught));
+    }
+  }
+
+  async function saveUser(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setUserError("");
+      setStatus("saving user");
+      const email = accessForm.email.trim().toLowerCase();
+      if (!email.includes("@")) throw new Error("enter a valid email");
+      const next: AccessUser = {
+        email,
+        role: selectedUser?.role ?? "user",
+        tenantId: accessForm.tenantId || "default",
+        enabled: accessForm.enabled,
+        groups: parseGroups(accessForm.groups),
+        contentRetentionDisabled: accessForm.contentRetentionDisabled,
+      };
+      const nextBindings = reconcileDirectUserBindings(bindings, email, keys, accessForm.policyIds);
+      if (demoMode) {
+        setUsers((current) => [next, ...current.filter((user) => user.email !== email)]);
+        setBindings(nextBindings);
+        setSelectedUserEmail(email);
+        setAccessForm(accessFormFromUser(next, nextBindings));
+        setStatus("saved user");
+        return;
+      }
+      await request<{ user: AccessUser; bindings: PolicyBinding[] }>(gatewayOrigin, `/v1/admin/access-user-grants/${encodeURIComponent(email)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tenantId: next.tenantId, enabled: next.enabled, groups: next.groups, contentRetentionDisabled: next.contentRetentionDisabled, policyIds: accessForm.policyIds }),
+      });
+      try {
+        await refresh();
+      } catch (caught) {
+        const message = errorMessage(caught);
+        setSelectedUserEmail(email);
+        setAccessForm(accessFormFromUser(next, nextBindings));
+        setUserError(`saved user, but refresh failed: ${message}`);
+        setStatus("saved user; refresh failed");
+        return;
+      }
+      setSelectedUserEmail(email);
+      setAccessForm(accessFormFromUser(next, nextBindings));
+      setStatus("saved user");
+    } catch (caught) {
+      const message = errorMessage(caught);
+      setUserError(message);
+      setStatus(message);
+      await refresh().catch(() => undefined);
+      setUserError(message);
+      setStatus(message);
+    }
+  }
+
+  async function revokePolicy(policyId: string) {
+    try {
+      setStatus(`revoking ${policyId}`);
+      if (demoMode) {
+        applyDemoKeys((current) => current.map((key) => key.policyId === policyId ? { ...key, enabled: false } : key));
+        setStatus(`revoked ${policyId}`);
+        return;
+      }
+      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyId)}/revoke`, { method: "POST" });
+      await refresh();
+      setStatus(`revoked ${policyId}`);
+    } catch (caught) {
+      handlePolicyError(caught);
+    }
+  }
+
+  function editPolicy(key: AccessPolicy) {
+    setIssuedKey("");
+    setSelectedPolicyId(key.policyId);
+    setPolicyForm(policyFormFromPolicy(key));
+    setCredentialForm((current) => ({ ...current, policyId: key.policyId }));
+    setBindingForm((current) => ({ ...current, policyId: key.policyId }));
+  }
+
+  function startNewPolicy() {
+    setIssuedKey("");
+    setPolicyError("");
+    setSelectedPolicyId("");
+    setPolicyForm({ ...defaultPolicy, policyId: "", tenantId: session.tenantId ?? "default", providers: [...defaultPolicy.providers] });
+  }
+
+  function startNewUser() {
+    setSelectedUserEmail("");
+    setUserError("");
+    setAccessForm({ ...defaultAccess, email: "", tenantId: session.tenantId ?? "default" });
+  }
+
+  function editBinding(binding: PolicyBinding) {
+    setSelectedBindingKey(bindingKey(binding));
+    setBindingForm(bindingFormFromBinding(binding));
+  }
+
+  function startNewBinding() {
+    setSelectedBindingKey("");
+    setBindingForm({ ...defaultBinding, policyId: selectedPolicyId || keys[0]?.policyId || "" });
+  }
+
+  function editUpstreamGrant(grant: UpstreamGrant) {
+    setSelectedUpstreamGrantKey(grant.key);
+    setUpstreamGrantForm(upstreamGrantFormFromGrant(grant));
+  }
+
+  function startNewUpstreamGrant() {
+    const provider = providers[0]?.id ?? "";
+    setSelectedUpstreamGrantKey("");
+    setUpstreamGrantForm({ ...defaultUpstreamGrant, scopeId: selectedPolicyId || keys[0]?.policyId || "default", provider, tokenRef: provider });
+  }
+
+  function editAssignmentRule(rule: AssignmentRule) {
+    setSelectedAssignmentRuleId(rule.ruleId);
+    setAssignmentRuleForm(assignmentRuleFormFromRule(rule));
+  }
+
+  function startNewAssignmentRule() {
+    setSelectedAssignmentRuleId("");
+    setAssignmentRuleForm({ ...defaultAssignmentRule, policyIds: [] });
+  }
+
+  function applyPreset(role: keyof typeof rolePresets) {
+    const preset = rolePresets[role];
+    const available = new Set(providers.map((provider) => provider.id));
+    setPolicyForm((current) => ({
+      ...current,
+      tokenRole: role,
+      monthlyBudgetMicros: currencyInput(optionalNumber(preset.budget)),
+      requestCostMicros: preset.request,
+      providers: preset.providers.length ? preset.providers.filter((id) => available.has(id)) : providers.map((provider) => provider.id),
+      allProviders: false,
+    }));
+  }
+
+  function togglePolicyProvider(providerId: string) {
+    const allProviderIds = providers.map((provider) => provider.id);
+    setPolicyForm((current) => ({
+      ...current,
+      allProviders: false,
+      providers: (current.allProviders ? allProviderIds : current.providers).includes(providerId)
+        ? (current.allProviders ? allProviderIds : current.providers).filter((id) => id !== providerId)
+        : [...current.providers, providerId].sort(),
+    }));
+  }
+
+  function setPolicyProviderGroup(providerIds: string[], checked: boolean) {
+    const allProviderIds = providers.map((provider) => provider.id);
+    setPolicyForm((current) => {
+      if (current.allProviders && checked) return current;
+      const selected = current.allProviders ? allProviderIds : current.providers;
+      return { ...current, allProviders: false, providers: checked ? unique([...selected, ...providerIds]).sort() : selected.filter((id) => !providerIds.includes(id)) };
+    });
+  }
+
+  function applyDemoKeys(updater: (current: AccessPolicy[]) => AccessPolicy[]) {
+    const next = updater(keys);
+    setKeys(next);
+    syncDemoAdmin(next, credentials, providers, routes, true);
+  }
+
+  function applyDemoCredentials(updater: (current: ProxyCredential[]) => ProxyCredential[]) {
+    const next = updater(credentials);
+    setCredentials(next);
+    syncDemoAdmin(keys, next, providers, routes);
+  }
+
+  function handlePolicyError(caught: unknown) {
+    const message = errorMessage(caught);
+    setPolicyError(message);
+    setStatus(message);
+  }
+
+  return {
+    loaded,
+    setLoaded,
+    tab: { value: accessTab, set: setAccessTab },
+    policies: { items: keys, setItems: setKeys, selected: selectedPolicy, selectedId: selectedPolicyId, setSelectedId: setSelectedPolicyId, form: policyForm, setForm: setPolicyForm, error: policyError, setError: setPolicyError, save: savePolicy, revoke: revokePolicy, edit: editPolicy, startNew: startNewPolicy, applyPreset, toggleProvider: togglePolicyProvider, setProviderGroup: setPolicyProviderGroup },
+    credentials: { items: credentials, setItems: setCredentials, selected: selectedCredential, selectedId: selectedCredentialId, setSelectedId: setSelectedCredentialId, form: credentialForm, setForm: setCredentialForm, issuedKey, setIssuedKey, issue: issueCredential, revoke: revokeCredential },
+    connections: { items: connections, setItems: setConnections, setEnabled: setProviderConnection },
+    bindings: { items: bindings, setItems: setBindings, selected: selectedBinding, selectedKey: selectedBindingKey, setSelectedKey: setSelectedBindingKey, form: bindingForm, setForm: setBindingForm, save: saveBinding, edit: editBinding, startNew: startNewBinding },
+    upstream: { items: upstreamGrants, setItems: setUpstreamGrants, selected: selectedUpstreamGrant, selectedKey: selectedUpstreamGrantKey, setSelectedKey: setSelectedUpstreamGrantKey, form: upstreamGrantForm, setForm: setUpstreamGrantForm, save: saveUpstreamGrant, revoke: revokeUpstreamGrant, refresh: refreshUpstreamGrant, authorize: authorizeUpstreamGrant, edit: editUpstreamGrant, startNew: startNewUpstreamGrant },
+    assignments: { items: assignmentRules, setItems: setAssignmentRules, selected: selectedAssignmentRule, selectedId: selectedAssignmentRuleId, setSelectedId: setSelectedAssignmentRuleId, form: assignmentRuleForm, setForm: setAssignmentRuleForm, save: saveAssignmentRule, reconcile: reconcileAssignments, edit: editAssignmentRule, startNew: startNewAssignmentRule },
+    users: { items: users, setItems: setUsers, selected: selectedUser, selectedEmail: selectedUserEmail, setSelectedEmail: setSelectedUserEmail, form: accessForm, setForm: setAccessForm, error: userError, setError: setUserError, save: saveUser, startNew: startNewUser },
+    hydrateAdmin,
+    hydrateUser,
+    hydrateDemo,
+  };
+}

--- a/admin/src/hooks/use-catalog.ts
+++ b/admin/src/hooks/use-catalog.ts
@@ -1,0 +1,66 @@
+import { useMemo, useState } from "react";
+import { accessMap, readinessMap, routeKey } from "../domain";
+import { demo, emptyRoutes } from "../ui-config";
+import { catalogModels, matchesServiceQuery, serviceItems } from "../ui-helpers";
+import type { EntitlementsResponse, ProviderReadiness, ProviderRow, RouteCatalog } from "../ui-types";
+
+export function useCatalog(allowDemo: boolean) {
+  const [providers, setProviders] = useState<ProviderRow[]>(allowDemo ? demo.providers : []);
+  const [routes, setRoutes] = useState<RouteCatalog>(allowDemo ? demo.routes : emptyRoutes);
+  const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
+  const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(
+    allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {},
+  );
+  const [query, setQuery] = useState("");
+  const [kind, setKind] = useState("all");
+  const [selectedServiceId, setSelectedServiceId] = useState(demo.services[0]?.id ?? "");
+  const accessByProvider = useMemo(() => accessMap(entitlements), [entitlements]);
+  const services = useMemo(
+    () => serviceItems(providers, routes, providerReadiness, accessByProvider),
+    [accessByProvider, providerReadiness, providers, routes],
+  );
+  const models = useMemo(() => catalogModels(routes), [routes]);
+  const serviceRoutes = useMemo(() => routes.manifestProxy, [routes]);
+  const kinds = useMemo(() => ["all", ...Array.from(new Set(services.map((item) => item.kind))).sort()], [services]);
+  const filteredServices = useMemo(
+    () => services.filter((item) => (kind === "all" || item.kind === kind) && matchesServiceQuery(item, query)),
+    [kind, query, services],
+  );
+  const selectedService = services.find((item) => item.id === selectedServiceId) ?? services[0];
+
+  function setEntitlementsWithReadiness(next: EntitlementsResponse | null) {
+    setEntitlements(next);
+    if (next) setProviderReadiness(readinessMap(next.providers.map((item) => item.readiness)));
+  }
+
+  function mergeReadiness(readiness: ProviderReadiness[]) {
+    setProviderReadiness((current) => ({ ...current, ...readinessMap(readiness) }));
+  }
+
+  return {
+    providers,
+    setProviders,
+    routes,
+    setRoutes,
+    entitlements,
+    setEntitlements: setEntitlementsWithReadiness,
+    providerReadiness,
+    setProviderReadiness,
+    mergeReadiness,
+    accessByProvider,
+    services,
+    models,
+    serviceRoutes,
+    query,
+    setQuery,
+    kind,
+    setKind,
+    kinds,
+    filteredServices,
+    selectedService,
+    selectedServiceId,
+    setSelectedServiceId,
+    modelFor: (id: string) => models.find((model) => model.id === id) ?? models[0],
+    serviceRouteFor: (key: string) => serviceRoutes.find((route) => routeKey(route) === key) ?? serviceRoutes[0],
+  };
+}

--- a/admin/src/hooks/use-playground.ts
+++ b/admin/src/hooks/use-playground.ts
@@ -1,0 +1,161 @@
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  playgroundAccessEndpoint,
+  playgroundBlocker,
+  playgroundPayload,
+  playgroundResponseText,
+  playgroundServicePreset,
+  routeKey,
+  errorMessage,
+} from "../domain";
+import { demo, demoServicePreset } from "../ui-config";
+import { catalogModels, createPlaygroundTurn, playgroundRequest } from "../ui-helpers";
+import type { CatalogModel } from "../domain";
+import type { PlaygroundForm, PlaygroundTurn, ProviderAccess, ProviderReadiness, RouteCatalog } from "../ui-types";
+
+interface PlaygroundDependencies {
+  gatewayOrigin: string;
+  demoMode: boolean;
+  setStatus: (status: string) => void;
+  models: CatalogModel[];
+  serviceRoutes: RouteCatalog["manifestProxy"];
+  accessByProvider: Map<string, ProviderAccess>;
+  providerReadiness: Record<string, ProviderReadiness>;
+}
+
+export function usePlayground({ gatewayOrigin, demoMode, setStatus, models, serviceRoutes, accessByProvider, providerReadiness }: PlaygroundDependencies) {
+  const [form, setForm] = useState<PlaygroundForm>({
+    mode: "model",
+    model: catalogModels(demo.routes)[0]?.id ?? "",
+    endpoint: "/v1/chat/completions",
+    ...demoServicePreset,
+    system: "You are concise and useful.",
+    prompt: "Say hello from ClawRouter in one short sentence.",
+    maxTokens: "128",
+    temperature: "0.7",
+  });
+  const [turns, setTurns] = useState<PlaygroundTurn[]>([]);
+  const [selectedTurnId, setSelectedTurnId] = useState("");
+  const [requestMode, setRequestMode] = useState<"json" | "curl">("json");
+  const [error, setError] = useState("");
+  const selectedModel = models.find((model) => model.id === form.model) ?? models[0];
+  const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === form.serviceRoute) ?? serviceRoutes[0];
+
+  useEffect(() => {
+    if (models.length && !models.some((model) => model.id === form.model)) {
+      setForm((current) => ({ ...current, model: models[0].id }));
+    }
+  }, [form.model, models]);
+
+  useEffect(() => {
+    if (serviceRoutes.length && !serviceRoutes.some((route) => routeKey(route) === form.serviceRoute)) {
+      setForm((current) => ({ ...current, ...playgroundServicePreset(serviceRoutes[0]) }));
+    }
+  }, [form.serviceRoute, serviceRoutes]);
+
+  async function run(event: FormEvent) {
+    event.preventDefault();
+    const startedAt = performance.now();
+    const prompt = form.mode === "model" ? form.prompt.trim() : form.servicePayload.trim();
+    const conversation = form.mode === "model"
+      ? turns.filter((turn) => turn.mode === "model" && !turn.error).flatMap((turn) => [
+        { role: "user" as const, content: turn.prompt },
+        { role: "assistant" as const, content: turn.response },
+      ])
+      : [];
+    const provider = form.mode === "model" ? selectedModel?.provider ?? "unknown" : selectedServiceRoute?.provider ?? "unknown";
+    const model = form.mode === "model" ? selectedModel?.id ?? form.model : selectedServiceRoute?.endpoint ?? form.serviceRoute;
+    const endpoint = playgroundAccessEndpoint(form, selectedServiceRoute);
+    let requestPreview = "";
+    try {
+      if (!prompt) throw new Error(form.mode === "model" ? "Enter a message." : "Enter a JSON request body.");
+      setError("");
+      setStatus("running playground");
+      const guard = playgroundBlocker(form, selectedModel, selectedServiceRoute, accessByProvider, providerReadiness);
+      if (guard) throw new Error(guard);
+      const payload = playgroundPayload(form, selectedServiceRoute, conversation);
+      requestPreview = JSON.stringify(payload, null, 2);
+      if (demoMode) {
+        const raw = JSON.stringify(form.mode === "model"
+          ? { provider: selectedModel?.provider, model: selectedModel?.id, output: "Hello from ClawRouter demo mode." }
+          : { provider: selectedServiceRoute?.provider, route: selectedServiceRoute?.route, output: "Service proxy demo response." }, null, 2);
+        appendTurn({ prompt, raw, requestPreview, provider, model, endpoint, status: 200, startedAt, retention: "demo" });
+        if (form.mode === "model") setForm((current) => ({ ...current, prompt: "" }));
+        setStatus("playground ready");
+        return;
+      }
+      const result = await playgroundRequest(gatewayOrigin, endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const responseError = result.ok ? undefined : playgroundResponseText(result.raw) || `Request failed with HTTP ${result.status}`;
+      appendTurn({ prompt, raw: result.raw, requestPreview, provider, model, endpoint, status: result.status, startedAt, retention: result.retention, error: responseError });
+      if (responseError) {
+        setError(responseError);
+        setStatus(responseError);
+        return;
+      }
+      if (form.mode === "model") setForm((current) => ({ ...current, prompt: "" }));
+      setStatus("playground ready");
+    } catch (caught) {
+      const message = errorMessage(caught);
+      if (prompt) appendTurn({ prompt, raw: message, requestPreview, provider, model, endpoint, status: null, startedAt, retention: "unknown", error: message });
+      setError(message);
+      setStatus(message);
+    }
+  }
+
+  function appendTurn(input: {
+    prompt: string;
+    raw: string;
+    requestPreview: string;
+    provider: string;
+    model: string;
+    endpoint: string;
+    status: number | null;
+    startedAt: number;
+    retention: string;
+    error?: string;
+  }) {
+    const turn = createPlaygroundTurn({
+      mode: form.mode,
+      prompt: input.prompt,
+      raw: input.raw,
+      request: input.requestPreview,
+      provider: input.provider,
+      model: input.model,
+      endpoint: input.endpoint,
+      status: input.status,
+      durationMs: Math.max(1, Math.round(performance.now() - input.startedAt)),
+      retention: input.retention,
+      error: input.error,
+    });
+    setTurns((current) => [...current, turn]);
+    setSelectedTurnId(turn.id);
+  }
+
+  function resetConversation() {
+    setTurns([]);
+    setSelectedTurnId("");
+    setError("");
+    setForm((current) => ({ ...current, prompt: "" }));
+  }
+
+  return {
+    form,
+    setForm,
+    turns,
+    setTurns,
+    selectedTurnId,
+    setSelectedTurnId,
+    requestMode,
+    setRequestMode,
+    error,
+    setError,
+    selectedModel,
+    selectedServiceRoute,
+    run,
+    resetConversation,
+  };
+}

--- a/admin/src/hooks/use-session.ts
+++ b/admin/src/hooks/use-session.ts
@@ -1,0 +1,55 @@
+import { useMemo, useState } from "react";
+import { consoleStatusPresentation } from "../status-display";
+import { adminViews, demo, emptySession, initialViewFromPath, viewPaths } from "../ui-config";
+import { isLocalDemoAllowed } from "../ui-helpers";
+import type { SessionResponse, View } from "../ui-types";
+
+export function useSession() {
+  const gatewayOrigin = window.location.origin;
+  const allowDemo = isLocalDemoAllowed();
+  const [view, setView] = useState<View>(initialViewFromPath);
+  const [value, setValue] = useState<SessionResponse>(allowDemo ? demo.session : emptySession);
+  const [status, setStatus] = useState(allowDemo ? "local demo data loaded" : "loading");
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(allowDemo ? Date.now() : null);
+  const [demoMode, setDemoMode] = useState(allowDemo);
+  const statusPresentation = useMemo(() => consoleStatusPresentation(status, demoMode), [demoMode, status]);
+  const busy = statusPresentation.tone === "pending";
+
+  function navigateTo(nextView: View, replace = false) {
+    setView(nextView);
+    const nextPath = viewPaths[nextView];
+    if (window.location.pathname === nextPath) return;
+    const nextUrl = `${nextPath}${window.location.search}${window.location.hash}`;
+    if (replace) window.history.replaceState(null, "", nextUrl);
+    else window.history.pushState(null, "", nextUrl);
+  }
+
+  function enforceRoleView() {
+    if (status !== "loading" && value.role !== "admin" && adminViews.has(view)) navigateTo("catalog", true);
+  }
+
+  function syncViewFromPath() {
+    setView(initialViewFromPath());
+  }
+
+  return {
+    gatewayOrigin,
+    allowDemo,
+    view,
+    setView,
+    value,
+    setValue,
+    status,
+    setStatus,
+    lastUpdatedAt,
+    setLastUpdatedAt,
+    demoMode,
+    setDemoMode,
+    statusPresentation,
+    statusTone: statusPresentation.tone,
+    busy,
+    navigateTo,
+    enforceRoleView,
+    syncViewFromPath,
+  };
+}

--- a/admin/src/hooks/use-usage.ts
+++ b/admin/src/hooks/use-usage.ts
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { policyUsageFallback, tenantSummaryFallback } from "../domain";
+import { demo, emptyUsageSnapshot } from "../ui-config";
+import { adminOverviewFromPolicies, request, settled } from "../ui-helpers";
+import type { AccessPolicy, AdminOverview, AdminTenantSummary, AdminUsageRow, ProviderRow, ProxyCredential, RouteCatalog, UsageSnapshot } from "../ui-types";
+
+export function useUsage(allowDemo: boolean) {
+  const [adminOverview, setAdminOverview] = useState<AdminOverview | null>(allowDemo ? demo.overview : null);
+  const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
+  const [rows, setRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
+  const [snapshot, setSnapshot] = useState<UsageSnapshot>(allowDemo ? demo.usage : emptyUsageSnapshot);
+  const [loaded, setLoaded] = useState(allowDemo);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  function reset() {
+    setAdminOverview(null);
+    setTenantSummaries([]);
+    setRows([]);
+    setSnapshot(emptyUsageSnapshot);
+    setLoaded(false);
+  }
+
+  function resetLedger() {
+    setRows([]);
+    setSnapshot(emptyUsageSnapshot);
+    setLoaded(false);
+  }
+
+  function syncDemoAdmin(policies: AccessPolicy[], credentials: ProxyCredential[], providers: ProviderRow[], routes: RouteCatalog, syncRows = false) {
+    setAdminOverview(adminOverviewFromPolicies(policies, credentials, providers, routes));
+    setTenantSummaries(tenantSummaryFallback(policies, credentials));
+    if (syncRows) {
+      setRows(policies.map(policyUsageFallback));
+      setLoaded(true);
+    }
+  }
+
+  async function refreshLedger(gatewayOrigin: string, setStatus: (status: string) => void, showError: boolean) {
+    const result = await settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/admin/usage"));
+    if (result.ok) {
+      setRows(result.value.policies ?? result.value.keys ?? []);
+      setSnapshot(result.value.usage);
+      setLoaded(true);
+      return;
+    }
+    resetLedger();
+    if (showError) setStatus(`usage ledger unavailable: ${result.error}`);
+  }
+
+  return {
+    adminOverview,
+    setAdminOverview,
+    tenantSummaries,
+    setTenantSummaries,
+    rows,
+    setRows,
+    snapshot,
+    setSnapshot,
+    loaded,
+    setLoaded,
+    refreshKey,
+    requestRefresh: () => setRefreshKey((current) => current + 1),
+    reset,
+    resetLedger,
+    syncDemoAdmin,
+    refreshLedger,
+  };
+}

--- a/admin/src/main.tsx
+++ b/admin/src/main.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { AppShell } from "./app-shell";
-import { useConsoleController } from "./use-console-controller";
+import { ConsoleControllerProvider } from "./console-controller-context";
 import "./style.css";
 
-function App() { return <AppShell controller={useConsoleController()} />; }
+function App() { return <ConsoleControllerProvider><AppShell /></ConsoleControllerProvider>; }
 createRoot(document.getElementById("root")!).render(<React.StrictMode><App /></React.StrictMode>);

--- a/admin/src/use-console-controller.ts
+++ b/admin/src/use-console-controller.ts
@@ -1,87 +1,66 @@
+import { useCallback, useEffect, useRef } from "react";
+import { effectiveAccess, errorMessage, policyUsageFallback, tenantSummaryFallback } from "./domain";
+import { useAccessAdmin } from "./hooks/use-access-admin";
+import { useCatalog } from "./hooks/use-catalog";
+import { usePlayground } from "./hooks/use-playground";
+import { useSession } from "./hooks/use-session";
+import { useUsage } from "./hooks/use-usage";
+import { installAutoRefresh } from "./auto-refresh";
+import { demo } from "./ui-config";
+import { adminOverviewFromPolicies, localDemoRole, oauthCallbackStatus, request, settled } from "./ui-helpers";
+import type {
+  AccessPolicy,
+  AccessUser,
+  AdminOverview,
+  AdminTenantSummary,
+  AdminUsageRow,
+  AssignmentRule,
+  EntitlementsResponse,
+  PolicyBinding,
+  ProviderConnection,
+  ProviderReadiness,
+  ProviderResponse,
+  ProxyCredential,
+  RefreshOptions,
+  RouteCatalog,
+  SessionResponse,
+  UpstreamGrant,
+  UsageSnapshot,
+  UsageSummary,
+} from "./ui-types";
+
 export function useConsoleController() {
-  const [view, setView] = useState<View>(initialViewFromPath);
-  const gatewayOrigin = window.location.origin;
-  const allowDemo = isLocalDemoAllowed();
-  const [session, setSession] = useState<SessionResponse>(allowDemo ? demo.session : emptySession);
-  const [providers, setProviders] = useState<ProviderRow[]>(allowDemo ? demo.providers : []);
-  const [routes, setRoutes] = useState<RouteCatalog>(allowDemo ? demo.routes : emptyRoutes);
-  const [keys, setKeys] = useState<AccessPolicy[]>(allowDemo ? demo.keys : []);
-  const [credentials, setCredentials] = useState<ProxyCredential[]>(allowDemo ? demo.credentials : []);
-  const [connections, setConnections] = useState<ProviderConnection[]>(allowDemo ? demo.connections : []);
-  const [upstreamGrants, setUpstreamGrants] = useState<UpstreamGrant[]>(allowDemo ? demo.upstreamGrants : []);
-  const [assignmentRules, setAssignmentRules] = useState<AssignmentRule[]>(allowDemo ? demo.assignmentRules : []);
-  const [policyDataLoaded, setPolicyDataLoaded] = useState(allowDemo);
-  const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
-  const [bindings, setBindings] = useState<PolicyBinding[]>(allowDemo ? demo.bindings : []);
-  const [adminOverview, setAdminOverview] = useState<AdminOverview | null>(allowDemo ? demo.overview : null);
-  const [tenantSummaries, setTenantSummaries] = useState<AdminTenantSummary[]>(allowDemo ? demo.tenants : []);
-  const [usageRows, setUsageRows] = useState<AdminUsageRow[]>(allowDemo ? demo.usageRows : []);
-  const [usageSnapshot, setUsageSnapshot] = useState<UsageSnapshot>(allowDemo ? demo.usage : emptyUsageSnapshot);
-  const [usageLoaded, setUsageLoaded] = useState(allowDemo);
-  const [usageRefreshKey, setUsageRefreshKey] = useState(0);
-  const [entitlements, setEntitlements] = useState<EntitlementsResponse | null>(allowDemo ? demo.entitlements : null);
-  const [providerReadiness, setProviderReadiness] = useState<Record<string, ProviderReadiness>>(allowDemo ? readinessMap(demo.entitlements.providers.map((item) => item.readiness)) : {});
-  const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
-  const [credentialForm, setCredentialForm] = useState<CredentialForm>(allowDemo && demo.keys[0] ? { credentialId: "", policyId: demo.keys[0].policyId, principalId: "" } : defaultCredential);
-  const [bindingForm, setBindingForm] = useState<BindingForm>(allowDemo && demo.keys[0] ? { ...defaultBinding, policyId: demo.keys[0].policyId } : defaultBinding);
-  const [upstreamGrantForm, setUpstreamGrantForm] = useState<UpstreamGrantForm>(allowDemo && demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
-  const [assignmentRuleForm, setAssignmentRuleForm] = useState<AssignmentRuleForm>(allowDemo && demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
-  const [accessTab, setAccessTab] = useState<AccessTab>(initialAccessTab);
-  const [accessForm, setAccessForm] = useState<AccessForm>(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
-  const [query, setQuery] = useState("");
-  const [kind, setKind] = useState("all");
-  const [selectedServiceId, setSelectedServiceId] = useState(demo.services[0]?.id ?? "");
-  const [selectedPolicyId, setSelectedPolicyId] = useState(allowDemo ? demo.keys[0]?.policyId ?? "" : "");
-  const [selectedCredentialId, setSelectedCredentialId] = useState(allowDemo ? demo.credentials[0]?.credentialId ?? "" : "");
-  const [selectedBindingKey, setSelectedBindingKey] = useState(allowDemo ? bindingKey(demo.bindings[0]) : "");
-  const [selectedUpstreamGrantKey, setSelectedUpstreamGrantKey] = useState(allowDemo ? demo.upstreamGrants[0]?.key ?? "" : "");
-  const [selectedAssignmentRuleId, setSelectedAssignmentRuleId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
-  const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
-  const [status, setStatus] = useState(allowDemo ? "local demo data loaded" : "loading");
-  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(allowDemo ? Date.now() : null);
-  const [demoMode, setDemoMode] = useState(allowDemo);
-  const [issuedKey, setIssuedKey] = useState("");
-  const [policyError, setPolicyError] = useState("");
-  const [userError, setUserError] = useState("");
-  const [playgroundError, setPlaygroundError] = useState("");
-  const [playground, setPlayground] = useState<PlaygroundForm>({
-    mode: "model",
-    model: catalogModels(demo.routes)[0]?.id ?? "",
-    endpoint: "/v1/chat/completions",
-    ...demoServicePreset,
-    system: "You are concise and useful.",
-    prompt: "Say hello from ClawRouter in one short sentence.",
-    maxTokens: "128",
-    temperature: "0.7",
-  });
-  const [playgroundTurns, setPlaygroundTurns] = useState<PlaygroundTurn[]>([]);
-  const [selectedPlaygroundTurnId, setSelectedPlaygroundTurnId] = useState("");
-  const [requestMode, setRequestMode] = useState<"json" | "curl">("json");
+  const session = useSession();
+  const catalog = useCatalog(session.allowDemo);
+  const usage = useUsage(session.allowDemo);
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
   const refreshBackgroundRef = useRef(false);
   const refreshRef = useRef<(options?: RefreshOptions) => Promise<void>>(async () => undefined);
-  const accessByProvider = useMemo(() => accessMap(entitlements), [entitlements]);
-  const services = useMemo(() => serviceItems(providers, routes, providerReadiness, accessByProvider), [accessByProvider, providerReadiness, providers, routes]);
-  const models = useMemo(() => catalogModels(routes), [routes]);
-  const serviceRoutes = useMemo(() => routes.manifestProxy, [routes]);
-  const kinds = useMemo(() => ["all", ...Array.from(new Set(services.map((item) => item.kind))).sort()], [services]);
-  const filteredServices = useMemo(() => {
-    return services.filter((item) => (kind === "all" || item.kind === kind) && matchesServiceQuery(item, query));
-  }, [kind, query, services]);
-  const selectedService = services.find((item) => item.id === selectedServiceId) ?? services[0];
-  const selectedPolicy = keys.find((key) => key.policyId === selectedPolicyId);
-  const selectedCredential = credentials.find((credential) => credential.credentialId === selectedCredentialId);
-  const selectedBinding = bindings.find((binding) => bindingKey(binding) === selectedBindingKey);
-  const selectedUpstreamGrant = upstreamGrants.find((grant) => grant.key === selectedUpstreamGrantKey);
-  const selectedAssignmentRule = assignmentRules.find((rule) => rule.ruleId === selectedAssignmentRuleId);
-  const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
-  const selectedModel = models.find((model) => model.id === playground.model) ?? models[0];
-  const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === playground.serviceRoute) ?? serviceRoutes[0];
-  const statusPresentation = consoleStatusPresentation(status, demoMode);
-  const busy = statusPresentation.tone === "pending";
-  const busyRef = useRef(busy);
-  busyRef.current = busy;
-  const statusTone = statusPresentation.tone;
+  const refreshCurrent = useCallback(() => refreshRef.current(), []);
+  const access = useAccessAdmin({
+    allowDemo: session.allowDemo,
+    gatewayOrigin: session.gatewayOrigin,
+    session: session.value,
+    demoMode: session.demoMode,
+    providers: catalog.providers,
+    routes: catalog.routes,
+    setStatus: session.setStatus,
+    setProviderReadiness: catalog.setProviderReadiness,
+    refresh: refreshCurrent,
+    syncDemoAdmin: usage.syncDemoAdmin,
+  });
+  const playground = usePlayground({
+    gatewayOrigin: session.gatewayOrigin,
+    demoMode: session.demoMode,
+    setStatus: session.setStatus,
+    models: catalog.models,
+    serviceRoutes: catalog.serviceRoutes,
+    accessByProvider: catalog.accessByProvider,
+    providerReadiness: catalog.providerReadiness,
+  });
+  const busyRef = useRef(session.busy);
+  busyRef.current = session.busy;
+
   useEffect(() => {
     if (localDemoRole() === "user") {
       loadUserDemo();
@@ -89,44 +68,37 @@ export function useConsoleController() {
     }
     void refresh();
   }, []);
+
   useEffect(() => {
     refreshRef.current = refresh;
   });
+
   useEffect(() => {
-    if (demoMode) return;
+    if (session.demoMode) return;
     return installAutoRefresh(() => {
       if (!busyRef.current) void refreshRef.current({ background: true });
     });
-  }, [demoMode]);
+  }, [session.demoMode]);
+
   useEffect(() => {
-    const onPopState = () => setView(initialViewFromPath());
+    const onPopState = () => session.syncViewFromPath();
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [session.setView]);
+
   useEffect(() => {
-    if (status !== "loading" && session.role !== "admin" && adminViews.has(view)) navigateTo("catalog", true);
-  }, [session.role, status, view]);
+    session.enforceRoleView();
+  }, [session.value.role, session.status, session.view]);
+
   useEffect(() => {
-    if ((view === "home" || view === "usage") && session.role === "admin" && policyDataLoaded && !demoMode && !usageLoaded) {
-      void refreshUsageLedger();
+    if ((session.view === "home" || session.view === "usage") && session.value.role === "admin" && access.loaded && !session.demoMode && !usage.loaded) {
+      void usage.refreshLedger(session.gatewayOrigin, session.setStatus, session.view === "usage");
     }
-  }, [demoMode, policyDataLoaded, session.role, usageLoaded, usageRefreshKey, view]);
-  useEffect(() => {
-    if (models.length && !models.some((model) => model.id === playground.model)) {
-      setPlayground((current) => ({ ...current, model: models[0].id }));
-    }
-  }, [models, playground.model]);
-  useEffect(() => {
-    if (serviceRoutes.length && !serviceRoutes.some((route) => routeKey(route) === playground.serviceRoute)) {
-      const route = serviceRoutes[0];
-      setPlayground((current) => ({ ...current, ...playgroundServicePreset(route) }));
-    }
-  }, [playground.serviceRoute, serviceRoutes]);
+  }, [access.loaded, session.demoMode, session.value.role, session.view, usage.loaded, usage.refreshKey]);
+
   function refresh(options: RefreshOptions = {}): Promise<void> {
     if (refreshPromiseRef.current) {
-      if (!options.background && refreshBackgroundRef.current) {
-        return refreshPromiseRef.current.then(() => refresh(options));
-      }
+      if (!options.background && refreshBackgroundRef.current) return refreshPromiseRef.current.then(() => refresh(options));
       return refreshPromiseRef.current;
     }
     refreshBackgroundRef.current = options.background ?? false;
@@ -139,827 +111,188 @@ export function useConsoleController() {
     refreshPromiseRef.current = operation;
     return operation;
   }
+
   async function refreshData({ background = false }: RefreshOptions) {
     try {
       if (!background) {
-        setStatus("loading");
-        setPolicyDataLoaded(false);
+        session.setStatus("loading");
+        access.setLoaded(false);
       }
       const [sessionData, providerData, routeData] = await Promise.all([
-        request<SessionResponse>(gatewayOrigin, "/v1/session"),
-        request<ProviderResponse>(gatewayOrigin, "/v1/providers"),
-        request<RouteCatalog>(gatewayOrigin, "/v1/routes"),
+        request<SessionResponse>(session.gatewayOrigin, "/v1/session"),
+        request<ProviderResponse>(session.gatewayOrigin, "/v1/providers"),
+        request<RouteCatalog>(session.gatewayOrigin, "/v1/routes"),
       ]);
-      setSession(sessionData);
-      setProviders(providerData.providers);
-      setRoutes(routeData);
-      let refreshWarnings = sessionData.entitlementsError ? [`entitlements unavailable: ${sessionData.entitlementsError}`] : [];
-      const sessionEntitlements = sessionData.entitlements
-        ? { session: sessionData, providers: sessionData.entitlements.providers, contentRetention: sessionData.contentRetention ?? { enabled: false, retentionDays: 30, policyEnabled: false, userExempt: false } }
+      session.setValue(sessionData);
+      catalog.setProviders(providerData.providers);
+      catalog.setRoutes(routeData);
+      let warnings = sessionData.entitlementsError ? [`entitlements unavailable: ${sessionData.entitlementsError}`] : [];
+      const sessionEntitlements: EntitlementsResponse | null = sessionData.entitlements
+        ? {
+          session: sessionData,
+          providers: sessionData.entitlements.providers,
+          contentRetention: sessionData.contentRetention ?? { enabled: false, retentionDays: 30, policyEnabled: false, userExempt: false },
+        }
         : null;
-      if (sessionEntitlements) {
-        setEntitlements(sessionEntitlements);
-        setProviderReadiness(readinessMap(sessionEntitlements.providers.map((item) => item.readiness)));
-      } else {
-        const entitlementResult = await settled(() => request<EntitlementsResponse>(gatewayOrigin, "/v1/entitlements"));
-        if (entitlementResult.ok) {
-          setEntitlements(entitlementResult.value);
-          setProviderReadiness(readinessMap(entitlementResult.value.providers.map((item) => item.readiness)));
-        } else {
-          setEntitlements(null);
-          refreshWarnings = [...refreshWarnings, `entitlements unavailable: ${entitlementResult.error}`];
+      if (sessionEntitlements) catalog.setEntitlements(sessionEntitlements);
+      else {
+        const entitlementResult = await settled(() => request<EntitlementsResponse>(session.gatewayOrigin, "/v1/entitlements"));
+        if (entitlementResult.ok) catalog.setEntitlements(entitlementResult.value);
+        else {
+          catalog.setEntitlements(null);
+          warnings = [...warnings, `entitlements unavailable: ${entitlementResult.error}`];
         }
       }
-      if (sessionData.role === "admin") {
-        const [policyData, credentialData, connectionData, userData, bindingData, readinessData, upstreamGrantData, assignmentRuleData] = await Promise.all([
-          request<{ policies: AccessPolicy[] }>(gatewayOrigin, "/v1/admin/policies"),
-          request<{ credentials: ProxyCredential[] }>(gatewayOrigin, "/v1/admin/credentials"),
-          request<{ connections: ProviderConnection[] }>(gatewayOrigin, "/v1/admin/connections"),
-          request<{ users: AccessUser[] }>(gatewayOrigin, "/v1/admin/access-users"),
-          request<{ bindings: PolicyBinding[] }>(gatewayOrigin, "/v1/admin/policy-bindings"),
-          request<{ providers: ProviderReadiness[] }>(gatewayOrigin, "/v1/admin/provider-status"),
-          request<{ grants: UpstreamGrant[] }>(gatewayOrigin, "/v1/admin/upstream-grants"),
-          request<{ rules: AssignmentRule[] }>(gatewayOrigin, "/v1/admin/assignment-rules"),
-        ]);
-        setKeys(policyData.policies);
-        setCredentials(credentialData.credentials);
-        setConnections(connectionData.connections);
-        setUpstreamGrants(upstreamGrantData.grants);
-        setAssignmentRules(assignmentRuleData.rules);
-        setUsers(userData.users);
-        setBindings(bindingData.bindings);
-        if (!background) {
-          const refreshedPolicy = policyData.policies.find((policy) => policy.policyId === selectedPolicyId) ?? policyData.policies[0];
-          setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
-          setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
-          const refreshedCredential = credentialData.credentials.find((credential) => credential.credentialId === selectedCredentialId) ?? credentialData.credentials[0];
-          setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
-          setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? policyData.policies[0]?.policyId ?? "", principalId: "" });
-          const refreshedBinding = bindingData.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? bindingData.bindings[0];
-          setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
-          setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
-          const refreshedGrant = upstreamGrantData.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? upstreamGrantData.grants[0];
-          setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
-          setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerData.providers[0]?.id ?? "", tokenRef: providerData.providers[0]?.id ?? "" });
-          const refreshedRule = assignmentRuleData.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? assignmentRuleData.rules[0];
-          setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
-          setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
-          const refreshedUser = userData.users.find((user) => user.email === selectedUserEmail) ?? userData.users[0];
-          setSelectedUserEmail(refreshedUser?.email ?? "");
-          setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, bindingData.bindings) : defaultAccess);
-        }
-        setProviderReadiness((current) => ({ ...current, ...readinessMap(readinessData.providers) }));
-        const [overviewResult, tenantResult, usageResult] = await Promise.all([
-          settled(() => request<AdminOverview>(gatewayOrigin, "/v1/admin/overview")),
-          settled(() => request<{ tenants: AdminTenantSummary[] }>(gatewayOrigin, "/v1/admin/tenants")),
-          background
-            ? settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/admin/usage"))
-            : Promise.resolve(null),
-        ]);
-        if (overviewResult.ok) {
-          setAdminOverview(overviewResult.value);
-        } else {
-          setAdminOverview(adminOverviewFromPolicies(policyData.policies, credentialData.credentials, providerData.providers, routeData));
-          refreshWarnings = [...refreshWarnings, `overview unavailable: ${overviewResult.error}`];
-        }
-        if (tenantResult.ok) {
-          setTenantSummaries(tenantResult.value.tenants);
-        } else {
-          setTenantSummaries(tenantSummaryFallback(policyData.policies, credentialData.credentials));
-          refreshWarnings = [...refreshWarnings, `tenant summary unavailable: ${tenantResult.error}`];
-        }
-        if (usageResult?.ok) {
-          setUsageRows(usageResult.value.policies ?? usageResult.value.keys ?? []);
-          setUsageSnapshot(usageResult.value.usage);
-          setUsageLoaded(true);
-        } else if (usageResult) {
-          refreshWarnings = [...refreshWarnings, `usage ledger unavailable: ${usageResult.error}`];
-        } else {
-          setUsageRows([]);
-          setUsageSnapshot(emptyUsageSnapshot);
-          setUsageLoaded(false);
-        }
-        setPolicyDataLoaded(true);
-        if (!background && view === "usage") setUsageRefreshKey((current) => current + 1);
-      } else {
-        const user = {
-          email: sessionData.email ?? "access-user",
-          role: sessionData.role,
-          tenantId: sessionData.tenantId ?? "default",
-          enabled: sessionData.authenticated,
-          groups: sessionData.groups ?? [],
-          contentRetentionDisabled: sessionData.contentRetention?.userExempt ?? false,
-        };
-        setKeys([]);
-        setCredentials([]);
-        setConnections([]);
-        setUpstreamGrants([]);
-        setAssignmentRules([]);
-        setPolicyDataLoaded(false);
-        setUsers([user]);
-        setBindings([]);
-        setAdminOverview(null);
-        setTenantSummaries([]);
-        const accessUsageResult = await settled(() => request<{ policies: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/session/usage"));
-        if (accessUsageResult.ok) {
-          setUsageRows(accessUsageResult.value.policies);
-          setUsageSnapshot(accessUsageResult.value.usage);
-          setUsageLoaded(true);
-        } else {
-          setUsageRows([]);
-          setUsageSnapshot(emptyUsageSnapshot);
-          setUsageLoaded(false);
-          refreshWarnings = [...refreshWarnings, `quota status unavailable: ${accessUsageResult.error}`];
-        }
-        setSelectedUserEmail(user.email);
-        setAccessForm(accessFormFromUser(user, []));
-      }
-      setDemoMode(false);
-      setLastUpdatedAt(Date.now());
-      if (!background) setStatus(refreshWarnings.length ? refreshWarnings.join("; ") : oauthCallbackStatus() ?? "connected");
-    } catch (error) {
-      const message = errorMessage(error);
-      if (allowDemo) {
-        setSession(demo.session);
-        setProviders(demo.providers);
-        setRoutes(demo.routes);
-        setKeys(demo.keys);
-        setCredentials(demo.credentials);
-        setConnections(demo.connections);
-        setUpstreamGrants(demo.upstreamGrants);
-        setAssignmentRules(demo.assignmentRules);
-        setPolicyDataLoaded(true);
-        setUsers(demo.users);
-        setBindings(demo.bindings);
-        setAdminOverview(demo.overview);
-        setTenantSummaries(demo.tenants);
-        setUsageRows(demo.usageRows);
-        setUsageSnapshot(demo.usage);
-        setUsageLoaded(true);
-        setEntitlements(demo.entitlements);
-        setProviderReadiness(readinessMap(demo.entitlements.providers.map((item) => item.readiness)));
-        setSelectedPolicyId(demo.keys[0]?.policyId ?? "");
-        setPolicyForm(demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
-        setSelectedCredentialId(demo.credentials[0]?.credentialId ?? "");
-        setCredentialForm({ credentialId: "", policyId: demo.keys[0]?.policyId ?? "", principalId: "" });
-        setSelectedBindingKey(demo.bindings[0] ? bindingKey(demo.bindings[0]) : "");
-        setBindingForm(demo.bindings[0] ? bindingFormFromBinding(demo.bindings[0]) : defaultBinding);
-        setSelectedUpstreamGrantKey(demo.upstreamGrants[0]?.key ?? "");
-        setUpstreamGrantForm(demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
-        setSelectedAssignmentRuleId(demo.assignmentRules[0]?.ruleId ?? "");
-        setAssignmentRuleForm(demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
-        setSelectedUserEmail(demo.users[0]?.email ?? "");
-        setAccessForm(demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
-        setDemoMode(true);
-        setLastUpdatedAt(Date.now());
-        setStatus("local demo data loaded");
+      if (sessionData.role === "admin") warnings = await loadAdminData(sessionData, providerData, routeData, background, warnings);
+      else warnings = await loadUserData(sessionData, warnings);
+      session.setDemoMode(false);
+      session.setLastUpdatedAt(Date.now());
+      if (!background) session.setStatus(warnings.length ? warnings.join("; ") : oauthCallbackStatus() ?? "connected");
+    } catch (caught) {
+      const message = errorMessage(caught);
+      if (session.allowDemo) {
+        loadAdminDemo();
         return;
       }
-      setDemoMode(false);
-      if (!background) setStatus(`load error: ${message}`);
+      session.setDemoMode(false);
+      if (!background) session.setStatus(`load error: ${message}`);
     }
   }
+
+  async function loadAdminData(sessionData: SessionResponse, providerData: ProviderResponse, routeData: RouteCatalog, background: boolean, initialWarnings: string[]) {
+    let warnings = initialWarnings;
+    const [policyData, credentialData, connectionData, userData, bindingData, readinessData, upstreamGrantData, assignmentRuleData] = await Promise.all([
+      request<{ policies: AccessPolicy[] }>(session.gatewayOrigin, "/v1/admin/policies"),
+      request<{ credentials: ProxyCredential[] }>(session.gatewayOrigin, "/v1/admin/credentials"),
+      request<{ connections: ProviderConnection[] }>(session.gatewayOrigin, "/v1/admin/connections"),
+      request<{ users: AccessUser[] }>(session.gatewayOrigin, "/v1/admin/access-users"),
+      request<{ bindings: PolicyBinding[] }>(session.gatewayOrigin, "/v1/admin/policy-bindings"),
+      request<{ providers: ProviderReadiness[] }>(session.gatewayOrigin, "/v1/admin/provider-status"),
+      request<{ grants: UpstreamGrant[] }>(session.gatewayOrigin, "/v1/admin/upstream-grants"),
+      request<{ rules: AssignmentRule[] }>(session.gatewayOrigin, "/v1/admin/assignment-rules"),
+    ]);
+    access.hydrateAdmin({
+      policies: policyData.policies,
+      credentials: credentialData.credentials,
+      connections: connectionData.connections,
+      users: userData.users,
+      bindings: bindingData.bindings,
+      grants: upstreamGrantData.grants,
+      rules: assignmentRuleData.rules,
+    }, background, sessionData, providerData.providers);
+    catalog.mergeReadiness(readinessData.providers);
+    const [overviewResult, tenantResult, usageResult] = await Promise.all([
+      settled(() => request<AdminOverview>(session.gatewayOrigin, "/v1/admin/overview")),
+      settled(() => request<{ tenants: AdminTenantSummary[] }>(session.gatewayOrigin, "/v1/admin/tenants")),
+      background
+        ? settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(session.gatewayOrigin, "/v1/admin/usage"))
+        : Promise.resolve(null),
+    ]);
+    if (overviewResult.ok) usage.setAdminOverview(overviewResult.value);
+    else {
+      usage.setAdminOverview(adminOverviewFromPolicies(policyData.policies, credentialData.credentials, providerData.providers, routeData));
+      warnings = [...warnings, `overview unavailable: ${overviewResult.error}`];
+    }
+    if (tenantResult.ok) usage.setTenantSummaries(tenantResult.value.tenants);
+    else {
+      usage.setTenantSummaries(tenantSummaryFallback(policyData.policies, credentialData.credentials));
+      warnings = [...warnings, `tenant summary unavailable: ${tenantResult.error}`];
+    }
+    if (usageResult?.ok) {
+      usage.setRows(usageResult.value.policies ?? usageResult.value.keys ?? []);
+      usage.setSnapshot(usageResult.value.usage);
+      usage.setLoaded(true);
+    } else if (usageResult) warnings = [...warnings, `usage ledger unavailable: ${usageResult.error}`];
+    else usage.resetLedger();
+    if (!background && session.view === "usage") usage.requestRefresh();
+    return warnings;
+  }
+
+  async function loadUserData(sessionData: SessionResponse, initialWarnings: string[]) {
+    let warnings = initialWarnings;
+    const user: AccessUser = {
+      email: sessionData.email ?? "access-user",
+      role: sessionData.role,
+      tenantId: sessionData.tenantId ?? "default",
+      enabled: sessionData.authenticated,
+      groups: sessionData.groups ?? [],
+      contentRetentionDisabled: sessionData.contentRetention?.userExempt ?? false,
+    };
+    access.hydrateUser(user);
+    usage.setAdminOverview(null);
+    usage.setTenantSummaries([]);
+    const result = await settled(() => request<{ policies: AdminUsageRow[]; usage: UsageSnapshot }>(session.gatewayOrigin, "/v1/session/usage"));
+    if (result.ok) {
+      usage.setRows(result.value.policies);
+      usage.setSnapshot(result.value.usage);
+      usage.setLoaded(true);
+    } else {
+      usage.resetLedger();
+      warnings = [...warnings, `quota status unavailable: ${result.error}`];
+    }
+    return warnings;
+  }
+
+  function loadAdminDemo() {
+    session.setValue(demo.session);
+    catalog.setProviders(demo.providers);
+    catalog.setRoutes(demo.routes);
+    catalog.setEntitlements(demo.entitlements);
+    access.hydrateDemo();
+    usage.setAdminOverview(demo.overview);
+    usage.setTenantSummaries(demo.tenants);
+    usage.setRows(demo.usageRows);
+    usage.setSnapshot(demo.usage);
+    usage.setLoaded(true);
+    session.setDemoMode(true);
+    session.setLastUpdatedAt(Date.now());
+    session.setStatus("local demo data loaded");
+  }
+
   function loadUserDemo() {
     const user = demo.users.find((candidate) => candidate.email === "research@example.com") ?? demo.users.find((candidate) => candidate.role === "user")!;
-    const access = effectiveAccess(user, demo.keys, demo.bindings, demo.services);
-    const policyIds = new Set(access.policies.map((policy) => policy.policyId));
-    const providers = new Set(access.services.map((service) => service.provider));
-    const providerUsage = demo.usage.providers.filter((provider) => providers.has(provider.provider));
-    const usageSummary = providerUsage.reduce<UsageSummary>((summary, provider) => ({
-      ...summary,
-      requestCount: summary.requestCount + provider.requestCount,
-      successCount: summary.successCount + provider.successCount,
-      errorCount: summary.errorCount + provider.errorCount,
-      totalTokens: summary.totalTokens + provider.totalTokens,
-      actualCostMicros: summary.actualCostMicros + provider.actualCostMicros,
+    const effective = effectiveAccess(user, demo.keys, demo.bindings, demo.services);
+    const policyIds = new Set(effective.policies.map((policy) => policy.policyId));
+    const providerIds = new Set(effective.services.map((service) => service.provider));
+    const providerUsage = demo.usage.providers.filter((provider) => providerIds.has(provider.provider));
+    const summary = providerUsage.reduce<UsageSummary>((current, provider) => ({
+      ...current,
+      requestCount: current.requestCount + provider.requestCount,
+      successCount: current.successCount + provider.successCount,
+      errorCount: current.errorCount + provider.errorCount,
+      totalTokens: current.totalTokens + provider.totalTokens,
+      actualCostMicros: current.actualCostMicros + provider.actualCostMicros,
     }), { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 });
-    const entitlements = {
+    const entitlements: EntitlementsResponse = {
       session: { ...demo.session, ...user, auth: "demo" },
       contentRetention: {
-        enabled: !user.contentRetentionDisabled && access.policies.some((policy) => policy.retainRequestContent),
+        enabled: !user.contentRetentionDisabled && effective.policies.some((policy) => policy.retainRequestContent),
         retentionDays: 30,
-        policyEnabled: access.policies.some((policy) => policy.retainRequestContent),
+        policyEnabled: effective.policies.some((policy) => policy.retainRequestContent),
         userExempt: user.contentRetentionDisabled,
       },
       providers: demo.entitlements.providers.map((provider) => ({
         ...provider,
-        allowed: providers.has(provider.provider),
+        allowed: providerIds.has(provider.provider),
         policies: provider.policies.filter((policyId) => policyIds.has(policyId)),
       })),
     };
-    setSession(entitlements.session);
-    setProviders(demo.providers);
-    setRoutes(demo.routes);
-    setKeys([]);
-    setCredentials([]);
-    setConnections([]);
-    setUpstreamGrants([]);
-    setAssignmentRules([]);
-    setPolicyDataLoaded(false);
-    setUsers([user]);
-    setBindings([]);
-    setAdminOverview(null);
-    setTenantSummaries([]);
-    setUsageRows(access.policies.map(policyUsageFallback));
-    setUsageSnapshot({ ...demo.usage, summary: usageSummary, providers: providerUsage, events: [] });
-    setUsageLoaded(true);
-    setEntitlements(entitlements);
-    setProviderReadiness(readinessMap(entitlements.providers.map((provider) => provider.readiness)));
-    setLastUpdatedAt(Date.now());
-    setStatus("local user demo loaded");
-    setDemoMode(true);
+    session.setValue(entitlements.session);
+    catalog.setProviders(demo.providers);
+    catalog.setRoutes(demo.routes);
+    catalog.setEntitlements(entitlements);
+    access.hydrateUser(user);
+    usage.setAdminOverview(null);
+    usage.setTenantSummaries([]);
+    usage.setRows(effective.policies.map(policyUsageFallback));
+    usage.setSnapshot({ ...demo.usage, summary, providers: providerUsage, events: [] });
+    usage.setLoaded(true);
+    session.setLastUpdatedAt(Date.now());
+    session.setStatus("local user demo loaded");
+    session.setDemoMode(true);
   }
-  async function savePolicy(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      setStatus("saving policy");
-      const policyProviders = knownPolicyProviders(policyForm.providers, providers.map((provider) => provider.id));
-      if (!policyForm.allProviders && !policyProviders.length) throw new Error("select at least one service");
-      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.policyId)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
-      const existingPolicy = keys.some((key) => key.policyId === policyForm.policyId);
-      if (existingPolicy && selectedPolicyId !== policyForm.policyId) throw new Error("policy id already exists; select it from the policy list to edit it");
-      const next: AccessPolicy = {
-        policyId: policyForm.policyId,
-        enabled: policyForm.enabled,
-        providers: policyForm.allProviders ? [] : policyProviders,
-        tenantId: policyForm.tenantId || "default",
-        tokenRole: policyForm.tokenRole || null,
-        monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,
-        requestCostMicros: optionalNumber(policyForm.requestCostMicros) ?? null,
-        retainRequestContent: policyForm.retainRequestContent,
-      };
-      if (demoMode) {
-        applyDemoKeys((current) => [next, ...current.filter((key) => key.policyId !== next.policyId)]);
-        setSelectedPolicyId(next.policyId);
-        setStatus("saved policy");
-        return;
-      }
-      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyForm.policyId)}`, {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ...next, allProviders: policyForm.allProviders }),
-      });
-      await refresh();
-      setSelectedPolicyId(next.policyId);
-      setPolicyForm(policyFormFromPolicy(next));
-      setStatus("saved policy");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function issueCredential(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const policyId = credentialForm.policyId || selectedPolicyId;
-      if (!keys.some((policy) => policy.policyId === policyId)) throw new Error("select a policy for this credential");
-      const credentialId = credentialForm.credentialId.trim() || `${policyId}_${Date.now().toString(36)}`;
-      if (!/^[A-Za-z0-9_]{4,}$/.test(credentialId)) throw new Error("credential id must use 4 or more letters, numbers, or underscores");
-      if (credentials.some((credential) => credential.credentialId === credentialId)) throw new Error("credential id already exists");
-      setStatus("issuing credential");
-      const secret = generateSecret();
-      const revealedKey = `clawrouter-live-${credentialId}-${secret}`;
-      const principalId = credentialForm.principalId.trim().toLowerCase() || null;
-      if (principalId && !principalId.includes("@")) throw new Error("owner must be a valid user email");
-      const next: ProxyCredential = { credentialId, policyId, enabled: true, principalId };
-      if (demoMode) {
-        applyDemoCredentials((current) => [next, ...current]);
-      } else {
-        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}`, {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: true, policyId, principalId, secretSha256: await sha256Hex(secret) }),
-        });
-        setIssuedKey(revealedKey);
-        try {
-          await refresh();
-        } catch (error) {
-          const message = errorMessage(error);
-          setSelectedCredentialId(credentialId);
-          setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
-          setPolicyError(`credential issued, but refresh failed: ${message}`);
-          setStatus("issued credential; refresh failed");
-          return;
-        }
-      }
-      setSelectedCredentialId(credentialId);
-      setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
-      setIssuedKey(revealedKey);
-      setStatus("issued credential");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function revokeCredential(credentialId: string) {
-    try {
-      setStatus(`revoking ${credentialId}`);
-      if (demoMode) {
-        applyDemoCredentials((current) => current.map((credential) => credential.credentialId === credentialId ? { ...credential, enabled: false } : credential));
-      } else {
-        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}/revoke`, { method: "POST" });
-        await refresh();
-      }
-      setIssuedKey("");
-      setStatus(`revoked ${credentialId}`);
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function saveBinding(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const principalId = bindingForm.principalId.trim().toLowerCase();
-      if (!principalId) throw new Error("principal is required");
-      if (!bindingForm.policyId) throw new Error("select a policy");
-      const next: PolicyBinding = {
-        policyId: bindingForm.policyId,
-        principalType: bindingForm.principalType,
-        principalId,
-        enabled: bindingForm.enabled,
-        priority: optionalNumber(bindingForm.priority) ?? 100,
-      };
-      setStatus("saving binding");
-      if (demoMode) {
-        setBindings((current) => [next, ...current.filter((binding) => bindingKey(binding) !== bindingKey(next))]);
-      } else {
-        await request<PolicyBinding>(gatewayOrigin, "/v1/admin/policy-bindings", {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(next),
-        });
-        await refresh();
-      }
-      setSelectedBindingKey(bindingKey(next));
-      setBindingForm(bindingFormFromBinding(next));
-      setStatus("saved binding");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function saveUpstreamGrant(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const scopeId = upstreamGrantForm.scopeId.trim();
-      const tokenRef = upstreamGrantForm.tokenRef.trim();
-      const provider = upstreamGrantForm.provider.trim();
-      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
-      const credentialBundle = parseCredentialBundle(upstreamGrantForm.credentialBundle);
-      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() || Object.keys(credentialBundle).length : upstreamGrantForm.accessToken.trim();
-      if (!selectedUpstreamGrant && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
-      const body = {
-        version: 1,
-        enabled: upstreamGrantForm.enabled,
-        kind: upstreamGrantForm.kind,
-        provider,
-        label: upstreamGrantForm.label.trim() || undefined,
-        tokenType: selectedUpstreamGrant?.tokenType ?? "Bearer",
-        expiresAt: upstreamGrantForm.expiresAt.trim() || undefined,
-        scopes: selectedUpstreamGrant?.scopes ?? [],
-        accountId: upstreamGrantForm.accountId.trim() || undefined,
-        subscription: selectedUpstreamGrant?.subscription ?? undefined,
-        ...(upstreamGrantForm.credential.trim() ? { credential: upstreamGrantForm.credential.trim() } : {}),
-        ...(Object.keys(credentialBundle).length ? { credentials: credentialBundle } : {}),
-        ...(upstreamGrantForm.accessToken.trim() ? { accessToken: upstreamGrantForm.accessToken.trim() } : {}),
-        ...(upstreamGrantForm.refreshToken.trim() ? { refreshToken: upstreamGrantForm.refreshToken.trim() } : {}),
-      };
-      const path = `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}`;
-      setStatus("saving upstream grant");
-      let saved: UpstreamGrant;
-      if (demoMode) {
-        saved = demoGrantFromForm(upstreamGrantForm, selectedUpstreamGrant);
-        setUpstreamGrants((current) => [saved, ...current.filter((grant) => grant.key !== saved.key)]);
-      } else {
-        saved = await request<UpstreamGrant>(gatewayOrigin, path, {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
-        });
-        await refresh();
-      }
-      setSelectedUpstreamGrantKey(saved.key);
-      setUpstreamGrantForm(upstreamGrantFormFromGrant(saved));
-      setStatus("saved upstream grant");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function revokeUpstreamGrant(grant: UpstreamGrant) {
-    try {
-      setPolicyError("");
-      setStatus("revoking upstream grant");
-      let revoked: UpstreamGrant;
-      if (demoMode) {
-        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
-        setUpstreamGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
-      } else {
-        revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" });
-        await refresh();
-      }
-      setSelectedUpstreamGrantKey(revoked.key);
-      setUpstreamGrantForm(upstreamGrantFormFromGrant(revoked));
-      setStatus("revoked upstream grant");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function refreshUpstreamGrant(grant: UpstreamGrant) {
-    try {
-      setPolicyError("");
-      setStatus("refreshing upstream grant");
-      if (!demoMode) {
-        const refreshed = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/refresh`, { method: "POST" });
-        await refresh();
-        setSelectedUpstreamGrantKey(refreshed.key);
-        setUpstreamGrantForm(upstreamGrantFormFromGrant(refreshed));
-      }
-      setStatus("refreshed upstream grant");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function authorizeUpstreamGrant() {
-    try {
-      setPolicyError("");
-      const scopeId = upstreamGrantForm.scopeId.trim();
-      const tokenRef = upstreamGrantForm.tokenRef.trim();
-      const provider = upstreamGrantForm.provider.trim();
-      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
-      if (!providers.find((item) => item.id === provider)?.auth?.authorization) throw new Error("selected provider does not support browser OAuth");
-      setStatus("connecting upstream grant");
-      if (demoMode) {
-        setStatus("browser OAuth unavailable in local demo");
-        return;
-      }
-      const result = await request<{ authorizationUrl: string }>(gatewayOrigin, `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}/authorize`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ provider }),
-      });
-      window.location.assign(result.authorizationUrl);
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function saveAssignmentRule(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const ruleId = assignmentRuleForm.ruleId.trim();
-      if (!/^[a-z0-9_]{4,48}$/.test(ruleId)) throw new Error("rule id must use 4-48 lowercase letters, numbers, or underscores");
-      if (!assignmentRuleForm.subject.trim()) throw new Error("rule subject is required");
-      const body = {
-        version: 1,
-        enabled: assignmentRuleForm.enabled,
-        kind: assignmentRuleForm.kind,
-        subject: assignmentRuleForm.subject.trim(),
-        groups: parseGroups(assignmentRuleForm.groups),
-        policyIds: assignmentRuleForm.policyIds,
-        priority: optionalNumber(assignmentRuleForm.priority) ?? 100,
-        revokeOnLoss: assignmentRuleForm.revokeOnLoss,
-        provenance: assignmentRuleForm.provenance.trim(),
-      };
-      setStatus("saving assignment rule");
-      let saved: AssignmentRule;
-      if (demoMode) {
-        saved = demoRuleFromForm(assignmentRuleForm);
-        setAssignmentRules((current) => [saved, ...current.filter((rule) => rule.ruleId !== saved.ruleId)]);
-      } else {
-        saved = await request<AssignmentRule>(gatewayOrigin, `/v1/admin/assignment-rules/${encodeURIComponent(ruleId)}`, {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
-        });
-        await refresh();
-      }
-      setSelectedAssignmentRuleId(saved.ruleId);
-      setAssignmentRuleForm(assignmentRuleFormFromRule(saved));
-      setStatus("saved assignment rule");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function reconcileAssignments() {
-    try {
-      setPolicyError("");
-      setStatus("reconciling assignments");
-      if (!demoMode) {
-        await request<{ results: unknown[] }>(gatewayOrigin, "/v1/admin/assignment-rules/reconcile", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ all: true }),
-        });
-        await refresh();
-      }
-      setStatus("reconciled assignments");
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function setProviderConnection(providerId: string, enabled: boolean) {
-    try {
-      setStatus(`${enabled ? "enabling" : "disabling"} ${providerId}`);
-      const current = connections.find((connection) => connection.providerId === providerId);
-      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null };
-      if (demoMode) {
-        setConnections((items) => [next, ...items.filter((item) => item.providerId !== providerId)]);
-        setProviderReadiness((items) => {
-          const readiness = items[providerId];
-          return readiness ? { ...items, [providerId]: { ...readiness, connectionEnabled: enabled, executable: enabled && readiness.configPresent && (!readiness.oauthGrantRequired || readiness.oauthGrantCount > 0), status: enabled ? (readiness.verified ? "verified" : "unverified") : "disabled" } } : items;
-        });
-      } else {
-        await request<ProviderConnection>(gatewayOrigin, `/v1/admin/connections/${encodeURIComponent(providerId)}`, {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(next),
-        });
-        await refresh();
-      }
-      setStatus(`${enabled ? "enabled" : "disabled"} ${providerId}`);
-    } catch (error) {
-      const message = errorMessage(error);
-      setStatus(message);
-    }
-  }
-  async function refreshUsageLedger() {
-    if (demoMode || session.role !== "admin") return;
-    const result = await settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(gatewayOrigin, "/v1/admin/usage"));
-    if (result.ok) {
-      setUsageRows(result.value.policies ?? result.value.keys ?? []);
-      setUsageSnapshot(result.value.usage);
-      setUsageLoaded(true);
-      return;
-    }
-    setUsageRows([]);
-    setUsageSnapshot(emptyUsageSnapshot);
-    setUsageLoaded(false);
-    if (view === "usage") setStatus(`usage ledger unavailable: ${result.error}`);
-  }
-  async function saveUser(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setUserError("");
-      setStatus("saving user");
-      const email = accessForm.email.trim().toLowerCase();
-      if (!email.includes("@")) throw new Error("enter a valid email");
-      const next: AccessUser = {
-        email,
-        role: selectedUser?.role ?? "user",
-        tenantId: accessForm.tenantId || "default",
-        enabled: accessForm.enabled,
-        groups: parseGroups(accessForm.groups),
-        contentRetentionDisabled: accessForm.contentRetentionDisabled,
-      };
-      const nextBindings = reconcileDirectUserBindings(bindings, email, keys, accessForm.policyIds);
-      if (demoMode) {
-        setUsers((current) => [next, ...current.filter((user) => user.email !== email)]);
-        setBindings(nextBindings);
-        setSelectedUserEmail(email);
-        setAccessForm(accessFormFromUser(next, nextBindings));
-        setStatus("saved user");
-        return;
-      }
-      await request<{ user: AccessUser; bindings: PolicyBinding[] }>(gatewayOrigin, `/v1/admin/access-user-grants/${encodeURIComponent(email)}`, {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          tenantId: next.tenantId,
-          enabled: next.enabled,
-          groups: next.groups,
-          contentRetentionDisabled: next.contentRetentionDisabled,
-          policyIds: accessForm.policyIds,
-        }),
-      });
-      try {
-        await refresh();
-      } catch (error) {
-        const message = errorMessage(error);
-        setSelectedUserEmail(email);
-        setAccessForm(accessFormFromUser(next, nextBindings));
-        setUserError(`saved user, but refresh failed: ${message}`);
-        setStatus("saved user; refresh failed");
-        return;
-      }
-      setSelectedUserEmail(email);
-      setAccessForm(accessFormFromUser(next, nextBindings));
-      setStatus("saved user");
-    } catch (error) {
-      const message = errorMessage(error);
-      setUserError(message);
-      setStatus(message);
-      await refresh().catch(() => undefined);
-      setUserError(message);
-      setStatus(message);
-    }
-  }
-  async function revoke(policyId: string) {
-    try {
-      setStatus(`revoking ${policyId}`);
-      if (demoMode) {
-        applyDemoKeys((current) => current.map((key) => (key.policyId === policyId ? { ...key, enabled: false } : key)));
-        setStatus(`revoked ${policyId}`);
-        return;
-      }
-      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyId)}/revoke`, { method: "POST" });
-      await refresh();
-      setStatus(`revoked ${policyId}`);
-    } catch (error) {
-      const message = errorMessage(error);
-      setPolicyError(message);
-      setStatus(message);
-    }
-  }
-  async function runPlayground(event: FormEvent) {
-    event.preventDefault();
-    const startedAt = performance.now();
-    const prompt = playground.mode === "model" ? playground.prompt.trim() : playground.servicePayload.trim();
-    const conversation = playground.mode === "model"
-      ? playgroundTurns.filter((turn) => turn.mode === "model" && !turn.error).flatMap((turn) => [
-        { role: "user" as const, content: turn.prompt },
-        { role: "assistant" as const, content: turn.response },
-      ])
-      : [];
-    const provider = playground.mode === "model" ? selectedModel?.provider ?? "unknown" : selectedServiceRoute?.provider ?? "unknown";
-    const model = playground.mode === "model" ? selectedModel?.id ?? playground.model : selectedServiceRoute?.endpoint ?? playground.serviceRoute;
-    const endpoint = playgroundAccessEndpoint(playground, selectedServiceRoute);
-    let requestPreview = "";
-    try {
-      if (!prompt) throw new Error(playground.mode === "model" ? "Enter a message." : "Enter a JSON request body.");
-      setPlaygroundError("");
-      setStatus("running playground");
-      const guard = playgroundBlocker(playground, selectedModel, selectedServiceRoute, accessByProvider, providerReadiness);
-      if (guard) throw new Error(guard);
-      const payload = playgroundPayload(playground, selectedServiceRoute, conversation);
-      requestPreview = JSON.stringify(payload, null, 2);
-      if (demoMode) {
-        const raw = JSON.stringify(playground.mode === "model"
-          ? { provider: selectedModel?.provider, model: selectedModel?.id, output: "Hello from ClawRouter demo mode." }
-          : { provider: selectedServiceRoute?.provider, route: selectedServiceRoute?.route, output: "Service proxy demo response." }, null, 2);
-        const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw, request: requestPreview, provider, model, endpoint, status: 200, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: "demo" });
-        setPlaygroundTurns((current) => [...current, turn]);
-        setSelectedPlaygroundTurnId(turn.id);
-        if (playground.mode === "model") setPlayground((current) => ({ ...current, prompt: "" }));
-        setStatus("playground ready");
-        return;
-      }
-      const method = "POST";
-      const result = await playgroundRequest(gatewayOrigin, playgroundAccessEndpoint(playground, selectedServiceRoute), {
-        method,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const responseError = result.ok ? undefined : playgroundResponseText(result.raw) || `Request failed with HTTP ${result.status}`;
-      const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw: result.raw, request: requestPreview, provider, model, endpoint, status: result.status, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: result.retention, error: responseError });
-      setPlaygroundTurns((current) => [...current, turn]);
-      setSelectedPlaygroundTurnId(turn.id);
-      if (responseError) {
-        setPlaygroundError(responseError);
-        setStatus(responseError);
-        return;
-      }
-      if (playground.mode === "model") setPlayground((current) => ({ ...current, prompt: "" }));
-      setStatus("playground ready");
-    } catch (error) {
-      const message = errorMessage(error);
-      const turn = createPlaygroundTurn({ mode: playground.mode, prompt, raw: message, request: requestPreview, provider, model, endpoint, status: null, durationMs: Math.max(1, Math.round(performance.now() - startedAt)), retention: "unknown", error: message });
-      if (prompt) {
-        setPlaygroundTurns((current) => [...current, turn]);
-        setSelectedPlaygroundTurnId(turn.id);
-      }
-      setPlaygroundError(message);
-      setStatus(message);
-    }
-  }
-  function editPolicy(key: AccessPolicy) {
-    setIssuedKey("");
-    setSelectedPolicyId(key.policyId);
-    setPolicyForm(policyFormFromPolicy(key));
-    setCredentialForm((current) => ({ ...current, policyId: key.policyId }));
-    setBindingForm((current) => ({ ...current, policyId: key.policyId }));
-  }
-  function startNewPolicy() {
-    setIssuedKey("");
-    setPolicyError("");
-    setSelectedPolicyId("");
-    setPolicyForm({ ...defaultPolicy, policyId: "", tenantId: session.tenantId ?? "default", providers: [...defaultPolicy.providers] });
-  }
-  function startNewUser() {
-    setSelectedUserEmail("");
-    setUserError("");
-    setAccessForm({ ...defaultAccess, email: "", tenantId: session.tenantId ?? "default" });
-  }
-  function editBinding(binding: PolicyBinding) {
-    setSelectedBindingKey(bindingKey(binding));
-    setBindingForm(bindingFormFromBinding(binding));
-  }
-  function editUpstreamGrant(grant: UpstreamGrant) {
-    setSelectedUpstreamGrantKey(grant.key);
-    setUpstreamGrantForm(upstreamGrantFormFromGrant(grant));
-  }
-  function startNewUpstreamGrant() {
-    const provider = providers[0]?.id ?? "";
-    setSelectedUpstreamGrantKey("");
-    setUpstreamGrantForm({ ...defaultUpstreamGrant, scopeId: selectedPolicyId || keys[0]?.policyId || "default", provider, tokenRef: provider });
-  }
-  function editAssignmentRule(rule: AssignmentRule) {
-    setSelectedAssignmentRuleId(rule.ruleId);
-    setAssignmentRuleForm(assignmentRuleFormFromRule(rule));
-  }
-  function startNewAssignmentRule() {
-    setSelectedAssignmentRuleId("");
-    setAssignmentRuleForm({ ...defaultAssignmentRule, policyIds: [] });
-  }
-  function applyPreset(role: keyof typeof rolePresets) {
-    const preset = rolePresets[role];
-    const available = new Set(providers.map((provider) => provider.id));
-    setPolicyForm((current) => ({
-      ...current,
-      tokenRole: role,
-      monthlyBudgetMicros: currencyInput(optionalNumber(preset.budget)),
-      requestCostMicros: preset.request,
-      providers: preset.providers.length ? preset.providers.filter((id) => available.has(id)) : providers.map((provider) => provider.id),
-      allProviders: false,
-    }));
-  }
-  function togglePolicyProvider(providerId: string) {
-    const allProviderIds = providers.map((provider) => provider.id);
-    setPolicyForm((current) => ({
-      ...current,
-      allProviders: false,
-      providers: (current.allProviders ? allProviderIds : current.providers).includes(providerId)
-        ? (current.allProviders ? allProviderIds : current.providers).filter((id) => id !== providerId)
-        : [...current.providers, providerId].sort(),
-    }));
-  }
-  function setPolicyProviderGroup(providerIds: string[], checked: boolean) {
-    const allProviderIds = providers.map((provider) => provider.id);
-    setPolicyForm((current) => {
-      if (current.allProviders && checked) return current;
-      const selected = current.allProviders ? allProviderIds : current.providers;
-      return {
-        ...current,
-        allProviders: false,
-        providers: checked
-          ? unique([...selected, ...providerIds]).sort()
-          : selected.filter((id) => !providerIds.includes(id)),
-      };
-    });
-  }
-  function applyDemoKeys(updater: (current: AccessPolicy[]) => AccessPolicy[]) {
-    setKeys((current) => {
-      const next = updater(current);
-      setAdminOverview(adminOverviewFromPolicies(next, credentials, providers, routes));
-      setTenantSummaries(tenantSummaryFallback(next, credentials));
-      setUsageRows(next.map(policyUsageFallback));
-      setUsageLoaded(true);
-      return next;
-    });
-  }
-  function applyDemoCredentials(updater: (current: ProxyCredential[]) => ProxyCredential[]) {
-    setCredentials((current) => {
-      const next = updater(current);
-      setAdminOverview(adminOverviewFromPolicies(keys, next, providers, routes));
-      setTenantSummaries(tenantSummaryFallback(keys, next));
-      return next;
-    });
-  }
-  function navigateTo(nextView: View, replace = false) {
-    setView(nextView);
-    const nextPath = viewPaths[nextView];
-    if (window.location.pathname !== nextPath) {
-      const nextUrl = `${nextPath}${window.location.search}${window.location.hash}`;
-      if (replace) window.history.replaceState(null, "", nextUrl);
-      else window.history.pushState(null, "", nextUrl);
-    }
-  }
-return { view, setView, gatewayOrigin, allowDemo, session, setSession, providers, setProviders, routes, setRoutes, keys, setKeys, credentials, setCredentials, connections, setConnections, upstreamGrants, setUpstreamGrants, assignmentRules, setAssignmentRules, policyDataLoaded, setPolicyDataLoaded, users, setUsers, bindings, setBindings, adminOverview, setAdminOverview, tenantSummaries, setTenantSummaries, usageRows, setUsageRows, usageSnapshot, setUsageSnapshot, usageLoaded, setUsageLoaded, usageRefreshKey, setUsageRefreshKey, entitlements, setEntitlements, providerReadiness, setProviderReadiness, policyForm, setPolicyForm, credentialForm, setCredentialForm, bindingForm, setBindingForm, upstreamGrantForm, setUpstreamGrantForm, assignmentRuleForm, setAssignmentRuleForm, accessTab, setAccessTab, accessForm, setAccessForm, query, setQuery, kind, setKind, selectedServiceId, setSelectedServiceId, selectedPolicyId, setSelectedPolicyId, selectedCredentialId, setSelectedCredentialId, selectedBindingKey, setSelectedBindingKey, selectedUpstreamGrantKey, setSelectedUpstreamGrantKey, selectedAssignmentRuleId, setSelectedAssignmentRuleId, selectedUserEmail, setSelectedUserEmail, status, setStatus, lastUpdatedAt, setLastUpdatedAt, demoMode, setDemoMode, issuedKey, setIssuedKey, policyError, setPolicyError, userError, setUserError, playgroundError, setPlaygroundError, playground, setPlayground, playgroundTurns, setPlaygroundTurns, selectedPlaygroundTurnId, setSelectedPlaygroundTurnId, requestMode, setRequestMode, refreshPromiseRef, refreshBackgroundRef, refreshRef, accessByProvider, services, models, serviceRoutes, kinds, filteredServices, selectedService, selectedPolicy, selectedCredential, selectedBinding, selectedUpstreamGrant, selectedAssignmentRule, selectedUser, selectedModel, selectedServiceRoute, statusPresentation, busy, busyRef, statusTone, refresh, refreshData, loadUserDemo, savePolicy, issueCredential, revokeCredential, saveBinding, saveUpstreamGrant, revokeUpstreamGrant, refreshUpstreamGrant, authorizeUpstreamGrant, saveAssignmentRule, reconcileAssignments, setProviderConnection, refreshUsageLedger, saveUser, revoke, runPlayground, editPolicy, startNewPolicy, startNewUser, editBinding, editUpstreamGrant, startNewUpstreamGrant, editAssignmentRule, startNewAssignmentRule, applyPreset, togglePolicyProvider, setPolicyProviderGroup, applyDemoKeys, applyDemoCredentials, navigateTo };
+
+  return { session, catalog, access, usage, playground, refresh };
 }
-import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
-import { installAutoRefresh } from "./auto-refresh";
-import { consoleStatusPresentation } from "./status-display";
-import { accessFormFromUser,accessMap,bindingFormFromBinding,bindingKey,catalogProviderIds,currencyInput,effectiveAccess,errorMessage,grantNamesForService,knownPolicyProviders,optionalCurrencyMicros,optionalNumber,parseGroups,playgroundAccessEndpoint,playgroundBlockedForService,playgroundBlocker,playgroundPayload,playgroundResponseText,playgroundServicePreset,playgroundSupportsTemperature,policyCoversProvider,policyUsageFallback,preferredPlaygroundEndpoint,readinessLabel,readinessMap,readinessTone,reconcileDirectUserBindings,routeKey,serviceOutcome,tenantSummaryFallback,unique } from "./domain";
-import { adminViews, defaultAccess, defaultAssignmentRule, defaultBinding, defaultCredential, defaultPolicy, defaultUpstreamGrant, demo, demoServicePreset, emptyRoutes, emptySession, emptyUsageSnapshot, initialAccessTab, initialViewFromPath, rolePresets, viewPaths } from "./ui-config";
-import { adminOverviewFromPolicies,assignmentRuleFormFromRule,catalogModels,createPlaygroundTurn,demoGrantFromForm,demoRuleFromForm,generateSecret,isLocalDemoAllowed,localDemoRole,matchesServiceQuery,oauthCallbackStatus,parseCredentialBundle,playgroundRequest,policyFormFromPolicy,request,serviceItems,settled,sha256Hex,upstreamGrantFormFromGrant } from "./ui-helpers";
-import type { AccessForm,AccessPolicy,AccessRole,AccessTab,AccessUser,AdminOverview,AdminTenantSummary,AdminUsageRow,AssignmentRule,AssignmentRuleForm,BindingForm,BrandIcon,BudgetStatus,ContentRetention,CredentialForm,EntitlementsResponse,IconComponent,OutcomeTone,PlaygroundForm,PlaygroundHttpResponse,PlaygroundTurn,PolicyBinding,PolicyForm,ProviderAccess,ProviderConnection,ProviderReadiness,ProviderResponse,ProviderRow,ProviderUsageSummary,ProxyCredential,RefreshOptions,RetainedRequestContent,RouteCatalog,ServiceItem,ServiceOutcome,SessionResponse,UpstreamGrant,UpstreamGrantForm,UsageAuditEvent,UsageSnapshot,UsageSummary,View } from "./ui-types";
+
+export type ConsoleController = ReturnType<typeof useConsoleController>;


### PR DESCRIPTION
## Summary

- split the monolithic console controller into session, catalog, access-admin, usage, and playground hooks
- replace the flat 100+ property controller contract with grouped domain objects
- add a context facade so the application shell no longer receives the controller as a prop
- preserve refresh coordination, demo behavior, access gating, and playground request behavior

## Verification

- `pnpm check`
- `pnpm build`
- structured autoreview: clean, no actionable findings
- existing-Chrome local E2E: admin dashboard, catalog, playground, access, users, usage; demo request; policy save; browser history; user-role redirect and admin navigation gate
- browser console: no warnings or errors

## Deployment

- not required; internal frontend refactor with no runtime or API contract change

## Remaining risk

- low; refresh orchestration remains centralized while state and actions moved behind domain hooks
