### PR TITLE
refactor: isolate control-plane state and console domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make accounting finalization independently retryable, scope readiness to entitled policies, move canonical access state out of KV fallback paths, shard usage by tenant/policy, consolidate admin bootstrap refreshes, and split shared contracts and access controllers into focused modules.
 - Collapse provider-readiness connection checks into one authority lookup so cold catalog requests no longer fan out across provider Durable Objects.
 - Replace the Rust/Wasm data plane and provider compiler with a modular TypeScript Worker while preserving Durable Object storage and public API contracts.
 - Add a persistent Light/Dark console toggle, refine interactive states and page alignment, and simplify the signed-in identity footer.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Current implementation target:
 - TypeScript data plane on Cloudflare Workers
 - Durable Object budget ledgers
 - serialized Durable Object access-control authority
+- tenant/policy-sharded Durable Object usage ledgers
 - TypeScript admin/control UI
 - declarative service provider manifests
 - OpenClaw-native `clawrouter-` key routing
-- Cloudflare KV-backed migration and compatibility records, version 1
-  API-key/OAuth/subscription grants, and provider health
+- Cloudflare KV-backed one-time migration seeds, version 1
+  API-key/OAuth/subscription grants, assignment rules, and provider health
 
 ## Provider Registry
 
@@ -110,6 +111,7 @@ The Worker currently exposes:
 - `POST /v1/proxy/<provider>/<endpoint>`
 - `<METHOD> /v1/native/<provider>/<provider-native-path>`
 - `GET /v1/admin/overview`
+- `GET /v1/admin/bootstrap`
 - `GET /v1/admin/tenants`
 - `GET /v1/admin/usage`
 - `GET /v1/admin/policies`
@@ -146,8 +148,7 @@ OpenAI-compatible proxy requests route by the request body `model` field, for
 example `openai/gpt-4.1-mini`. Before an upstream provider secret is used, the
 Worker verifies the issued credential and its policy from serialized
 `ACCESS_CONTROL` Durable Object authority. `credentials/<credential-id>` and
-`policies/<policy-id>` in `POLICY_KV` seed migration and remain compatibility
-copies:
+`policies/<policy-id>` in `POLICY_KV` are one-time migration seeds:
 
 ```json
 {"enabled":true,"secretSha256":"<sha256 of key secret>","policyId":"team_docs","policyGeneration":"policy_..."}
@@ -218,8 +219,8 @@ curl "$CLAWROUTER_BASE_URL/v1/proxy/tavily/search" \
 The Worker resolves `provider` and `endpoint` from the compiled provider
 snapshot, applies manifest path/query/header/auth mapping, forwards the request,
 and emits a usage event to `USAGE_QUEUE`. The same Worker consumes that queue
-into the bounded `USAGE_LEDGER` reporting Durable Object and replays unsettled
-budget updates. Audit events retain
+into tenant/policy-sharded, bounded `USAGE_LEDGER` reporting Durable Objects and
+replays unsettled budget updates. Audit events retain
 identity, policy, credential, provider, route capability, model, timing,
 outcome, tokens when safely available, and cost for 30 days. Prompt and
 completion bodies are never stored in the usage ledger. LLM request bodies are stored separately for
@@ -237,9 +238,10 @@ calls without versioned pricing fail closed. Successful responses settle
 their actual token cost, including cached input when reported. SSE responses are metered
 inline without buffering the client stream. Missing or interrupted usage stays
 charged at the conservative reservation; non-2xx and transport failures refund
-the reservation. Failed settlement calls are
-persisted to `USAGE_QUEUE` for durable retry while the reservation remains
-charged fail-closed. Messages that exhaust automatic retries move to the
+the reservation. Failed settlement calls are persisted to `USAGE_QUEUE` for
+durable retry while the reservation remains charged fail-closed. Settlement and
+audit delivery are independent: failure of either cannot suppress the provider
+response or the other accounting operation. Messages that exhaust automatic retries move to the
 separate usage DLQ for operator inspection and replay before Cloudflare's
 four-day unconsumed-DLQ retention expires. Internal reservation ids are
 generated independently from caller-supplied request ids.
@@ -251,3 +253,6 @@ OAuth, SigV4, and deployment-templated providers execute through the same
 policy-enforced proxy when their manifest-declared grant and remaining runtime
 configuration are present. Provider secrets can come from scoped upstream
 grants instead of Worker-global bindings.
+
+Control-plane boundaries, migration rules, refresh behavior, and failure
+semantics are summarized in [Architecture](docs/architecture.md).

--- a/admin/src/demo-catalog.ts
+++ b/admin/src/demo-catalog.ts
@@ -1,0 +1,60 @@
+import snapshot from "../../worker/generated/provider-snapshot.json";
+import type { ProviderRow, RouteCatalog } from "./ui-types";
+
+interface CatalogSnapshot {
+  providers: Array<{
+    id: string;
+    display_name: string;
+    class: string;
+    service_kind: string;
+    meter?: string | null;
+    capabilities: Array<{ id: string; endpoint: string }>;
+    auth: { authorization?: { grantKind?: "oauth" | "subscription" } | null };
+    routing: { modelPrefixes?: string[] };
+    models: Array<{ id: string; capabilities: string[] }>;
+    endpoints: Array<{ id: string; methods: string[]; path_params: string[]; request_format?: string | null; response_format?: string | null; streaming?: string | null }>;
+  }>;
+}
+
+const catalogSnapshot = snapshot as unknown as CatalogSnapshot;
+
+export function demoCatalog(): { providers: ProviderRow[]; routes: RouteCatalog } {
+  const providers: ProviderRow[] = catalogSnapshot.providers.map((provider) => ({
+    id: provider.id,
+    display_name: provider.display_name,
+    class: provider.class,
+    service_kind: provider.service_kind,
+    meter: provider.meter,
+    capabilities: provider.capabilities.map((capability) => ({ id: capability.id })),
+    auth: provider.auth.authorization ? { authorization: { grantKind: provider.auth.authorization.grantKind } } : undefined,
+  }));
+  const routes: RouteCatalog = {
+    openaiCompatible: catalogSnapshot.providers.filter((provider) => provider.class === "openai_compatible").map((provider) => ({
+      provider: provider.id,
+      models: provider.models.map((model) => ({
+        id: model.id,
+        capabilities: model.capabilities,
+        endpoints: model.capabilities.map(unifiedPathForCapability).filter(Boolean),
+      })),
+      modelPrefixes: provider.routing.modelPrefixes,
+      endpoints: provider.capabilities.map((capability) => unifiedPathForCapability(capability.id)).filter(Boolean),
+    })),
+    manifestProxy: catalogSnapshot.providers.flatMap((provider) => provider.endpoints.map((endpoint) => ({
+      provider: provider.id,
+      endpoint: endpoint.id,
+      route: `/v1/proxy/${provider.id}/${endpoint.id}`,
+      methods: endpoint.methods,
+      pathParams: endpoint.path_params,
+      requestFormat: endpoint.request_format ?? undefined,
+      responseFormat: endpoint.response_format ?? undefined,
+      sampleModel: provider.models.find((model) => model.capabilities.some((capability) => provider.capabilities.find((item) => item.id === capability)?.endpoint === endpoint.id))?.id ?? null,
+      models: provider.models.map((model) => ({ id: model.id, capabilities: model.capabilities })),
+      streaming: endpoint.streaming != null,
+    }))),
+  };
+  return { providers, routes };
+}
+
+function unifiedPathForCapability(capability: string): string {
+  return capability === "llm.chat" ? "/v1/chat/completions" : capability === "llm.responses" ? "/v1/responses" : capability === "llm.embeddings" ? "/v1/embeddings" : "";
+}

--- a/admin/src/demo-data.ts
+++ b/admin/src/demo-data.ts
@@ -1,3 +1,13 @@
+import { accessMap, effectiveAccess, policyCoversProvider, policyUsageFallback, readinessMap, tenantSummaryFallback } from "./domain";
+import { demoCatalog } from "./demo-catalog";
+import { demoDisabledProviderIds, demoMissingConfigProviderIds } from "./ui-config";
+import { adminOverviewFromPolicies, serviceItems } from "./ui-helpers";
+import type {
+  AccessPolicy, AccessRole, AccessUser, AssignmentRule, EntitlementsResponse, PolicyBinding,
+  ProviderConnection, ProviderReadiness, ProviderRow, ProxyCredential, RouteCatalog, UpstreamGrant,
+  UsageAuditEvent, UsageSnapshot,
+} from "./ui-types";
+
 export function demoUsageSnapshot(): UsageSnapshot {
   const now = Date.now();
   const events: UsageAuditEvent[] = [
@@ -66,59 +76,10 @@ export function demoUsageEvent(id: string, occurredAt: number, principal: string
 }
 
 export function demoData() {
-  const providers = [
-    provider("anthropic", "Anthropic", "anthropic_compatible", "model_provider", ["llm.messages"]),
-    provider("aws-bedrock", "AWS Bedrock", "custom_adapter", "model_provider", ["llm.invoke", "llm.stream"]),
-    provider("azure-openai", "Azure OpenAI", "openai_compatible", "model_provider", ["llm.chat", "llm.embeddings"]),
-    provider("cloudflare-ai-gateway", "Cloudflare AI Gateway", "cloudflare_ai_gateway", "gateway_platform", ["llm.chat", "llm.responses"]),
-    provider("cohere", "Cohere", "rest_json", "model_provider", ["llm.chat", "llm.embeddings"]),
-    provider("deepseek", "DeepSeek", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("fireworks", "Fireworks AI", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("google-gemini", "Google Gemini", "rest_json", "model_provider", ["llm.generate", "llm.stream"]),
-    provider("groq", "Groq", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("huggingface", "Hugging Face", "rest_json", "model_provider", ["llm.invoke"]),
-    provider("minimax", "MiniMax", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("mistral", "Mistral AI", "openai_compatible", "model_provider", ["llm.chat", "llm.embeddings"]),
-    provider("openai", "OpenAI", "openai_compatible", "model_provider", ["llm.responses", "llm.chat", "llm.embeddings"], "subscription"),
-    provider("openrouter", "OpenRouter", "openai_compatible", "gateway_platform", ["llm.chat"]),
-    provider("perplexity", "Perplexity", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("replicate", "Replicate", "rest_json", "tool_provider", ["media.predict", "media.prediction.read"]),
-    provider("tavily", "Tavily", "rest_json", "tool_provider", ["web.search", "web.extract", "web.crawl"]),
-    provider("together", "Together AI", "openai_compatible", "model_provider", ["llm.chat"]),
-    provider("xai", "xAI", "openai_compatible", "model_provider", ["llm.chat"]),
-  ];
-  const routes: RouteCatalog = {
-    openaiCompatible: [
-      modelRoute("anthropic", ["/v1/messages"], [modelEntry("anthropic/default", ["llm.messages"], ["/v1/messages"])]),
-      modelRoute("aws-bedrock", ["/model/{model}/invoke", "/model/{model}/invoke-with-response-stream"], [modelEntry("bedrock/model", ["llm.invoke", "llm.stream"], ["/model/{model}/invoke", "/model/{model}/invoke-with-response-stream"])]),
-      modelRoute("azure-openai", ["/openai/deployments/{deployment}/chat/completions", "/openai/deployments/{deployment}/embeddings"], [modelEntry("azure-openai/deployment", ["llm.chat", "llm.embeddings"], ["/openai/deployments/{deployment}/chat/completions", "/openai/deployments/{deployment}/embeddings"])]),
-      modelRoute("cloudflare-ai-gateway", ["/"], [modelEntry("cloudflare-ai-gateway/auto", ["llm.chat", "llm.responses"], ["/"])]),
-      modelRoute("cohere", ["/v2/chat", "/v2/embed"], [modelEntry("cohere/default", ["llm.chat", "llm.embeddings"], ["/v2/chat", "/v2/embed"])]),
-      modelRoute("deepseek", ["/chat/completions"], [modelEntry("deepseek/default", ["llm.chat"], ["/chat/completions"])]),
-      modelRoute("fireworks", ["/v1/chat/completions"], [modelEntry("fireworks/default", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("google-gemini", ["/v1beta/models/{model}:generateContent", "/v1beta/models/{model}:streamGenerateContent"], [modelEntry("google/gemini-default", ["llm.generate", "llm.stream"], ["/v1beta/models/{model}:generateContent", "/v1beta/models/{model}:streamGenerateContent"])]),
-      modelRoute("groq", ["/v1/chat/completions"], [modelEntry("groq/default", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("huggingface", ["/models/{model}"], [modelEntry("huggingface/model", ["llm.invoke"], ["/models/{model}"])]),
-      modelRoute("minimax", ["/v1/chat/completions"], [modelEntry("minimax/MiniMax-M3", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("mistral", ["/v1/chat/completions", "/v1/embeddings"], [modelEntry("mistral/default", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("openai", ["/v1/responses", "/v1/chat/completions", "/v1/embeddings"], [modelEntry("openai/gpt-4.1-mini", ["llm.responses", "llm.chat"], ["/v1/responses", "/v1/chat/completions"]), modelEntry("openai/text-embedding-3-large", ["llm.embeddings"], ["/v1/embeddings"])]),
-      modelRoute("openrouter", ["/v1/chat/completions"], [modelEntry("openrouter/auto", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("perplexity", ["/chat/completions"], [modelEntry("perplexity/default", ["llm.chat"], ["/chat/completions"])]),
-      modelRoute("together", ["/v1/chat/completions"], [modelEntry("together/default", ["llm.chat"], ["/v1/chat/completions"])]),
-      modelRoute("xai", ["/v1/chat/completions"], [modelEntry("xai/default", ["llm.chat"], ["/v1/chat/completions"])]),
-    ],
-    manifestProxy: [
-      manifestRoute("openai", "responses", "/v1/proxy/openai/responses", ["POST"], [], "openai.responses", "openai/gpt-4.1-mini"),
-      manifestRoute("replicate", "predictions", "/v1/proxy/replicate/predictions", ["POST"], [], "replicate.prediction_create", "replicate/predictions"),
-      manifestRoute("replicate", "prediction", "/v1/proxy/replicate/prediction", ["GET"], ["prediction_id"], "replicate.prediction_get", "replicate/predictions"),
-      manifestRoute("tavily", "search", "/v1/proxy/tavily/search", ["POST"], [], "tavily.search", "tavily/search"),
-      manifestRoute("tavily", "extract", "/v1/proxy/tavily/extract", ["POST"], [], "tavily.extract", "tavily/extract"),
-      manifestRoute("tavily", "crawl", "/v1/proxy/tavily/crawl", ["POST"], [], "tavily.crawl", "tavily/search"),
-    ],
-  };
+  const { providers, routes } = demoCatalog();
   const keys: AccessPolicy[] = [
     { policyId: "maintainer_models", enabled: true, providers: ["anthropic", "aws-bedrock", "azure-openai", "cloudflare-ai-gateway", "cohere", "deepseek", "fireworks", "google-gemini", "groq", "huggingface", "minimax", "mistral", "openai", "openrouter", "perplexity", "together", "xai"], tenantId: "openclaw", tokenRole: "maintainer", monthlyBudgetMicros: 250000000, requestCostMicros: 1000, retainRequestContent: true },
-    { policyId: "openclaw_tools", enabled: true, providers: ["replicate", "tavily"], tenantId: "openclaw", tokenRole: "tooling", monthlyBudgetMicros: 75000000, requestCostMicros: 500, retainRequestContent: true },
+    { policyId: "openclaw_tools", enabled: true, providers: ["firecrawl", "replicate", "tavily"], tenantId: "openclaw", tokenRole: "tooling", monthlyBudgetMicros: 75000000, requestCostMicros: 500, retainRequestContent: true },
     { policyId: "user_research", enabled: true, providers: ["openai", "google-gemini", "tavily"], tenantId: "research", tokenRole: "user", monthlyBudgetMicros: 50000000, requestCostMicros: 1000, retainRequestContent: true },
     { policyId: "sandbox_eval", enabled: false, providers: ["openai"], tenantId: "sandbox", tokenRole: "sandbox", monthlyBudgetMicros: 5000000, requestCostMicros: 500, retainRequestContent: true },
   ];
@@ -205,24 +166,3 @@ export function demoReadiness(provider: ProviderRow, routes: RouteCatalog): Prov
     reasons: status === "verified" ? [] : status === "disabled" ? ["Provider connection is disabled by an administrator."] : status === "grant_required" ? ["OAuth grant required before service calls can run."] : status === "missing_config" ? ["Provider config is not present in the runtime environment."] : ["Provider is declared but has no executable route."],
   };
 }
-
-export function modelRoute(provider: string, endpoints: string[], models: RouteCatalog["openaiCompatible"][number]["models"]): RouteCatalog["openaiCompatible"][number] {
-  return { provider, endpoints, models };
-}
-
-export function modelEntry(id: string, capabilities: string[], endpoints: string[]) {
-  return { id, capabilities, endpoints };
-}
-
-export function manifestRoute(provider: string, endpoint: string, route: string, methods: string[], pathParams: string[] = [], requestFormat?: string, sampleModel?: string): RouteCatalog["manifestProxy"][number] {
-  return { provider, endpoint, route, methods, pathParams, requestFormat, sampleModel };
-}
-
-export function provider(id: string, display_name: string, providerClass: string, service_kind: string, capabilities: string[], authorizationKind?: "oauth" | "subscription"): ProviderRow {
-  return { id, display_name, class: providerClass, service_kind, meter: "request", capabilities: capabilities.map((capability) => ({ id: capability })), auth: authorizationKind ? { authorization: { grantKind: authorizationKind } } : undefined };
-}
-import { accessMap, effectiveAccess, policyCoversProvider, policyUsageFallback, readinessMap, tenantSummaryFallback } from "./domain";
-import { demoDisabledProviderIds, demoMissingConfigProviderIds } from "./ui-config";
-import { adminOverviewFromPolicies, serviceItems } from "./ui-helpers";
-import type { AccessForm,AccessPolicy,AccessRole,AccessTab,AccessUser,AdminOverview,AdminTenantSummary,AdminUsageRow,AssignmentRule,AssignmentRuleForm,BindingForm,BrandIcon,BudgetStatus,ContentRetention,CredentialForm,EntitlementsResponse,IconComponent,OutcomeTone,PlaygroundForm,PlaygroundHttpResponse,PlaygroundTurn,PolicyBinding,PolicyForm,ProviderAccess,ProviderConnection,ProviderReadiness,ProviderResponse,ProviderRow,ProviderUsageSummary,ProxyCredential,RefreshOptions,RetainedRequestContent,RouteCatalog,ServiceItem,ServiceOutcome,SessionResponse,UpstreamGrant,UpstreamGrantForm,UsageAuditEvent,UsageSnapshot,UsageSummary,View } from "./ui-types";
-

--- a/admin/src/domain.ts
+++ b/admin/src/domain.ts
@@ -1,177 +1,24 @@
-export interface RouteCatalog {
-  openaiCompatible: Array<{
-    provider: string;
-    models: Array<{ id: string; capabilities: string[]; endpoints: string[] }>;
-    modelPrefixes?: string[];
-    endpoints: string[];
-  }>;
-  manifestProxy: Array<{
-    provider: string;
-    endpoint: string;
-    route: string;
-    methods: string[];
-    pathParams?: string[];
-    requestFormat?: string;
-    sampleModel?: string | null;
-    models?: Array<{ id: string; capabilities: string[] }>;
-    streaming?: boolean | null;
-  }>;
-}
-
-export interface AccessPolicy {
-  policyId: string;
-  enabled: boolean;
-  providers: string[];
-  tenantId?: string | null;
-  tokenRole?: string | null;
-  monthlyBudgetMicros?: number | null;
-  requestCostMicros?: number | null;
-  retainRequestContent: boolean;
-}
+import type {
+  AccessForm,
+  AccessPolicy,
+  AccessUser,
+  AdminTenantSummary,
+  AdminUsageRow,
+  BindingForm,
+  PlaygroundForm,
+  PolicyBinding,
+  ProviderAccess,
+  ProviderReadiness,
+  RouteCatalog,
+  ServiceItem,
+  ServiceOutcome,
+} from "./ui-types";
 
 export interface CredentialSummary {
   credentialId: string;
   policyId: string;
   enabled: boolean;
   active?: boolean;
-}
-
-export interface ProviderReadiness {
-  id: string;
-  displayName: string;
-  class: string;
-  serviceKind: string;
-  requiredConfig: string[];
-  optionalConfig: string[];
-  missingConfig: string[];
-  configPresent: boolean;
-  oauthGrantRequired: boolean;
-  oauthGrantCount: number;
-  upstreamGrantCount: number;
-  openaiCompatible: boolean;
-  manifestRoutes: number;
-  modelCount: number;
-  connectionEnabled?: boolean;
-  verified?: boolean;
-  lastCheckedAt?: string | null;
-  latencyMs?: number | null;
-  executable: boolean;
-  status: string;
-  reasons: string[];
-}
-
-export interface ProviderAccess {
-  provider: string;
-  displayName: string;
-  serviceKind: string;
-  allowed: boolean;
-  policies: string[];
-  readiness: ProviderReadiness;
-}
-
-export interface AccessUser {
-  email: string;
-  role: "admin" | "user";
-  tenantId: string;
-  enabled: boolean;
-  groups: string[];
-  contentRetentionDisabled: boolean;
-}
-
-export interface PolicyBinding {
-  policyId: string;
-  principalType: "user" | "group";
-  principalId: string;
-  enabled: boolean;
-  priority: number;
-}
-
-export interface AccessForm {
-  email: string;
-  tenantId: string;
-  enabled: boolean;
-  groups: string;
-  contentRetentionDisabled: boolean;
-  policyIds: string[];
-}
-
-export interface BindingForm {
-  policyId: string;
-  principalType: "user" | "group";
-  principalId: string;
-  enabled: boolean;
-  priority: string;
-}
-
-export interface BudgetStatus {
-  configured: boolean;
-  ledger: string;
-  windowKey?: string | null;
-  limitMicros?: number | null;
-  spentMicros?: number | null;
-  remainingMicros?: number | null;
-}
-
-export interface AdminUsageRow {
-  policyId?: string;
-  kid: string;
-  tenantId: string;
-  enabled: boolean;
-  providers: string[];
-  tokenRole?: string | null;
-  monthlyBudgetMicros?: number | null;
-  requestCostMicros?: number | null;
-  budget: BudgetStatus;
-}
-
-export interface AdminTenantSummary {
-  tenantId: string;
-  policies?: number;
-  activePolicies?: number;
-  keys: number;
-  activeKeys: number;
-  providers: string[];
-  allProviders?: boolean;
-  monthlyBudgetMicros: number;
-  requestCostMicros: number;
-}
-
-export interface ServiceItem {
-  id: string;
-  name: string;
-  provider: string;
-  kind: string;
-  category: string;
-  capabilities: string[];
-  surfaces: string[];
-  route: string;
-  routeCount: number;
-  models: number;
-  modelIds: string[];
-  access?: ProviderAccess;
-  readiness?: ProviderReadiness;
-}
-
-export interface ServiceOutcome {
-  label: string;
-  detail: string;
-  tone: "active" | "revoked" | "neutral";
-  playable: boolean;
-  blocked: boolean;
-}
-
-export interface PlaygroundForm {
-  mode: "model" | "service";
-  model: string;
-  endpoint: "/v1/chat/completions" | "/v1/responses";
-  serviceRoute: string;
-  serviceMethod: string;
-  servicePath: string;
-  servicePayload: string;
-  system: string;
-  prompt: string;
-  maxTokens: string;
-  temperature: string;
 }
 
 export interface PlaygroundMessage {

--- a/admin/src/hooks/access/use-assignment-admin.ts
+++ b/admin/src/hooks/access/use-assignment-admin.ts
@@ -1,0 +1,70 @@
+import { type FormEvent, useState } from "react";
+import { errorMessage, optionalNumber, parseGroups } from "../../domain";
+import { defaultAssignmentRule, demo } from "../../ui-config";
+import { assignmentRuleFormFromRule, demoRuleFromForm, request } from "../../ui-helpers";
+import type { AssignmentRule, AssignmentRuleForm } from "../../ui-types";
+
+interface Dependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  demoMode: boolean;
+  setError: (message: string) => void;
+  setStatus: (status: string) => void;
+  refresh: () => Promise<void>;
+}
+
+export function useAssignmentAdmin({ allowDemo, gatewayOrigin, demoMode, setError, setStatus, refresh }: Dependencies) {
+  const [rules, setRules] = useState<AssignmentRule[]>(allowDemo ? demo.assignmentRules : []);
+  const [form, setForm] = useState<AssignmentRuleForm>(allowDemo && demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
+  const [selectedId, setSelectedId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
+  const selected = rules.find((rule) => rule.ruleId === selectedId);
+
+  function hydrate(nextRules: AssignmentRule[], background: boolean) {
+    setRules(nextRules);
+    if (background) return;
+    const refreshed = nextRules.find((rule) => rule.ruleId === selectedId) ?? nextRules[0];
+    setSelectedId(refreshed?.ruleId ?? "");
+    setForm(refreshed ? assignmentRuleFormFromRule(refreshed) : defaultAssignmentRule);
+  }
+
+  async function save(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setError("");
+      const ruleId = form.ruleId.trim();
+      if (!/^[a-z0-9_]{4,48}$/.test(ruleId)) throw new Error("rule id must use 4-48 lowercase letters, numbers, or underscores");
+      if (!form.subject.trim()) throw new Error("rule subject is required");
+      const body = { version: 1, enabled: form.enabled, kind: form.kind, subject: form.subject.trim(), groups: parseGroups(form.groups), policyIds: form.policyIds, priority: optionalNumber(form.priority) ?? 100, revokeOnLoss: form.revokeOnLoss, provenance: form.provenance.trim() };
+      setStatus("saving assignment rule");
+      let saved: AssignmentRule;
+      if (demoMode) {
+        saved = demoRuleFromForm(form);
+        setRules((current) => [saved, ...current.filter((rule) => rule.ruleId !== saved.ruleId)]);
+      } else {
+        saved = await request<AssignmentRule>(gatewayOrigin, `/v1/admin/assignment-rules/${encodeURIComponent(ruleId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+        await refresh();
+      }
+      setSelectedId(saved.ruleId);
+      setForm(assignmentRuleFormFromRule(saved));
+      setStatus("saved assignment rule");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function reconcile() {
+    try {
+      setError("");
+      setStatus("reconciling assignments");
+      if (!demoMode) {
+        await request<{ results: unknown[] }>(gatewayOrigin, "/v1/admin/assignment-rules/reconcile", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ all: true }) });
+        await refresh();
+      }
+      setStatus("reconciled assignments");
+    } catch (caught) { handleError(caught); }
+  }
+
+  function edit(rule: AssignmentRule) { setSelectedId(rule.ruleId); setForm(assignmentRuleFormFromRule(rule)); }
+  function startNew() { setSelectedId(""); setForm({ ...defaultAssignmentRule, policyIds: [] }); }
+  function handleError(caught: unknown) { const message = errorMessage(caught); setError(message); setStatus(message); }
+
+  return { assignments: { items: rules, setItems: setRules, selected, selectedId, setSelectedId, form, setForm, save, reconcile, edit, startNew }, hydrate };
+}

--- a/admin/src/hooks/access/use-connection-admin.ts
+++ b/admin/src/hooks/access/use-connection-admin.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { errorMessage } from "../../domain";
+import { demo } from "../../ui-config";
+import { request } from "../../ui-helpers";
+import type { ProviderConnection, ProviderReadiness } from "../../ui-types";
+
+interface Dependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  demoMode: boolean;
+  setStatus: (status: string) => void;
+  setProviderReadiness: React.Dispatch<React.SetStateAction<Record<string, ProviderReadiness>>>;
+  refresh: () => Promise<void>;
+}
+
+export function useConnectionAdmin({ allowDemo, gatewayOrigin, demoMode, setStatus, setProviderReadiness, refresh }: Dependencies) {
+  const [connections, setConnections] = useState<ProviderConnection[]>(allowDemo ? demo.connections : []);
+
+  async function setEnabled(providerId: string, enabled: boolean) {
+    try {
+      setStatus(`${enabled ? "enabling" : "disabling"} ${providerId}`);
+      const current = connections.find((connection) => connection.providerId === providerId);
+      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null };
+      if (demoMode) {
+        setConnections((items) => [next, ...items.filter((item) => item.providerId !== providerId)]);
+        setProviderReadiness((items) => {
+          const readiness = items[providerId];
+          return readiness ? { ...items, [providerId]: { ...readiness, connectionEnabled: enabled, executable: enabled && readiness.configPresent && (!readiness.oauthGrantRequired || readiness.oauthGrantCount > 0), status: enabled ? (readiness.verified ? "verified" : "unverified") : "disabled" } } : items;
+        });
+      } else {
+        await request<ProviderConnection>(gatewayOrigin, `/v1/admin/connections/${encodeURIComponent(providerId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
+        await refresh();
+      }
+      setStatus(`${enabled ? "enabled" : "disabled"} ${providerId}`);
+    } catch (caught) {
+      setStatus(errorMessage(caught));
+    }
+  }
+
+  return { connections: { items: connections, setItems: setConnections, setEnabled }, hydrate: setConnections };
+}

--- a/admin/src/hooks/access/use-policy-admin.ts
+++ b/admin/src/hooks/access/use-policy-admin.ts
@@ -1,0 +1,175 @@
+import { type FormEvent, useState } from "react";
+import { currencyInput, errorMessage, knownPolicyProviders, optionalCurrencyMicros, optionalNumber, unique } from "../../domain";
+import { defaultCredential, defaultPolicy, demo, rolePresets } from "../../ui-config";
+import { generateSecret, policyFormFromPolicy, request, sha256Hex } from "../../ui-helpers";
+import type { AccessPolicy, CredentialForm, PolicyForm, ProviderRow, ProxyCredential, RouteCatalog, SessionResponse } from "../../ui-types";
+
+interface Dependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  session: SessionResponse;
+  demoMode: boolean;
+  providers: ProviderRow[];
+  routes: RouteCatalog;
+  setStatus: (status: string) => void;
+  refresh: () => Promise<void>;
+  syncDemoAdmin: (policies: AccessPolicy[], credentials: ProxyCredential[], providers: ProviderRow[], routes: RouteCatalog, syncRows?: boolean) => void;
+}
+
+export function usePolicyAdmin({ allowDemo, gatewayOrigin, session, demoMode, providers, routes, setStatus, refresh, syncDemoAdmin }: Dependencies) {
+  const [keys, setKeys] = useState<AccessPolicy[]>(allowDemo ? demo.keys : []);
+  const [credentials, setCredentials] = useState<ProxyCredential[]>(allowDemo ? demo.credentials : []);
+  const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
+  const [credentialForm, setCredentialForm] = useState<CredentialForm>(allowDemo && demo.keys[0] ? { credentialId: "", policyId: demo.keys[0].policyId, principalId: "" } : defaultCredential);
+  const [selectedPolicyId, setSelectedPolicyId] = useState(allowDemo ? demo.keys[0]?.policyId ?? "" : "");
+  const [selectedCredentialId, setSelectedCredentialId] = useState(allowDemo ? demo.credentials[0]?.credentialId ?? "" : "");
+  const [issuedKey, setIssuedKey] = useState("");
+  const [error, setError] = useState("");
+  const selectedPolicy = keys.find((key) => key.policyId === selectedPolicyId);
+  const selectedCredential = credentials.find((credential) => credential.credentialId === selectedCredentialId);
+
+  function hydrate(policies: AccessPolicy[], nextCredentials: ProxyCredential[], background: boolean, sessionData: SessionResponse) {
+    setKeys(policies);
+    setCredentials(nextCredentials);
+    if (background) return;
+    const refreshedPolicy = policies.find((policy) => policy.policyId === selectedPolicyId) ?? policies[0];
+    setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
+    setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
+    const refreshedCredential = nextCredentials.find((credential) => credential.credentialId === selectedCredentialId) ?? nextCredentials[0];
+    setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
+    setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? policies[0]?.policyId ?? "", principalId: "" });
+  }
+
+  async function save(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setError("");
+      setStatus("saving policy");
+      const policyProviders = knownPolicyProviders(policyForm.providers, providers.map((provider) => provider.id));
+      if (!policyForm.allProviders && !policyProviders.length) throw new Error("select at least one service");
+      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.policyId)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
+      const existingPolicy = keys.some((key) => key.policyId === policyForm.policyId);
+      if (existingPolicy && selectedPolicyId !== policyForm.policyId) throw new Error("policy id already exists; select it from the policy list to edit it");
+      const next: AccessPolicy = {
+        policyId: policyForm.policyId,
+        enabled: policyForm.enabled,
+        providers: policyForm.allProviders ? [] : policyProviders,
+        tenantId: policyForm.tenantId || "default",
+        tokenRole: policyForm.tokenRole || null,
+        monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,
+        requestCostMicros: optionalNumber(policyForm.requestCostMicros) ?? null,
+        retainRequestContent: policyForm.retainRequestContent,
+      };
+      if (demoMode) {
+        applyDemoKeys((current) => [next, ...current.filter((key) => key.policyId !== next.policyId)]);
+        setSelectedPolicyId(next.policyId);
+        setStatus("saved policy");
+        return;
+      }
+      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyForm.policyId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ ...next, allProviders: policyForm.allProviders }) });
+      await refresh();
+      setSelectedPolicyId(next.policyId);
+      setPolicyForm(policyFormFromPolicy(next));
+      setStatus("saved policy");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function issueCredential(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setError("");
+      const policyId = credentialForm.policyId || selectedPolicyId;
+      if (!keys.some((policy) => policy.policyId === policyId)) throw new Error("select a policy for this credential");
+      const credentialId = credentialForm.credentialId.trim() || `${policyId}_${Date.now().toString(36)}`;
+      if (!/^[A-Za-z0-9_]{4,}$/.test(credentialId)) throw new Error("credential id must use 4 or more letters, numbers, or underscores");
+      if (credentials.some((credential) => credential.credentialId === credentialId)) throw new Error("credential id already exists");
+      setStatus("issuing credential");
+      const secret = generateSecret();
+      const revealedKey = `clawrouter-live-${credentialId}-${secret}`;
+      const principalId = credentialForm.principalId.trim().toLowerCase() || null;
+      if (principalId && !principalId.includes("@")) throw new Error("owner must be a valid user email");
+      const next: ProxyCredential = { credentialId, policyId, enabled: true, principalId };
+      if (demoMode) applyDemoCredentials((current) => [next, ...current]);
+      else {
+        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ enabled: true, policyId, principalId, secretSha256: await sha256Hex(secret) }) });
+        setIssuedKey(revealedKey);
+        try { await refresh(); }
+        catch (caught) {
+          const message = errorMessage(caught);
+          setSelectedCredentialId(credentialId);
+          setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
+          setError(`credential issued, but refresh failed: ${message}`);
+          setStatus("issued credential; refresh failed");
+          return;
+        }
+      }
+      setSelectedCredentialId(credentialId);
+      setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
+      setIssuedKey(revealedKey);
+      setStatus("issued credential");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function revokeCredential(credentialId: string) {
+    try {
+      setStatus(`revoking ${credentialId}`);
+      if (demoMode) applyDemoCredentials((current) => current.map((credential) => credential.credentialId === credentialId ? { ...credential, enabled: false } : credential));
+      else { await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}/revoke`, { method: "POST" }); await refresh(); }
+      setIssuedKey("");
+      setStatus(`revoked ${credentialId}`);
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function revokePolicy(policyId: string) {
+    try {
+      setStatus(`revoking ${policyId}`);
+      if (demoMode) { applyDemoKeys((current) => current.map((key) => key.policyId === policyId ? { ...key, enabled: false } : key)); setStatus(`revoked ${policyId}`); return; }
+      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyId)}/revoke`, { method: "POST" });
+      await refresh();
+      setStatus(`revoked ${policyId}`);
+    } catch (caught) { handleError(caught); }
+  }
+
+  function edit(key: AccessPolicy) {
+    setIssuedKey("");
+    setSelectedPolicyId(key.policyId);
+    setPolicyForm(policyFormFromPolicy(key));
+    setCredentialForm((current) => ({ ...current, policyId: key.policyId }));
+  }
+
+  function startNew() {
+    setIssuedKey("");
+    setError("");
+    setSelectedPolicyId("");
+    setPolicyForm({ ...defaultPolicy, policyId: "", tenantId: session.tenantId ?? "default", providers: [...defaultPolicy.providers] });
+  }
+
+  function applyPreset(role: keyof typeof rolePresets) {
+    const preset = rolePresets[role], available = new Set(providers.map((provider) => provider.id));
+    setPolicyForm((current) => ({ ...current, tokenRole: role, monthlyBudgetMicros: currencyInput(optionalNumber(preset.budget)), requestCostMicros: preset.request, providers: preset.providers.length ? preset.providers.filter((id) => available.has(id)) : providers.map((provider) => provider.id), allProviders: false }));
+  }
+
+  function toggleProvider(providerId: string) {
+    const allProviderIds = providers.map((provider) => provider.id);
+    setPolicyForm((current) => ({ ...current, allProviders: false, providers: (current.allProviders ? allProviderIds : current.providers).includes(providerId) ? (current.allProviders ? allProviderIds : current.providers).filter((id) => id !== providerId) : [...current.providers, providerId].sort() }));
+  }
+
+  function setProviderGroup(providerIds: string[], checked: boolean) {
+    const allProviderIds = providers.map((provider) => provider.id);
+    setPolicyForm((current) => {
+      if (current.allProviders && checked) return current;
+      const selected = current.allProviders ? allProviderIds : current.providers;
+      return { ...current, allProviders: false, providers: checked ? unique([...selected, ...providerIds]).sort() : selected.filter((id) => !providerIds.includes(id)) };
+    });
+  }
+
+  function applyDemoKeys(updater: (current: AccessPolicy[]) => AccessPolicy[]) { const next = updater(keys); setKeys(next); syncDemoAdmin(next, credentials, providers, routes, true); }
+  function applyDemoCredentials(updater: (current: ProxyCredential[]) => ProxyCredential[]) { const next = updater(credentials); setCredentials(next); syncDemoAdmin(keys, next, providers, routes); }
+  function handleError(caught: unknown) { const message = errorMessage(caught); setError(message); setStatus(message); }
+
+  return {
+    policies: { items: keys, setItems: setKeys, selected: selectedPolicy, selectedId: selectedPolicyId, setSelectedId: setSelectedPolicyId, form: policyForm, setForm: setPolicyForm, error, setError, save, revoke: revokePolicy, edit, startNew, applyPreset, toggleProvider, setProviderGroup },
+    credentials: { items: credentials, setItems: setCredentials, selected: selectedCredential, selectedId: selectedCredentialId, setSelectedId: setSelectedCredentialId, form: credentialForm, setForm: setCredentialForm, issuedKey, setIssuedKey, issue: issueCredential, revoke: revokeCredential },
+    hydrate,
+  };
+}

--- a/admin/src/hooks/access/use-principal-admin.ts
+++ b/admin/src/hooks/access/use-principal-admin.ts
@@ -1,0 +1,147 @@
+import { type FormEvent, useState } from "react";
+import { accessFormFromUser, bindingFormFromBinding, bindingKey, errorMessage, optionalNumber, parseGroups, reconcileDirectUserBindings } from "../../domain";
+import { defaultAccess, defaultBinding, demo } from "../../ui-config";
+import { request } from "../../ui-helpers";
+import type { AccessPolicy, AccessUser, BindingForm, PolicyBinding, SessionResponse } from "../../ui-types";
+
+interface Dependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  session: SessionResponse;
+  demoMode: boolean;
+  policies: AccessPolicy[];
+  selectedPolicyId: string;
+  setPolicyError: (message: string) => void;
+  setStatus: (status: string) => void;
+  refresh: () => Promise<void>;
+}
+
+export function usePrincipalAdmin({ allowDemo, gatewayOrigin, session, demoMode, policies, selectedPolicyId, setPolicyError, setStatus, refresh }: Dependencies) {
+  const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
+  const [bindings, setBindings] = useState<PolicyBinding[]>(allowDemo ? demo.bindings : []);
+  const [accessForm, setAccessForm] = useState(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
+  const [bindingForm, setBindingForm] = useState<BindingForm>(allowDemo && demo.keys[0] ? { ...defaultBinding, policyId: demo.keys[0].policyId } : defaultBinding);
+  const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
+  const [selectedBindingKey, setSelectedBindingKey] = useState(allowDemo ? bindingKey(demo.bindings[0]) : "");
+  const [userError, setUserError] = useState("");
+  const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
+  const selectedBinding = bindings.find((binding) => bindingKey(binding) === selectedBindingKey);
+
+  function hydrate(nextUsers: AccessUser[], nextBindings: PolicyBinding[], background: boolean, policyId: string) {
+    setUsers(nextUsers);
+    setBindings(nextBindings);
+    if (background) return;
+    const refreshedBinding = nextBindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? nextBindings[0];
+    setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
+    setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId });
+    const refreshedUser = nextUsers.find((user) => user.email === selectedUserEmail) ?? nextUsers[0];
+    setSelectedUserEmail(refreshedUser?.email ?? "");
+    setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, nextBindings) : defaultAccess);
+  }
+
+  function hydrateUser(user: AccessUser) {
+    setUsers([user]);
+    setBindings([]);
+    setSelectedUserEmail(user.email);
+    setAccessForm(accessFormFromUser(user, []));
+  }
+
+  async function saveBinding(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setPolicyError("");
+      const principalId = bindingForm.principalId.trim().toLowerCase();
+      if (!principalId) throw new Error("principal is required");
+      if (!bindingForm.policyId) throw new Error("select a policy");
+      const next: PolicyBinding = { policyId: bindingForm.policyId, principalType: bindingForm.principalType, principalId, enabled: bindingForm.enabled, priority: optionalNumber(bindingForm.priority) ?? 100 };
+      setStatus("saving binding");
+      if (demoMode) setBindings((current) => [next, ...current.filter((binding) => bindingKey(binding) !== bindingKey(next))]);
+      else {
+        await request<PolicyBinding>(gatewayOrigin, "/v1/admin/policy-bindings", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
+        await refresh();
+      }
+      setSelectedBindingKey(bindingKey(next));
+      setBindingForm(bindingFormFromBinding(next));
+      setStatus("saved binding");
+    } catch (caught) {
+      const message = errorMessage(caught);
+      setPolicyError(message);
+      setStatus(message);
+    }
+  }
+
+  async function saveUser(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setUserError("");
+      setStatus("saving user");
+      const email = accessForm.email.trim().toLowerCase();
+      if (!email.includes("@")) throw new Error("enter a valid email");
+      const next: AccessUser = {
+        email,
+        role: selectedUser?.role ?? "user",
+        tenantId: accessForm.tenantId || "default",
+        enabled: accessForm.enabled,
+        groups: parseGroups(accessForm.groups),
+        contentRetentionDisabled: accessForm.contentRetentionDisabled,
+      };
+      const nextBindings = reconcileDirectUserBindings(bindings, email, policies, accessForm.policyIds);
+      if (demoMode) {
+        setUsers((current) => [next, ...current.filter((user) => user.email !== email)]);
+        setBindings(nextBindings);
+        setSelectedUserEmail(email);
+        setAccessForm(accessFormFromUser(next, nextBindings));
+        setStatus("saved user");
+        return;
+      }
+      await request<{ user: AccessUser; bindings: PolicyBinding[] }>(gatewayOrigin, `/v1/admin/access-user-grants/${encodeURIComponent(email)}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tenantId: next.tenantId, enabled: next.enabled, groups: next.groups, contentRetentionDisabled: next.contentRetentionDisabled, policyIds: accessForm.policyIds }),
+      });
+      try {
+        await refresh();
+      } catch (caught) {
+        const message = errorMessage(caught);
+        setSelectedUserEmail(email);
+        setAccessForm(accessFormFromUser(next, nextBindings));
+        setUserError(`saved user, but refresh failed: ${message}`);
+        setStatus("saved user; refresh failed");
+        return;
+      }
+      setSelectedUserEmail(email);
+      setAccessForm(accessFormFromUser(next, nextBindings));
+      setStatus("saved user");
+    } catch (caught) {
+      const message = errorMessage(caught);
+      setUserError(message);
+      setStatus(message);
+      await refresh().catch(() => undefined);
+      setUserError(message);
+      setStatus(message);
+    }
+  }
+
+  function editBinding(binding: PolicyBinding) {
+    setSelectedBindingKey(bindingKey(binding));
+    setBindingForm(bindingFormFromBinding(binding));
+  }
+
+  function startNewBinding() {
+    setSelectedBindingKey("");
+    setBindingForm({ ...defaultBinding, policyId: selectedPolicyId || policies[0]?.policyId || "" });
+  }
+
+  function startNewUser() {
+    setSelectedUserEmail("");
+    setUserError("");
+    setAccessForm({ ...defaultAccess, email: "", tenantId: session.tenantId ?? "default" });
+  }
+
+  return {
+    bindings: { items: bindings, setItems: setBindings, selected: selectedBinding, selectedKey: selectedBindingKey, setSelectedKey: setSelectedBindingKey, form: bindingForm, setForm: setBindingForm, save: saveBinding, edit: editBinding, startNew: startNewBinding },
+    users: { items: users, setItems: setUsers, selected: selectedUser, selectedEmail: selectedUserEmail, setSelectedEmail: setSelectedUserEmail, form: accessForm, setForm: setAccessForm, error: userError, setError: setUserError, save: saveUser, startNew: startNewUser },
+    hydrate,
+    hydrateUser,
+  };
+}

--- a/admin/src/hooks/access/use-upstream-admin.ts
+++ b/admin/src/hooks/access/use-upstream-admin.ts
@@ -1,0 +1,109 @@
+import { type FormEvent, useState } from "react";
+import { errorMessage } from "../../domain";
+import { defaultUpstreamGrant, demo } from "../../ui-config";
+import { demoGrantFromForm, parseCredentialBundle, request, upstreamGrantFormFromGrant } from "../../ui-helpers";
+import type { AccessPolicy, ProviderRow, UpstreamGrant, UpstreamGrantForm } from "../../ui-types";
+
+interface Dependencies {
+  allowDemo: boolean;
+  gatewayOrigin: string;
+  demoMode: boolean;
+  providers: ProviderRow[];
+  policies: AccessPolicy[];
+  selectedPolicyId: string;
+  setError: (message: string) => void;
+  setStatus: (status: string) => void;
+  refresh: () => Promise<void>;
+}
+
+export function useUpstreamAdmin({ allowDemo, gatewayOrigin, demoMode, providers, policies, selectedPolicyId, setError, setStatus, refresh }: Dependencies) {
+  const [grants, setGrants] = useState<UpstreamGrant[]>(allowDemo ? demo.upstreamGrants : []);
+  const [form, setForm] = useState<UpstreamGrantForm>(allowDemo && demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
+  const [selectedKey, setSelectedKey] = useState(allowDemo ? demo.upstreamGrants[0]?.key ?? "" : "");
+  const selected = grants.find((grant) => grant.key === selectedKey);
+
+  function hydrate(nextGrants: UpstreamGrant[], background: boolean, policyId: string, providerRows: ProviderRow[]) {
+    setGrants(nextGrants);
+    if (background) return;
+    const refreshed = nextGrants.find((grant) => grant.key === selectedKey) ?? nextGrants[0];
+    setSelectedKey(refreshed?.key ?? "");
+    setForm(refreshed ? upstreamGrantFormFromGrant(refreshed) : { ...defaultUpstreamGrant, scopeId: policyId, provider: providerRows[0]?.id ?? "", tokenRef: providerRows[0]?.id ?? "" });
+  }
+
+  async function save(event: FormEvent) {
+    event.preventDefault();
+    try {
+      setError("");
+      const scopeId = form.scopeId.trim(), tokenRef = form.tokenRef.trim(), provider = form.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      const credentialBundle = parseCredentialBundle(form.credentialBundle);
+      const primarySecret = form.kind === "api_key" ? form.credential.trim() || Object.keys(credentialBundle).length : form.accessToken.trim();
+      if (!selected && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
+      const body = {
+        version: 1, enabled: form.enabled, kind: form.kind, provider, label: form.label.trim() || undefined,
+        tokenType: selected?.tokenType ?? "Bearer", expiresAt: form.expiresAt.trim() || undefined, scopes: selected?.scopes ?? [],
+        accountId: form.accountId.trim() || undefined, subscription: selected?.subscription ?? undefined,
+        ...(form.credential.trim() ? { credential: form.credential.trim() } : {}),
+        ...(Object.keys(credentialBundle).length ? { credentials: credentialBundle } : {}),
+        ...(form.accessToken.trim() ? { accessToken: form.accessToken.trim() } : {}),
+        ...(form.refreshToken.trim() ? { refreshToken: form.refreshToken.trim() } : {}),
+      };
+      const path = `/v1/admin/upstream-grants/${form.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}`;
+      setStatus("saving upstream grant");
+      let saved: UpstreamGrant;
+      if (demoMode) { saved = demoGrantFromForm(form, selected); setGrants((current) => [saved, ...current.filter((grant) => grant.key !== saved.key)]); }
+      else { saved = await request<UpstreamGrant>(gatewayOrigin, path, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) }); await refresh(); }
+      setSelectedKey(saved.key);
+      setForm(upstreamGrantFormFromGrant(saved));
+      setStatus("saved upstream grant");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function revoke(grant: UpstreamGrant) {
+    try {
+      setError("");
+      setStatus("revoking upstream grant");
+      let revoked: UpstreamGrant;
+      if (demoMode) {
+        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
+        setGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
+      } else { revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" }); await refresh(); }
+      setSelectedKey(revoked.key);
+      setForm(upstreamGrantFormFromGrant(revoked));
+      setStatus("revoked upstream grant");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function refreshGrant(grant: UpstreamGrant) {
+    try {
+      setError("");
+      setStatus("refreshing upstream grant");
+      if (!demoMode) {
+        const refreshed = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/refresh`, { method: "POST" });
+        await refresh();
+        setSelectedKey(refreshed.key);
+        setForm(upstreamGrantFormFromGrant(refreshed));
+      }
+      setStatus("refreshed upstream grant");
+    } catch (caught) { handleError(caught); }
+  }
+
+  async function authorize() {
+    try {
+      setError("");
+      const scopeId = form.scopeId.trim(), tokenRef = form.tokenRef.trim(), provider = form.provider.trim();
+      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
+      if (!providers.find((item) => item.id === provider)?.auth?.authorization) throw new Error("selected provider does not support browser OAuth");
+      setStatus("connecting upstream grant");
+      if (demoMode) { setStatus("browser OAuth unavailable in local demo"); return; }
+      const result = await request<{ authorizationUrl: string }>(gatewayOrigin, `/v1/admin/upstream-grants/${form.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}/authorize`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ provider }) });
+      window.location.assign(result.authorizationUrl);
+    } catch (caught) { handleError(caught); }
+  }
+
+  function edit(grant: UpstreamGrant) { setSelectedKey(grant.key); setForm(upstreamGrantFormFromGrant(grant)); }
+  function startNew() { const provider = providers[0]?.id ?? ""; setSelectedKey(""); setForm({ ...defaultUpstreamGrant, scopeId: selectedPolicyId || policies[0]?.policyId || "default", provider, tokenRef: provider }); }
+  function handleError(caught: unknown) { const message = errorMessage(caught); setError(message); setStatus(message); }
+
+  return { upstream: { items: grants, setItems: setGrants, selected, selectedKey, setSelectedKey, form, setForm, save, revoke, refresh: refreshGrant, authorize, edit, startNew }, hydrate };
+}

--- a/admin/src/hooks/use-access-admin.ts
+++ b/admin/src/hooks/use-access-admin.ts
@@ -1,60 +1,13 @@
-import { type FormEvent, useState } from "react";
-import {
-  accessFormFromUser,
-  bindingFormFromBinding,
-  bindingKey,
-  currencyInput,
-  errorMessage,
-  knownPolicyProviders,
-  optionalCurrencyMicros,
-  optionalNumber,
-  parseGroups,
-  reconcileDirectUserBindings,
-  unique,
-} from "../domain";
-import {
-  defaultAccess,
-  defaultAssignmentRule,
-  defaultBinding,
-  defaultCredential,
-  defaultPolicy,
-  defaultUpstreamGrant,
-  demo,
-  initialAccessTab,
-  rolePresets,
-} from "../ui-config";
-import {
-  assignmentRuleFormFromRule,
-  demoGrantFromForm,
-  demoRuleFromForm,
-  generateSecret,
-  parseCredentialBundle,
-  policyFormFromPolicy,
-  request,
-  sha256Hex,
-  upstreamGrantFormFromGrant,
-} from "../ui-helpers";
-import type {
-  AccessPolicy,
-  AccessTab,
-  AccessUser,
-  AssignmentRule,
-  AssignmentRuleForm,
-  BindingForm,
-  CredentialForm,
-  PolicyBinding,
-  PolicyForm,
-  ProviderConnection,
-  ProviderReadiness,
-  ProviderRow,
-  ProxyCredential,
-  RouteCatalog,
-  SessionResponse,
-  UpstreamGrant,
-  UpstreamGrantForm,
-} from "../ui-types";
+import { useState } from "react";
+import { initialAccessTab, demo } from "../ui-config";
+import type { AccessPolicy, AccessTab, AccessUser, AssignmentRule, PolicyBinding, ProviderConnection, ProviderReadiness, ProviderRow, ProxyCredential, RouteCatalog, SessionResponse, UpstreamGrant } from "../ui-types";
+import { useAssignmentAdmin } from "./access/use-assignment-admin";
+import { useConnectionAdmin } from "./access/use-connection-admin";
+import { usePolicyAdmin } from "./access/use-policy-admin";
+import { usePrincipalAdmin } from "./access/use-principal-admin";
+import { useUpstreamAdmin } from "./access/use-upstream-admin";
 
-interface AccessAdminDependencies {
+interface Dependencies {
   allowDemo: boolean;
   gatewayOrigin: string;
   session: SessionResponse;
@@ -77,564 +30,55 @@ interface AdminRecords {
   rules: AssignmentRule[];
 }
 
-export function useAccessAdmin(dependencies: AccessAdminDependencies) {
+export function useAccessAdmin(dependencies: Dependencies) {
   const { allowDemo, gatewayOrigin, session, demoMode, providers, routes, setStatus, setProviderReadiness, refresh, syncDemoAdmin } = dependencies;
-  const [keys, setKeys] = useState<AccessPolicy[]>(allowDemo ? demo.keys : []);
-  const [credentials, setCredentials] = useState<ProxyCredential[]>(allowDemo ? demo.credentials : []);
-  const [connections, setConnections] = useState<ProviderConnection[]>(allowDemo ? demo.connections : []);
-  const [upstreamGrants, setUpstreamGrants] = useState<UpstreamGrant[]>(allowDemo ? demo.upstreamGrants : []);
-  const [assignmentRules, setAssignmentRules] = useState<AssignmentRule[]>(allowDemo ? demo.assignmentRules : []);
-  const [users, setUsers] = useState<AccessUser[]>(allowDemo ? demo.users : []);
-  const [bindings, setBindings] = useState<PolicyBinding[]>(allowDemo ? demo.bindings : []);
   const [loaded, setLoaded] = useState(allowDemo);
-  const [policyForm, setPolicyForm] = useState<PolicyForm>(allowDemo && demo.keys[0] ? policyFormFromPolicy(demo.keys[0]) : defaultPolicy);
-  const [credentialForm, setCredentialForm] = useState<CredentialForm>(allowDemo && demo.keys[0] ? { credentialId: "", policyId: demo.keys[0].policyId, principalId: "" } : defaultCredential);
-  const [bindingForm, setBindingForm] = useState<BindingForm>(allowDemo && demo.keys[0] ? { ...defaultBinding, policyId: demo.keys[0].policyId } : defaultBinding);
-  const [upstreamGrantForm, setUpstreamGrantForm] = useState<UpstreamGrantForm>(allowDemo && demo.upstreamGrants[0] ? upstreamGrantFormFromGrant(demo.upstreamGrants[0]) : defaultUpstreamGrant);
-  const [assignmentRuleForm, setAssignmentRuleForm] = useState<AssignmentRuleForm>(allowDemo && demo.assignmentRules[0] ? assignmentRuleFormFromRule(demo.assignmentRules[0]) : defaultAssignmentRule);
-  const [accessTab, setAccessTab] = useState<AccessTab>(initialAccessTab);
-  const [accessForm, setAccessForm] = useState(allowDemo && demo.users[0] ? accessFormFromUser(demo.users[0], demo.bindings) : defaultAccess);
-  const [selectedPolicyId, setSelectedPolicyId] = useState(allowDemo ? demo.keys[0]?.policyId ?? "" : "");
-  const [selectedCredentialId, setSelectedCredentialId] = useState(allowDemo ? demo.credentials[0]?.credentialId ?? "" : "");
-  const [selectedBindingKey, setSelectedBindingKey] = useState(allowDemo ? bindingKey(demo.bindings[0]) : "");
-  const [selectedUpstreamGrantKey, setSelectedUpstreamGrantKey] = useState(allowDemo ? demo.upstreamGrants[0]?.key ?? "" : "");
-  const [selectedAssignmentRuleId, setSelectedAssignmentRuleId] = useState(allowDemo ? demo.assignmentRules[0]?.ruleId ?? "" : "");
-  const [selectedUserEmail, setSelectedUserEmail] = useState(demo.users[0]?.email ?? "");
-  const [issuedKey, setIssuedKey] = useState("");
-  const [policyError, setPolicyError] = useState("");
-  const [userError, setUserError] = useState("");
-  const selectedPolicy = keys.find((key) => key.policyId === selectedPolicyId);
-  const selectedCredential = credentials.find((credential) => credential.credentialId === selectedCredentialId);
-  const selectedBinding = bindings.find((binding) => bindingKey(binding) === selectedBindingKey);
-  const selectedUpstreamGrant = upstreamGrants.find((grant) => grant.key === selectedUpstreamGrantKey);
-  const selectedAssignmentRule = assignmentRules.find((rule) => rule.ruleId === selectedAssignmentRuleId);
-  const selectedUser = selectedUserEmail ? users.find((user) => user.email === selectedUserEmail) : undefined;
+  const [tab, setTab] = useState<AccessTab>(initialAccessTab);
+  const policy = usePolicyAdmin({ allowDemo, gatewayOrigin, session, demoMode, providers, routes, setStatus, refresh, syncDemoAdmin });
+  const principal = usePrincipalAdmin({ allowDemo, gatewayOrigin, session, demoMode, policies: policy.policies.items, selectedPolicyId: policy.policies.selectedId, setPolicyError: policy.policies.setError, setStatus, refresh });
+  const connection = useConnectionAdmin({ allowDemo, gatewayOrigin, demoMode, setStatus, setProviderReadiness, refresh });
+  const upstream = useUpstreamAdmin({ allowDemo, gatewayOrigin, demoMode, providers, policies: policy.policies.items, selectedPolicyId: policy.policies.selectedId, setError: policy.policies.setError, setStatus, refresh });
+  const assignment = useAssignmentAdmin({ allowDemo, gatewayOrigin, demoMode, setError: policy.policies.setError, setStatus, refresh });
 
   function hydrateAdmin(records: AdminRecords, background: boolean, sessionData: SessionResponse, providerRows: ProviderRow[]) {
-    setKeys(records.policies);
-    setCredentials(records.credentials);
-    setConnections(records.connections);
-    setUpstreamGrants(records.grants);
-    setAssignmentRules(records.rules);
-    setUsers(records.users);
-    setBindings(records.bindings);
+    policy.hydrate(records.policies, records.credentials, background, sessionData);
+    connection.hydrate(records.connections);
+    const policyId = records.policies.find((item) => item.policyId === policy.policies.selectedId)?.policyId ?? records.policies[0]?.policyId ?? "";
+    principal.hydrate(records.users, records.bindings, background, policyId);
+    upstream.hydrate(records.grants, background, policyId, providerRows);
+    assignment.hydrate(records.rules, background);
     setLoaded(true);
-    if (background) return;
-    const refreshedPolicy = records.policies.find((policy) => policy.policyId === selectedPolicyId) ?? records.policies[0];
-    setSelectedPolicyId(refreshedPolicy?.policyId ?? "");
-    setPolicyForm(refreshedPolicy ? policyFormFromPolicy(refreshedPolicy) : { ...defaultPolicy, policyId: "", tenantId: sessionData.tenantId ?? "default", providers: [...defaultPolicy.providers] });
-    const refreshedCredential = records.credentials.find((credential) => credential.credentialId === selectedCredentialId) ?? records.credentials[0];
-    setSelectedCredentialId(refreshedCredential?.credentialId ?? "");
-    setCredentialForm({ credentialId: "", policyId: refreshedPolicy?.policyId ?? records.policies[0]?.policyId ?? "", principalId: "" });
-    const refreshedBinding = records.bindings.find((binding) => bindingKey(binding) === selectedBindingKey) ?? records.bindings[0];
-    setSelectedBindingKey(refreshedBinding ? bindingKey(refreshedBinding) : "");
-    setBindingForm(refreshedBinding ? bindingFormFromBinding(refreshedBinding) : { ...defaultBinding, policyId: refreshedPolicy?.policyId ?? "" });
-    const refreshedGrant = records.grants.find((grant) => grant.key === selectedUpstreamGrantKey) ?? records.grants[0];
-    setSelectedUpstreamGrantKey(refreshedGrant?.key ?? "");
-    setUpstreamGrantForm(refreshedGrant ? upstreamGrantFormFromGrant(refreshedGrant) : { ...defaultUpstreamGrant, scopeId: refreshedPolicy?.policyId ?? "", provider: providerRows[0]?.id ?? "", tokenRef: providerRows[0]?.id ?? "" });
-    const refreshedRule = records.rules.find((rule) => rule.ruleId === selectedAssignmentRuleId) ?? records.rules[0];
-    setSelectedAssignmentRuleId(refreshedRule?.ruleId ?? "");
-    setAssignmentRuleForm(refreshedRule ? assignmentRuleFormFromRule(refreshedRule) : defaultAssignmentRule);
-    const refreshedUser = records.users.find((user) => user.email === selectedUserEmail) ?? records.users[0];
-    setSelectedUserEmail(refreshedUser?.email ?? "");
-    setAccessForm(refreshedUser ? accessFormFromUser(refreshedUser, records.bindings) : defaultAccess);
   }
 
   function hydrateUser(user: AccessUser) {
-    setKeys([]);
-    setCredentials([]);
-    setConnections([]);
-    setUpstreamGrants([]);
-    setAssignmentRules([]);
+    policy.hydrate([], [], false, session);
+    connection.hydrate([]);
+    upstream.hydrate([], false, "", []);
+    assignment.hydrate([], false);
+    principal.hydrateUser(user);
     setLoaded(false);
-    setUsers([user]);
-    setBindings([]);
-    setSelectedUserEmail(user.email);
-    setAccessForm(accessFormFromUser(user, []));
   }
 
   function hydrateDemo() {
     hydrateAdmin({ policies: demo.keys, credentials: demo.credentials, connections: demo.connections, users: demo.users, bindings: demo.bindings, grants: demo.upstreamGrants, rules: demo.assignmentRules }, false, demo.session, demo.providers);
   }
 
-  async function savePolicy(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      setStatus("saving policy");
-      const policyProviders = knownPolicyProviders(policyForm.providers, providers.map((provider) => provider.id));
-      if (!policyForm.allProviders && !policyProviders.length) throw new Error("select at least one service");
-      if (!/^[A-Za-z0-9_]{4,}$/.test(policyForm.policyId)) throw new Error("policy id must use 4 or more letters, numbers, or underscores");
-      const existingPolicy = keys.some((key) => key.policyId === policyForm.policyId);
-      if (existingPolicy && selectedPolicyId !== policyForm.policyId) throw new Error("policy id already exists; select it from the policy list to edit it");
-      const next: AccessPolicy = {
-        policyId: policyForm.policyId,
-        enabled: policyForm.enabled,
-        providers: policyForm.allProviders ? [] : policyProviders,
-        tenantId: policyForm.tenantId || "default",
-        tokenRole: policyForm.tokenRole || null,
-        monthlyBudgetMicros: optionalCurrencyMicros(policyForm.monthlyBudgetMicros) ?? null,
-        requestCostMicros: optionalNumber(policyForm.requestCostMicros) ?? null,
-        retainRequestContent: policyForm.retainRequestContent,
-      };
-      if (demoMode) {
-        applyDemoKeys((current) => [next, ...current.filter((key) => key.policyId !== next.policyId)]);
-        setSelectedPolicyId(next.policyId);
-        setStatus("saved policy");
-        return;
-      }
-      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyForm.policyId)}`, {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ...next, allProviders: policyForm.allProviders }),
-      });
-      await refresh();
-      setSelectedPolicyId(next.policyId);
-      setPolicyForm(policyFormFromPolicy(next));
-      setStatus("saved policy");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function issueCredential(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const policyId = credentialForm.policyId || selectedPolicyId;
-      if (!keys.some((policy) => policy.policyId === policyId)) throw new Error("select a policy for this credential");
-      const credentialId = credentialForm.credentialId.trim() || `${policyId}_${Date.now().toString(36)}`;
-      if (!/^[A-Za-z0-9_]{4,}$/.test(credentialId)) throw new Error("credential id must use 4 or more letters, numbers, or underscores");
-      if (credentials.some((credential) => credential.credentialId === credentialId)) throw new Error("credential id already exists");
-      setStatus("issuing credential");
-      const secret = generateSecret();
-      const revealedKey = `clawrouter-live-${credentialId}-${secret}`;
-      const principalId = credentialForm.principalId.trim().toLowerCase() || null;
-      if (principalId && !principalId.includes("@")) throw new Error("owner must be a valid user email");
-      const next: ProxyCredential = { credentialId, policyId, enabled: true, principalId };
-      if (demoMode) {
-        applyDemoCredentials((current) => [next, ...current]);
-      } else {
-        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}`, {
-          method: "PUT",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ enabled: true, policyId, principalId, secretSha256: await sha256Hex(secret) }),
-        });
-        setIssuedKey(revealedKey);
-        try {
-          await refresh();
-        } catch (caught) {
-          const message = errorMessage(caught);
-          setSelectedCredentialId(credentialId);
-          setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
-          setPolicyError(`credential issued, but refresh failed: ${message}`);
-          setStatus("issued credential; refresh failed");
-          return;
-        }
-      }
-      setSelectedCredentialId(credentialId);
-      setCredentialForm({ credentialId: "", policyId, principalId: credentialForm.principalId });
-      setIssuedKey(revealedKey);
-      setStatus("issued credential");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function revokeCredential(credentialId: string) {
-    try {
-      setStatus(`revoking ${credentialId}`);
-      if (demoMode) applyDemoCredentials((current) => current.map((credential) => credential.credentialId === credentialId ? { ...credential, enabled: false } : credential));
-      else {
-        await request<ProxyCredential>(gatewayOrigin, `/v1/admin/credentials/${encodeURIComponent(credentialId)}/revoke`, { method: "POST" });
-        await refresh();
-      }
-      setIssuedKey("");
-      setStatus(`revoked ${credentialId}`);
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function saveBinding(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const principalId = bindingForm.principalId.trim().toLowerCase();
-      if (!principalId) throw new Error("principal is required");
-      if (!bindingForm.policyId) throw new Error("select a policy");
-      const next: PolicyBinding = { policyId: bindingForm.policyId, principalType: bindingForm.principalType, principalId, enabled: bindingForm.enabled, priority: optionalNumber(bindingForm.priority) ?? 100 };
-      setStatus("saving binding");
-      if (demoMode) setBindings((current) => [next, ...current.filter((binding) => bindingKey(binding) !== bindingKey(next))]);
-      else {
-        await request<PolicyBinding>(gatewayOrigin, "/v1/admin/policy-bindings", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
-        await refresh();
-      }
-      setSelectedBindingKey(bindingKey(next));
-      setBindingForm(bindingFormFromBinding(next));
-      setStatus("saved binding");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function saveUpstreamGrant(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const scopeId = upstreamGrantForm.scopeId.trim();
-      const tokenRef = upstreamGrantForm.tokenRef.trim();
-      const provider = upstreamGrantForm.provider.trim();
-      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
-      const credentialBundle = parseCredentialBundle(upstreamGrantForm.credentialBundle);
-      const primarySecret = upstreamGrantForm.kind === "api_key" ? upstreamGrantForm.credential.trim() || Object.keys(credentialBundle).length : upstreamGrantForm.accessToken.trim();
-      if (!selectedUpstreamGrant && !primarySecret) throw new Error("a new upstream grant requires its primary secret");
-      const body = {
-        version: 1,
-        enabled: upstreamGrantForm.enabled,
-        kind: upstreamGrantForm.kind,
-        provider,
-        label: upstreamGrantForm.label.trim() || undefined,
-        tokenType: selectedUpstreamGrant?.tokenType ?? "Bearer",
-        expiresAt: upstreamGrantForm.expiresAt.trim() || undefined,
-        scopes: selectedUpstreamGrant?.scopes ?? [],
-        accountId: upstreamGrantForm.accountId.trim() || undefined,
-        subscription: selectedUpstreamGrant?.subscription ?? undefined,
-        ...(upstreamGrantForm.credential.trim() ? { credential: upstreamGrantForm.credential.trim() } : {}),
-        ...(Object.keys(credentialBundle).length ? { credentials: credentialBundle } : {}),
-        ...(upstreamGrantForm.accessToken.trim() ? { accessToken: upstreamGrantForm.accessToken.trim() } : {}),
-        ...(upstreamGrantForm.refreshToken.trim() ? { refreshToken: upstreamGrantForm.refreshToken.trim() } : {}),
-      };
-      const path = `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}`;
-      setStatus("saving upstream grant");
-      let saved: UpstreamGrant;
-      if (demoMode) {
-        saved = demoGrantFromForm(upstreamGrantForm, selectedUpstreamGrant);
-        setUpstreamGrants((current) => [saved, ...current.filter((grant) => grant.key !== saved.key)]);
-      } else {
-        saved = await request<UpstreamGrant>(gatewayOrigin, path, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
-        await refresh();
-      }
-      setSelectedUpstreamGrantKey(saved.key);
-      setUpstreamGrantForm(upstreamGrantFormFromGrant(saved));
-      setStatus("saved upstream grant");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function revokeUpstreamGrant(grant: UpstreamGrant) {
-    try {
-      setPolicyError("");
-      setStatus("revoking upstream grant");
-      let revoked: UpstreamGrant;
-      if (demoMode) {
-        revoked = { ...grant, enabled: false, usable: false, hasCredential: false, credentialFields: [], hasAccessToken: false, hasRefreshToken: false, revokedAt: new Date().toISOString() };
-        setUpstreamGrants((current) => current.map((item) => item.key === grant.key ? revoked : item));
-      } else {
-        revoked = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/revoke`, { method: "POST" });
-        await refresh();
-      }
-      setSelectedUpstreamGrantKey(revoked.key);
-      setUpstreamGrantForm(upstreamGrantFormFromGrant(revoked));
-      setStatus("revoked upstream grant");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function refreshUpstreamGrant(grant: UpstreamGrant) {
-    try {
-      setPolicyError("");
-      setStatus("refreshing upstream grant");
-      if (!demoMode) {
-        const refreshed = await request<UpstreamGrant>(gatewayOrigin, `/v1/admin/upstream-grants/${grant.scope}/${encodeURIComponent(grant.scopeId)}/${encodeURIComponent(grant.tokenRef)}/refresh`, { method: "POST" });
-        await refresh();
-        setSelectedUpstreamGrantKey(refreshed.key);
-        setUpstreamGrantForm(upstreamGrantFormFromGrant(refreshed));
-      }
-      setStatus("refreshed upstream grant");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function authorizeUpstreamGrant() {
-    try {
-      setPolicyError("");
-      const scopeId = upstreamGrantForm.scopeId.trim();
-      const tokenRef = upstreamGrantForm.tokenRef.trim();
-      const provider = upstreamGrantForm.provider.trim();
-      if (!scopeId || !tokenRef || !provider) throw new Error("scope, token reference, and provider are required");
-      if (!providers.find((item) => item.id === provider)?.auth?.authorization) throw new Error("selected provider does not support browser OAuth");
-      setStatus("connecting upstream grant");
-      if (demoMode) {
-        setStatus("browser OAuth unavailable in local demo");
-        return;
-      }
-      const result = await request<{ authorizationUrl: string }>(gatewayOrigin, `/v1/admin/upstream-grants/${upstreamGrantForm.scope}/${encodeURIComponent(scopeId)}/${encodeURIComponent(tokenRef)}/authorize`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ provider }),
-      });
-      window.location.assign(result.authorizationUrl);
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function saveAssignmentRule(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setPolicyError("");
-      const ruleId = assignmentRuleForm.ruleId.trim();
-      if (!/^[a-z0-9_]{4,48}$/.test(ruleId)) throw new Error("rule id must use 4-48 lowercase letters, numbers, or underscores");
-      if (!assignmentRuleForm.subject.trim()) throw new Error("rule subject is required");
-      const body = {
-        version: 1,
-        enabled: assignmentRuleForm.enabled,
-        kind: assignmentRuleForm.kind,
-        subject: assignmentRuleForm.subject.trim(),
-        groups: parseGroups(assignmentRuleForm.groups),
-        policyIds: assignmentRuleForm.policyIds,
-        priority: optionalNumber(assignmentRuleForm.priority) ?? 100,
-        revokeOnLoss: assignmentRuleForm.revokeOnLoss,
-        provenance: assignmentRuleForm.provenance.trim(),
-      };
-      setStatus("saving assignment rule");
-      let saved: AssignmentRule;
-      if (demoMode) {
-        saved = demoRuleFromForm(assignmentRuleForm);
-        setAssignmentRules((current) => [saved, ...current.filter((rule) => rule.ruleId !== saved.ruleId)]);
-      } else {
-        saved = await request<AssignmentRule>(gatewayOrigin, `/v1/admin/assignment-rules/${encodeURIComponent(ruleId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
-        await refresh();
-      }
-      setSelectedAssignmentRuleId(saved.ruleId);
-      setAssignmentRuleForm(assignmentRuleFormFromRule(saved));
-      setStatus("saved assignment rule");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function reconcileAssignments() {
-    try {
-      setPolicyError("");
-      setStatus("reconciling assignments");
-      if (!demoMode) {
-        await request<{ results: unknown[] }>(gatewayOrigin, "/v1/admin/assignment-rules/reconcile", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ all: true }) });
-        await refresh();
-      }
-      setStatus("reconciled assignments");
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  async function setProviderConnection(providerId: string, enabled: boolean) {
-    try {
-      setStatus(`${enabled ? "enabling" : "disabling"} ${providerId}`);
-      const current = connections.find((connection) => connection.providerId === providerId);
-      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null };
-      if (demoMode) {
-        setConnections((items) => [next, ...items.filter((item) => item.providerId !== providerId)]);
-        setProviderReadiness((items) => {
-          const readiness = items[providerId];
-          return readiness ? { ...items, [providerId]: { ...readiness, connectionEnabled: enabled, executable: enabled && readiness.configPresent && (!readiness.oauthGrantRequired || readiness.oauthGrantCount > 0), status: enabled ? (readiness.verified ? "verified" : "unverified") : "disabled" } } : items;
-        });
-      } else {
-        await request<ProviderConnection>(gatewayOrigin, `/v1/admin/connections/${encodeURIComponent(providerId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
-        await refresh();
-      }
-      setStatus(`${enabled ? "enabled" : "disabled"} ${providerId}`);
-    } catch (caught) {
-      setStatus(errorMessage(caught));
-    }
-  }
-
-  async function saveUser(event: FormEvent) {
-    event.preventDefault();
-    try {
-      setUserError("");
-      setStatus("saving user");
-      const email = accessForm.email.trim().toLowerCase();
-      if (!email.includes("@")) throw new Error("enter a valid email");
-      const next: AccessUser = {
-        email,
-        role: selectedUser?.role ?? "user",
-        tenantId: accessForm.tenantId || "default",
-        enabled: accessForm.enabled,
-        groups: parseGroups(accessForm.groups),
-        contentRetentionDisabled: accessForm.contentRetentionDisabled,
-      };
-      const nextBindings = reconcileDirectUserBindings(bindings, email, keys, accessForm.policyIds);
-      if (demoMode) {
-        setUsers((current) => [next, ...current.filter((user) => user.email !== email)]);
-        setBindings(nextBindings);
-        setSelectedUserEmail(email);
-        setAccessForm(accessFormFromUser(next, nextBindings));
-        setStatus("saved user");
-        return;
-      }
-      await request<{ user: AccessUser; bindings: PolicyBinding[] }>(gatewayOrigin, `/v1/admin/access-user-grants/${encodeURIComponent(email)}`, {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ tenantId: next.tenantId, enabled: next.enabled, groups: next.groups, contentRetentionDisabled: next.contentRetentionDisabled, policyIds: accessForm.policyIds }),
-      });
-      try {
-        await refresh();
-      } catch (caught) {
-        const message = errorMessage(caught);
-        setSelectedUserEmail(email);
-        setAccessForm(accessFormFromUser(next, nextBindings));
-        setUserError(`saved user, but refresh failed: ${message}`);
-        setStatus("saved user; refresh failed");
-        return;
-      }
-      setSelectedUserEmail(email);
-      setAccessForm(accessFormFromUser(next, nextBindings));
-      setStatus("saved user");
-    } catch (caught) {
-      const message = errorMessage(caught);
-      setUserError(message);
-      setStatus(message);
-      await refresh().catch(() => undefined);
-      setUserError(message);
-      setStatus(message);
-    }
-  }
-
-  async function revokePolicy(policyId: string) {
-    try {
-      setStatus(`revoking ${policyId}`);
-      if (demoMode) {
-        applyDemoKeys((current) => current.map((key) => key.policyId === policyId ? { ...key, enabled: false } : key));
-        setStatus(`revoked ${policyId}`);
-        return;
-      }
-      await request<AccessPolicy>(gatewayOrigin, `/v1/admin/policies/${encodeURIComponent(policyId)}/revoke`, { method: "POST" });
-      await refresh();
-      setStatus(`revoked ${policyId}`);
-    } catch (caught) {
-      handlePolicyError(caught);
-    }
-  }
-
-  function editPolicy(key: AccessPolicy) {
-    setIssuedKey("");
-    setSelectedPolicyId(key.policyId);
-    setPolicyForm(policyFormFromPolicy(key));
-    setCredentialForm((current) => ({ ...current, policyId: key.policyId }));
-    setBindingForm((current) => ({ ...current, policyId: key.policyId }));
-  }
-
-  function startNewPolicy() {
-    setIssuedKey("");
-    setPolicyError("");
-    setSelectedPolicyId("");
-    setPolicyForm({ ...defaultPolicy, policyId: "", tenantId: session.tenantId ?? "default", providers: [...defaultPolicy.providers] });
-  }
-
-  function startNewUser() {
-    setSelectedUserEmail("");
-    setUserError("");
-    setAccessForm({ ...defaultAccess, email: "", tenantId: session.tenantId ?? "default" });
-  }
-
-  function editBinding(binding: PolicyBinding) {
-    setSelectedBindingKey(bindingKey(binding));
-    setBindingForm(bindingFormFromBinding(binding));
-  }
-
-  function startNewBinding() {
-    setSelectedBindingKey("");
-    setBindingForm({ ...defaultBinding, policyId: selectedPolicyId || keys[0]?.policyId || "" });
-  }
-
-  function editUpstreamGrant(grant: UpstreamGrant) {
-    setSelectedUpstreamGrantKey(grant.key);
-    setUpstreamGrantForm(upstreamGrantFormFromGrant(grant));
-  }
-
-  function startNewUpstreamGrant() {
-    const provider = providers[0]?.id ?? "";
-    setSelectedUpstreamGrantKey("");
-    setUpstreamGrantForm({ ...defaultUpstreamGrant, scopeId: selectedPolicyId || keys[0]?.policyId || "default", provider, tokenRef: provider });
-  }
-
-  function editAssignmentRule(rule: AssignmentRule) {
-    setSelectedAssignmentRuleId(rule.ruleId);
-    setAssignmentRuleForm(assignmentRuleFormFromRule(rule));
-  }
-
-  function startNewAssignmentRule() {
-    setSelectedAssignmentRuleId("");
-    setAssignmentRuleForm({ ...defaultAssignmentRule, policyIds: [] });
-  }
-
-  function applyPreset(role: keyof typeof rolePresets) {
-    const preset = rolePresets[role];
-    const available = new Set(providers.map((provider) => provider.id));
-    setPolicyForm((current) => ({
-      ...current,
-      tokenRole: role,
-      monthlyBudgetMicros: currencyInput(optionalNumber(preset.budget)),
-      requestCostMicros: preset.request,
-      providers: preset.providers.length ? preset.providers.filter((id) => available.has(id)) : providers.map((provider) => provider.id),
-      allProviders: false,
-    }));
-  }
-
-  function togglePolicyProvider(providerId: string) {
-    const allProviderIds = providers.map((provider) => provider.id);
-    setPolicyForm((current) => ({
-      ...current,
-      allProviders: false,
-      providers: (current.allProviders ? allProviderIds : current.providers).includes(providerId)
-        ? (current.allProviders ? allProviderIds : current.providers).filter((id) => id !== providerId)
-        : [...current.providers, providerId].sort(),
-    }));
-  }
-
-  function setPolicyProviderGroup(providerIds: string[], checked: boolean) {
-    const allProviderIds = providers.map((provider) => provider.id);
-    setPolicyForm((current) => {
-      if (current.allProviders && checked) return current;
-      const selected = current.allProviders ? allProviderIds : current.providers;
-      return { ...current, allProviders: false, providers: checked ? unique([...selected, ...providerIds]).sort() : selected.filter((id) => !providerIds.includes(id)) };
-    });
-  }
-
-  function applyDemoKeys(updater: (current: AccessPolicy[]) => AccessPolicy[]) {
-    const next = updater(keys);
-    setKeys(next);
-    syncDemoAdmin(next, credentials, providers, routes, true);
-  }
-
-  function applyDemoCredentials(updater: (current: ProxyCredential[]) => ProxyCredential[]) {
-    const next = updater(credentials);
-    setCredentials(next);
-    syncDemoAdmin(keys, next, providers, routes);
-  }
-
-  function handlePolicyError(caught: unknown) {
-    const message = errorMessage(caught);
-    setPolicyError(message);
-    setStatus(message);
+  function editPolicy(item: AccessPolicy) {
+    policy.policies.edit(item);
+    principal.bindings.setForm((current) => ({ ...current, policyId: item.policyId }));
   }
 
   return {
     loaded,
     setLoaded,
-    tab: { value: accessTab, set: setAccessTab },
-    policies: { items: keys, setItems: setKeys, selected: selectedPolicy, selectedId: selectedPolicyId, setSelectedId: setSelectedPolicyId, form: policyForm, setForm: setPolicyForm, error: policyError, setError: setPolicyError, save: savePolicy, revoke: revokePolicy, edit: editPolicy, startNew: startNewPolicy, applyPreset, toggleProvider: togglePolicyProvider, setProviderGroup: setPolicyProviderGroup },
-    credentials: { items: credentials, setItems: setCredentials, selected: selectedCredential, selectedId: selectedCredentialId, setSelectedId: setSelectedCredentialId, form: credentialForm, setForm: setCredentialForm, issuedKey, setIssuedKey, issue: issueCredential, revoke: revokeCredential },
-    connections: { items: connections, setItems: setConnections, setEnabled: setProviderConnection },
-    bindings: { items: bindings, setItems: setBindings, selected: selectedBinding, selectedKey: selectedBindingKey, setSelectedKey: setSelectedBindingKey, form: bindingForm, setForm: setBindingForm, save: saveBinding, edit: editBinding, startNew: startNewBinding },
-    upstream: { items: upstreamGrants, setItems: setUpstreamGrants, selected: selectedUpstreamGrant, selectedKey: selectedUpstreamGrantKey, setSelectedKey: setSelectedUpstreamGrantKey, form: upstreamGrantForm, setForm: setUpstreamGrantForm, save: saveUpstreamGrant, revoke: revokeUpstreamGrant, refresh: refreshUpstreamGrant, authorize: authorizeUpstreamGrant, edit: editUpstreamGrant, startNew: startNewUpstreamGrant },
-    assignments: { items: assignmentRules, setItems: setAssignmentRules, selected: selectedAssignmentRule, selectedId: selectedAssignmentRuleId, setSelectedId: setSelectedAssignmentRuleId, form: assignmentRuleForm, setForm: setAssignmentRuleForm, save: saveAssignmentRule, reconcile: reconcileAssignments, edit: editAssignmentRule, startNew: startNewAssignmentRule },
-    users: { items: users, setItems: setUsers, selected: selectedUser, selectedEmail: selectedUserEmail, setSelectedEmail: setSelectedUserEmail, form: accessForm, setForm: setAccessForm, error: userError, setError: setUserError, save: saveUser, startNew: startNewUser },
+    tab: { value: tab, set: setTab },
+    policies: { ...policy.policies, edit: editPolicy },
+    credentials: policy.credentials,
+    connections: connection.connections,
+    bindings: principal.bindings,
+    upstream: upstream.upstream,
+    assignments: assignment.assignments,
+    users: principal.users,
     hydrateAdmin,
     hydrateUser,
     hydrateDemo,

--- a/admin/src/hooks/use-playground.ts
+++ b/admin/src/hooks/use-playground.ts
@@ -1,4 +1,4 @@
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import {
   playgroundAccessEndpoint,
   playgroundBlocker,
@@ -24,6 +24,7 @@ interface PlaygroundDependencies {
 }
 
 export function usePlayground({ gatewayOrigin, demoMode, setStatus, models, serviceRoutes, accessByProvider, providerReadiness }: PlaygroundDependencies) {
+  const initializedModelsRef = useRef(false);
   const [form, setForm] = useState<PlaygroundForm>({
     mode: "model",
     model: catalogModels(demo.routes)[0]?.id ?? "",
@@ -42,10 +43,14 @@ export function usePlayground({ gatewayOrigin, demoMode, setStatus, models, serv
   const selectedServiceRoute = serviceRoutes.find((route) => routeKey(route) === form.serviceRoute) ?? serviceRoutes[0];
 
   useEffect(() => {
-    if (models.length && !models.some((model) => model.id === form.model)) {
-      setForm((current) => ({ ...current, model: models[0].id }));
+    if (!models.length) return;
+    if (!initializedModelsRef.current || !models.some((model) => model.id === form.model)) {
+      initializedModelsRef.current = true;
+      const usable = models.filter((model) => accessByProvider.get(model.provider)?.allowed && providerReadiness[model.provider]?.executable);
+      const preferred = usable.find((model) => model.provider === "openai") ?? usable[0] ?? models[0];
+      setForm((current) => ({ ...current, model: preferred.id }));
     }
-  }, [form.model, models]);
+  }, [accessByProvider, form.model, models, providerReadiness]);
 
   useEffect(() => {
     if (serviceRoutes.length && !serviceRoutes.some((route) => routeKey(route) === form.serviceRoute)) {

--- a/admin/src/screens/access.tsx
+++ b/admin/src/screens/access.tsx
@@ -148,7 +148,7 @@ export function AssignmentRulePanel({ policies, rules, selected, form, setForm, 
       <section className="mainPane">
         <div className="overviewStrip">
           <Metric label="active rules" value={String(rules.filter((rule) => rule.enabled).length)} meta={`${rules.length} total`} />
-          <Metric label="email rules" value={String(rules.filter((rule) => rule.kind.startsWith("email") || rule.kind === "exact_email").length)} meta="reconcile on login" />
+          <Metric label="email rules" value={String(rules.filter((rule) => rule.kind.startsWith("email") || rule.kind === "exact_email").length)} meta="reconcile on rule change" />
           <Metric label="GitHub rules" value={String(rules.filter((rule) => rule.kind.startsWith("github")).length)} meta="verified evidence only" />
         </div>
         <div className="tableSectionHeader"><div><strong>Automatic assignments</strong><span>Identity evidence to managed group access</span></div><div className="inlineActions"><button type="button" className="buttonSecondary" onClick={onReconcile} disabled={busy}><RefreshCw className="buttonIcon" aria-hidden="true" /><span>Reconcile all</span></button><button type="button" onClick={onNew} disabled={busy}><Plus className="buttonIcon" aria-hidden="true" /><span>New rule</span></button></div></div>

--- a/admin/src/screens/dashboard-catalog.tsx
+++ b/admin/src/screens/dashboard-catalog.tsx
@@ -191,7 +191,7 @@ export function CatalogScreen({ services, allServices, selected, policies, conne
       <section className="mainPane">
         <div className="catalogControls">
           <div className="catalogMeta"><strong>{services.length} services</strong><span>{usableCount} usable · {grantedCount} granted · {blockedCount} blocked</span></div>
-          <label><span>search catalog</span><div className="inputWithIcon"><Search aria-hidden="true" /><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="service, provider, model, route" /></div></label>
+          <label><span>search catalog</span><div className="inputWithIcon"><Search aria-hidden="true" /><input name="catalog-search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="service, provider, model, route" /></div></label>
           <div className="kindTabs" role="tablist" aria-label="service kind">
             {kinds.map((item) => <button key={item} type="button" className={kind === item ? "active" : ""} onClick={() => setKind(item)}>{kindLabel(item)}<span>{kindCounts.get(item) ?? 0}</span></button>)}
           </div>

--- a/admin/src/ui-types.ts
+++ b/admin/src/ui-types.ts
@@ -1,313 +1,67 @@
+import type React from "react";
+import type {
+  AccessPolicy,
+  AccessRole,
+  AccessUser,
+  AdminBootstrapResponse,
+  AdminOverview,
+  AdminTenantSummary,
+  AdminUsageRow,
+  AssignmentRule,
+  BudgetStatus,
+  ContentRetention,
+  EntitlementsResponse,
+  PolicyBinding,
+  ProviderAccess,
+  ProviderConnection,
+  ProviderReadiness,
+  ProviderResponse,
+  ProviderRow,
+  ProviderUsageSummary,
+  ProxyCredential,
+  RetainedRequestContent,
+  RouteCatalog,
+  SessionResponse,
+  UpstreamGrant,
+  UsageAuditEvent,
+  UsageSnapshot,
+  UsageSummary,
+} from "../../shared/contracts";
+
+export type {
+  AccessPolicy,
+  AccessRole,
+  AccessUser,
+  AdminBootstrapResponse,
+  AdminOverview,
+  AdminTenantSummary,
+  AdminUsageRow,
+  AssignmentRule,
+  BudgetStatus,
+  ContentRetention,
+  EntitlementsResponse,
+  PolicyBinding,
+  ProviderAccess,
+  ProviderConnection,
+  ProviderReadiness,
+  ProviderResponse,
+  ProviderRow,
+  ProviderUsageSummary,
+  ProxyCredential,
+  RetainedRequestContent,
+  RouteCatalog,
+  SessionResponse,
+  UpstreamGrant,
+  UsageAuditEvent,
+  UsageSnapshot,
+  UsageSummary,
+} from "../../shared/contracts";
+
 export type View = "home" | "catalog" | "playground" | "policies" | "users" | "usage";
 export type Theme = "light" | "dark";
 export type RefreshOptions = { background?: boolean };
-export type AccessRole = "admin" | "user";
 export type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 export type BrandIcon = { label?: string; title?: string; viewBox?: string; body?: string };
-
-export interface ProviderRow {
-  id: string;
-  display_name: string;
-  class: string;
-  service_kind: string;
-  meter?: string | null;
-  capabilities: Array<{ id: string }>;
-  auth?: {
-    authorization?: {
-      grantKind?: "oauth" | "subscription";
-    } | null;
-  };
-}
-
-export interface ProviderResponse {
-  providers: ProviderRow[];
-}
-
-export interface RouteCatalog {
-  openaiCompatible: Array<{
-    provider: string;
-    models: Array<{ id: string; capabilities: string[]; endpoints: string[] }>;
-    modelPrefixes?: string[];
-    endpoints: string[];
-  }>;
-  manifestProxy: Array<{
-    provider: string;
-    endpoint: string;
-    route: string;
-    methods: string[];
-    pathParams?: string[];
-    requestFormat?: string;
-    sampleModel?: string | null;
-    models?: Array<{ id: string; capabilities: string[] }>;
-    streaming?: boolean | null;
-  }>;
-}
-
-export interface AccessPolicy {
-  policyId: string;
-  enabled: boolean;
-  providers: string[];
-  tenantId?: string | null;
-  tokenRole?: string | null;
-  monthlyBudgetMicros?: number | null;
-  requestCostMicros?: number | null;
-  retainRequestContent: boolean;
-}
-
-export interface ProxyCredential {
-  credentialId: string;
-  policyId: string;
-  enabled: boolean;
-  policyEnabled?: boolean;
-  generationMatches?: boolean;
-  active?: boolean;
-  principalId?: string | null;
-}
-
-export interface ProviderConnection {
-  providerId: string;
-  enabled: boolean;
-  label?: string | null;
-}
-
-export interface UpstreamGrant {
-  key: string;
-  scope: "policies" | "tenants";
-  scopeId: string;
-  tokenRef: string;
-  version: number;
-  enabled: boolean;
-  kind: "api_key" | "oauth" | "subscription";
-  provider?: string | null;
-  label?: string | null;
-  tokenType: string;
-  expiresAt?: string | null;
-  scopes: string[];
-  accountId?: string | null;
-  subscription?: { plan?: string | null; subject?: string | null } | null;
-  createdAt?: string | null;
-  updatedAt?: string | null;
-  revokedAt?: string | null;
-  hasCredential: boolean;
-  credentialFields: string[];
-  hasAccessToken: boolean;
-  hasRefreshToken: boolean;
-  refreshConfigured: boolean;
-  usable: boolean;
-}
-
-export interface AssignmentRule {
-  ruleId: string;
-  version: number;
-  enabled: boolean;
-  kind: "exact_email" | "email_domain" | "github_org" | "github_team";
-  subject: string;
-  groups: string[];
-  policyIds: string[];
-  priority: number;
-  revokeOnLoss: boolean;
-  provenance: string;
-  generatedGroup: string;
-  createdAt?: string | null;
-  updatedAt?: string | null;
-}
-
-export interface SessionResponse {
-  authenticated: boolean;
-  auth: string;
-  role: AccessRole;
-  email?: string | null;
-  subject?: string | null;
-  tenantId?: string | null;
-  groups?: string[];
-  entitlements?: { providers: ProviderAccess[] } | null;
-  entitlementsError?: string | null;
-  contentRetention?: ContentRetention;
-}
-
-export interface ContentRetention {
-  enabled: boolean;
-  retentionDays: number;
-  policyEnabled: boolean;
-  userExempt: boolean;
-}
-
-export interface ProviderReadiness {
-  id: string;
-  displayName: string;
-  class: string;
-  serviceKind: string;
-  requiredConfig: string[];
-  optionalConfig: string[];
-  missingConfig: string[];
-  configPresent: boolean;
-  oauthGrantRequired: boolean;
-  oauthGrantCount: number;
-  upstreamGrantCount: number;
-  openaiCompatible: boolean;
-  manifestRoutes: number;
-  modelCount: number;
-  connectionEnabled?: boolean;
-  verified?: boolean;
-  lastCheckedAt?: string | null;
-  latencyMs?: number | null;
-  executable: boolean;
-  status: string;
-  reasons: string[];
-}
-
-export interface ProviderAccess {
-  provider: string;
-  displayName: string;
-  serviceKind: string;
-  allowed: boolean;
-  policies: string[];
-  readiness: ProviderReadiness;
-}
-
-export interface EntitlementsResponse {
-  session: SessionResponse;
-  providers: ProviderAccess[];
-  contentRetention: ContentRetention;
-}
-
-export interface AccessUser {
-  email: string;
-  role: AccessRole;
-  tenantId: string;
-  enabled: boolean;
-  groups: string[];
-  contentRetentionDisabled: boolean;
-}
-
-export interface PolicyBinding {
-  policyId: string;
-  principalType: "user" | "group";
-  principalId: string;
-  enabled: boolean;
-  priority: number;
-}
-
-export interface AdminOverview {
-  policiesTotal?: number;
-  policiesActive?: number;
-  keysTotal: number;
-  keysActive: number;
-  tenantsTotal: number;
-  providerCount: number;
-  openaiCompatibleProviders: number;
-  manifestRoutes: number;
-  monthlyBudgetMicros: number;
-  requestCostMicros: number;
-}
-
-export interface AdminTenantSummary {
-  tenantId: string;
-  policies?: number;
-  activePolicies?: number;
-  keys: number;
-  activeKeys: number;
-  providers: string[];
-  allProviders?: boolean;
-  monthlyBudgetMicros: number;
-  requestCostMicros: number;
-}
-
-export interface BudgetStatus {
-  configured: boolean;
-  ledger: string;
-  windowKey?: string | null;
-  limitMicros?: number | null;
-  spentMicros?: number | null;
-  remainingMicros?: number | null;
-}
-
-export interface AdminUsageRow {
-  policyId?: string;
-  kid: string;
-  tenantId: string;
-  enabled: boolean;
-  providers: string[];
-  tokenRole?: string | null;
-  monthlyBudgetMicros?: number | null;
-  requestCostMicros?: number | null;
-  budget: BudgetStatus;
-}
-
-export interface UsageSummary {
-  requestCount: number;
-  successCount: number;
-  errorCount: number;
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  actualCostMicros: number;
-}
-
-export interface ProviderUsageSummary {
-  provider: string;
-  requestCount: number;
-  successCount: number;
-  errorCount: number;
-  totalTokens: number;
-  actualCostMicros: number;
-}
-
-export interface UsageAuditEvent {
-  id: string;
-  type: string;
-  occurred_at_ms: number;
-  tenant_id: string;
-  policy_id?: string | null;
-  credential_id?: string | null;
-  principal_id?: string | null;
-  auth_type?: string | null;
-  session_id?: string | null;
-  agent_id?: string | null;
-  parent_agent_id?: string | null;
-  project_id?: string | null;
-  client?: string | null;
-  key_id?: string | null;
-  request_id?: string | null;
-  provider: string;
-  capability?: string | null;
-  model?: string | null;
-  input_tokens?: number | null;
-  output_tokens?: number | null;
-  total_tokens?: number | null;
-  cached_input_tokens?: number | null;
-  cache_write_input_tokens?: number | null;
-  reserved_cost_micros: number;
-  actual_cost_micros: number;
-  reserved_input_tokens?: number | null;
-  reserved_output_tokens?: number | null;
-  pricing_ref?: string | null;
-  pricing_effective_at?: string | null;
-  cost_basis?: string | null;
-  status_code?: number | null;
-  duration_ms?: number | null;
-  status: string;
-  content_retained?: boolean;
-  content_ref?: string | null;
-}
-
-export interface UsageSnapshot {
-  ledger: string;
-  summary: UsageSummary;
-  providers: ProviderUsageSummary[];
-  events: UsageAuditEvent[];
-}
-
-export interface RetainedRequestContent {
-  requestId: string;
-  occurredAtMs: number;
-  expiresAtMs: number;
-  principalId?: string | null;
-  provider: string;
-  capability: string;
-  model?: string | null;
-  body: unknown;
-}
 
 export interface ServiceItem {
   id: string;
@@ -327,14 +81,7 @@ export interface ServiceItem {
 }
 
 export type OutcomeTone = "active" | "revoked" | "neutral";
-
-export interface ServiceOutcome {
-  label: string;
-  detail: string;
-  tone: OutcomeTone;
-  playable: boolean;
-  blocked: boolean;
-}
+export interface ServiceOutcome { label: string; detail: string; tone: OutcomeTone; playable: boolean; blocked: boolean }
 
 export interface PolicyForm {
   policyId: string;
@@ -348,57 +95,11 @@ export interface PolicyForm {
   retainRequestContent: boolean;
 }
 
-export interface AccessForm {
-  email: string;
-  tenantId: string;
-  enabled: boolean;
-  groups: string;
-  policyIds: string[];
-  contentRetentionDisabled: boolean;
-}
-
-export interface CredentialForm {
-  credentialId: string;
-  policyId: string;
-  principalId: string;
-}
-
-export interface BindingForm {
-  policyId: string;
-  principalType: "user" | "group";
-  principalId: string;
-  enabled: boolean;
-  priority: string;
-}
-
-export interface UpstreamGrantForm {
-  scope: "policies" | "tenants";
-  scopeId: string;
-  tokenRef: string;
-  kind: UpstreamGrant["kind"];
-  provider: string;
-  label: string;
-  enabled: boolean;
-  credential: string;
-  credentialBundle: string;
-  accessToken: string;
-  refreshToken: string;
-  accountId: string;
-  expiresAt: string;
-}
-
-export interface AssignmentRuleForm {
-  ruleId: string;
-  enabled: boolean;
-  kind: AssignmentRule["kind"];
-  subject: string;
-  groups: string;
-  policyIds: string[];
-  priority: string;
-  revokeOnLoss: boolean;
-  provenance: string;
-}
-
+export interface AccessForm { email: string; tenantId: string; enabled: boolean; groups: string; policyIds: string[]; contentRetentionDisabled: boolean }
+export interface CredentialForm { credentialId: string; policyId: string; principalId: string }
+export interface BindingForm { policyId: string; principalType: "user" | "group"; principalId: string; enabled: boolean; priority: string }
+export interface UpstreamGrantForm { scope: "policies" | "tenants"; scopeId: string; tokenRef: string; kind: UpstreamGrant["kind"]; provider: string; label: string; enabled: boolean; credential: string; credentialBundle: string; accessToken: string; refreshToken: string; accountId: string; expiresAt: string }
+export interface AssignmentRuleForm { ruleId: string; enabled: boolean; kind: AssignmentRule["kind"]; subject: string; groups: string; policyIds: string[]; priority: string; revokeOnLoss: boolean; provenance: string }
 export type AccessTab = "policies" | "credentials" | "bindings" | "upstream" | "assignments";
 
 export interface PlaygroundForm {
@@ -415,28 +116,5 @@ export interface PlaygroundForm {
   temperature: string;
 }
 
-export interface PlaygroundTurn {
-  id: string;
-  mode: PlaygroundForm["mode"];
-  prompt: string;
-  response: string;
-  rawResponse: string;
-  request: string;
-  provider: string;
-  model: string;
-  endpoint: string;
-  status: number | null;
-  durationMs: number;
-  retention: string;
-  error?: string;
-}
-
-export interface PlaygroundHttpResponse {
-  ok: boolean;
-  raw: string;
-  status: number;
-  statusText: string;
-  contentType: string;
-  retention: string;
-}
-import type React from "react";
+export interface PlaygroundTurn { id: string; mode: PlaygroundForm["mode"]; prompt: string; response: string; rawResponse: string; request: string; provider: string; model: string; endpoint: string; status: number | null; durationMs: number; retention: string; error?: string }
+export interface PlaygroundHttpResponse { ok: boolean; raw: string; status: number; statusText: string; contentType: string; retention: string }

--- a/admin/src/use-console-controller.ts
+++ b/admin/src/use-console-controller.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { effectiveAccess, errorMessage, policyUsageFallback, tenantSummaryFallback } from "./domain";
+import { effectiveAccess, errorMessage, policyCoversProvider, policyUsageFallback } from "./domain";
 import { useAccessAdmin } from "./hooks/use-access-admin";
 import { useCatalog } from "./hooks/use-catalog";
 import { usePlayground } from "./hooks/use-playground";
@@ -7,20 +7,13 @@ import { useSession } from "./hooks/use-session";
 import { useUsage } from "./hooks/use-usage";
 import { installAutoRefresh } from "./auto-refresh";
 import { demo } from "./ui-config";
-import { adminOverviewFromPolicies, localDemoRole, oauthCallbackStatus, request, settled } from "./ui-helpers";
+import { localDemoRole, oauthCallbackStatus, request, settled } from "./ui-helpers";
 import type {
-  AccessPolicy,
   AccessUser,
-  AdminOverview,
-  AdminTenantSummary,
+  AdminBootstrapResponse,
   AdminUsageRow,
-  AssignmentRule,
   EntitlementsResponse,
-  PolicyBinding,
-  ProviderConnection,
-  ProviderReadiness,
   ProviderResponse,
-  ProxyCredential,
   RefreshOptions,
   RouteCatalog,
   SessionResponse,
@@ -35,6 +28,7 @@ export function useConsoleController() {
   const usage = useUsage(session.allowDemo);
   const refreshPromiseRef = useRef<Promise<void> | null>(null);
   const refreshBackgroundRef = useRef(false);
+  const catalogLoadedRef = useRef(false);
   const refreshRef = useRef<(options?: RefreshOptions) => Promise<void>>(async () => undefined);
   const refreshCurrent = useCallback(() => refreshRef.current(), []);
   const access = useAccessAdmin({
@@ -118,14 +112,20 @@ export function useConsoleController() {
         session.setStatus("loading");
         access.setLoaded(false);
       }
-      const [sessionData, providerData, routeData] = await Promise.all([
+      const staticCatalog = catalogLoadedRef.current
+        ? Promise.resolve({ providerData: { providers: catalog.providers }, routeData: catalog.routes })
+        : Promise.all([
+          request<ProviderResponse>(session.gatewayOrigin, "/v1/providers"),
+          request<RouteCatalog>(session.gatewayOrigin, "/v1/routes"),
+        ]).then(([providerData, routeData]) => ({ providerData, routeData }));
+      const [sessionData, { providerData, routeData }] = await Promise.all([
         request<SessionResponse>(session.gatewayOrigin, "/v1/session"),
-        request<ProviderResponse>(session.gatewayOrigin, "/v1/providers"),
-        request<RouteCatalog>(session.gatewayOrigin, "/v1/routes"),
+        staticCatalog,
       ]);
       session.setValue(sessionData);
       catalog.setProviders(providerData.providers);
       catalog.setRoutes(routeData);
+      catalogLoadedRef.current = true;
       let warnings = sessionData.entitlementsError ? [`entitlements unavailable: ${sessionData.entitlementsError}`] : [];
       const sessionEntitlements: EntitlementsResponse | null = sessionData.entitlements
         ? {
@@ -143,7 +143,7 @@ export function useConsoleController() {
           warnings = [...warnings, `entitlements unavailable: ${entitlementResult.error}`];
         }
       }
-      if (sessionData.role === "admin") warnings = await loadAdminData(sessionData, providerData, routeData, background, warnings);
+      if (sessionData.role === "admin") warnings = await loadAdminData(sessionData, providerData, background, warnings);
       else warnings = await loadUserData(sessionData, warnings);
       session.setDemoMode(false);
       session.setLastUpdatedAt(Date.now());
@@ -159,51 +159,30 @@ export function useConsoleController() {
     }
   }
 
-  async function loadAdminData(sessionData: SessionResponse, providerData: ProviderResponse, routeData: RouteCatalog, background: boolean, initialWarnings: string[]) {
+  async function loadAdminData(sessionData: SessionResponse, providerData: ProviderResponse, background: boolean, initialWarnings: string[]) {
     let warnings = initialWarnings;
-    const [policyData, credentialData, connectionData, userData, bindingData, readinessData, upstreamGrantData, assignmentRuleData] = await Promise.all([
-      request<{ policies: AccessPolicy[] }>(session.gatewayOrigin, "/v1/admin/policies"),
-      request<{ credentials: ProxyCredential[] }>(session.gatewayOrigin, "/v1/admin/credentials"),
-      request<{ connections: ProviderConnection[] }>(session.gatewayOrigin, "/v1/admin/connections"),
-      request<{ users: AccessUser[] }>(session.gatewayOrigin, "/v1/admin/access-users"),
-      request<{ bindings: PolicyBinding[] }>(session.gatewayOrigin, "/v1/admin/policy-bindings"),
-      request<{ providers: ProviderReadiness[] }>(session.gatewayOrigin, "/v1/admin/provider-status"),
-      request<{ grants: UpstreamGrant[] }>(session.gatewayOrigin, "/v1/admin/upstream-grants"),
-      request<{ rules: AssignmentRule[] }>(session.gatewayOrigin, "/v1/admin/assignment-rules"),
-    ]);
+    const data = await request<AdminBootstrapResponse>(session.gatewayOrigin, "/v1/admin/bootstrap");
     access.hydrateAdmin({
-      policies: policyData.policies,
-      credentials: credentialData.credentials,
-      connections: connectionData.connections,
-      users: userData.users,
-      bindings: bindingData.bindings,
-      grants: upstreamGrantData.grants,
-      rules: assignmentRuleData.rules,
+      policies: data.policies,
+      credentials: data.credentials,
+      connections: data.connections,
+      users: data.users,
+      bindings: data.bindings,
+      grants: data.grants,
+      rules: data.rules,
     }, background, sessionData, providerData.providers);
-    catalog.mergeReadiness(readinessData.providers);
-    const [overviewResult, tenantResult, usageResult] = await Promise.all([
-      settled(() => request<AdminOverview>(session.gatewayOrigin, "/v1/admin/overview")),
-      settled(() => request<{ tenants: AdminTenantSummary[] }>(session.gatewayOrigin, "/v1/admin/tenants")),
-      background
-        ? settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(session.gatewayOrigin, "/v1/admin/usage"))
-        : Promise.resolve(null),
-    ]);
-    if (overviewResult.ok) usage.setAdminOverview(overviewResult.value);
-    else {
-      usage.setAdminOverview(adminOverviewFromPolicies(policyData.policies, credentialData.credentials, providerData.providers, routeData));
-      warnings = [...warnings, `overview unavailable: ${overviewResult.error}`];
-    }
-    if (tenantResult.ok) usage.setTenantSummaries(tenantResult.value.tenants);
-    else {
-      usage.setTenantSummaries(tenantSummaryFallback(policyData.policies, credentialData.credentials));
-      warnings = [...warnings, `tenant summary unavailable: ${tenantResult.error}`];
-    }
+    catalog.mergeReadiness(data.providers);
+    usage.setAdminOverview(data.overview);
+    usage.setTenantSummaries(data.tenants);
+    const usageResult = background && (session.view === "home" || session.view === "usage")
+      ? await settled(() => request<{ policies?: AdminUsageRow[]; keys?: AdminUsageRow[]; usage: UsageSnapshot }>(session.gatewayOrigin, "/v1/admin/usage"))
+      : null;
     if (usageResult?.ok) {
       usage.setRows(usageResult.value.policies ?? usageResult.value.keys ?? []);
       usage.setSnapshot(usageResult.value.usage);
       usage.setLoaded(true);
     } else if (usageResult) warnings = [...warnings, `usage ledger unavailable: ${usageResult.error}`];
-    else usage.resetLedger();
+    else if (!background) usage.resetLedger();
     if (!background && session.view === "usage") usage.requestRefresh();
     return warnings;
   }
@@ -252,7 +231,6 @@ export function useConsoleController() {
   function loadUserDemo() {
     const user = demo.users.find((candidate) => candidate.email === "research@example.com") ?? demo.users.find((candidate) => candidate.role === "user")!;
     const effective = effectiveAccess(user, demo.keys, demo.bindings, demo.services);
-    const policyIds = new Set(effective.policies.map((policy) => policy.policyId));
     const providerIds = new Set(effective.services.map((service) => service.provider));
     const providerUsage = demo.usage.providers.filter((provider) => providerIds.has(provider.provider));
     const summary = providerUsage.reduce<UsageSummary>((current, provider) => ({
@@ -263,18 +241,19 @@ export function useConsoleController() {
       totalTokens: current.totalTokens + provider.totalTokens,
       actualCostMicros: current.actualCostMicros + provider.actualCostMicros,
     }), { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 });
+    const contentRetention = {
+      enabled: !user.contentRetentionDisabled && effective.policies.some((policy) => policy.retainRequestContent),
+      retentionDays: 30,
+      policyEnabled: effective.policies.some((policy) => policy.retainRequestContent),
+      userExempt: user.contentRetentionDisabled,
+    };
     const entitlements: EntitlementsResponse = {
-      session: { ...demo.session, ...user, auth: "demo" },
-      contentRetention: {
-        enabled: !user.contentRetentionDisabled && effective.policies.some((policy) => policy.retainRequestContent),
-        retentionDays: 30,
-        policyEnabled: effective.policies.some((policy) => policy.retainRequestContent),
-        userExempt: user.contentRetentionDisabled,
-      },
+      session: { ...demo.session, ...user, auth: "demo", contentRetention },
+      contentRetention,
       providers: demo.entitlements.providers.map((provider) => ({
         ...provider,
         allowed: providerIds.has(provider.provider),
-        policies: provider.policies.filter((policyId) => policyIds.has(policyId)),
+        policies: effective.policies.filter((policy) => policyCoversProvider(policy, provider.provider)).map((policy) => policy.policyId),
       })),
     };
     session.setValue(entitlements.session);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,55 @@
+# Architecture
+
+ClawRouter keeps the request path small and provider-neutral. Provider manifests
+compile into one immutable catalog; runtime modules enforce identity, access,
+readiness, retention, budget, forwarding, and accounting in that order.
+
+## Control plane
+
+`ACCESS_CONTROL` is canonical for policies, proxy credentials, users, policy
+bindings, provider connections, and OAuth authorization state. Existing KV data
+is imported once per resource family and recorded with a Durable Object migration
+marker. After that marker, missing records remain missing; request paths never
+resurrect stale KV state. Assignment rules, scoped upstream grants, and provider
+health remain in KV because they have separate lifecycle and consistency needs.
+
+Authentication is read-only after an existing user receives versioned
+`assignmentState`. Rule changes reconcile users from the admin mutation path;
+verified GitHub evidence remains an explicit admin operation. Legacy KV
+assignment retention state is imported once before the first canonical
+reconciliation so unknown external membership does not revoke existing access.
+
+The browser loads immutable providers/routes once. Admin refreshes use
+`GET /v1/admin/bootstrap` for one coherent authority/readiness snapshot. Usage is
+loaded separately only on dashboard/usage surfaces. UI transport contracts live
+in `shared/contracts.ts`; forms and view models remain frontend-local. Local demo
+mode derives its catalog from the same generated provider snapshot to prevent
+provider and model drift.
+
+## Data plane
+
+1. Authenticate the Access session or proxy credential against canonical state.
+2. Resolve the selected policy and provider-scoped readiness. Tenant grants are
+   visible only to policies in that tenant; policy grants are exact-scope.
+3. Reserve the conservative budget before provider work.
+4. Retain eligible LLM request content in R2 when policy requires it. Storage
+   failure is fail-closed and prevents the upstream call.
+5. Sign and forward the provider request.
+6. Settle budget and enqueue the usage event independently. Either failure is
+   retried without masking the provider response or suppressing the other task.
+
+Usage events are queued into a Durable Object shard named by tenant and policy.
+Session/admin reads aggregate only their relevant shards. A bounded legacy read
+bridge includes the former global ledger through 2026-07-23; it performs one
+filtered global read per aggregate and can then be removed.
+
+## Failure boundaries
+
+- Revocation, provider connection state, and budget preflight fail closed.
+- Required request retention fails closed before upstream traffic.
+- Provider failures release a reservation to zero and emit audit metadata.
+- Settlement and usage delivery retry independently through `USAGE_QUEUE`.
+- Non-2xx Durable Object queue writes are retried and eventually reach the
+  configured dead-letter queue.
+- Raw requests live only in the retention archive; usage ledgers contain metadata
+  and content references, never prompts or completions.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -2,24 +2,25 @@
 
 ClawRouter’s edge runtime is a TypeScript Worker. Revocation-critical runtime
 policy lives in serialized Durable Object authority so access can be revoked
-without a redeploy. Cloudflare KV stores migration seeds, compatibility copies,
-OAuth grants, and operational health.
+without a redeploy. Cloudflare KV stores one-time migration seeds, assignment
+rules, OAuth grants, and operational health.
 
 ## Required Bindings
 
-- `POLICY_KV`: migration seeds and compatibility copies for access policies,
-  issued credential hashes, principal bindings, users, and provider
-  connections, plus OAuth grants and provider health records.
+- `POLICY_KV`: one-time migration seeds for access policies, issued credential
+  hashes, principal bindings, users, and provider connections, plus assignment
+  rules, OAuth grants, and provider health records. After each resource family
+  is marked migrated, request paths do not fall back to its KV records.
 - `USAGE_QUEUE`: metered usage events and durable budget-settlement retries,
   with this Worker configured as producer and consumer.
 - usage DLQ, named by `CLAWROUTER_USAGE_DLQ`: separate queue for usage or
   settlement messages that exhaust automatic retries.
 - `BUDGET_LEDGER`: SQLite-backed Durable Object budget ledger.
 - `ACCESS_CONTROL`: SQLite-backed Durable Object authority for policies,
-  credential hashes, user state, per-provider kill-switch shards, serialized
-  user/group policy-binding mutations, and session entitlement lookup.
-- `USAGE_LEDGER`: SQLite-backed Durable Object request audit and reporting
-  ledger. It retains bounded metadata for 30 days and never stores prompt or
+  credential hashes, user state, provider kill switches, serialized user/group
+  policy-binding mutations, and session entitlement lookup.
+- `USAGE_LEDGER`: tenant/policy-sharded SQLite-backed Durable Object request
+  audit and reporting ledgers. They retain bounded metadata for 30 days and never store prompt or
   completion bodies. Request content retention uses the separate `CONTENT_ARCHIVE`
   R2 binding and never writes bodies to this ledger.
 - `CONTENT_ARCHIVE`: encrypted R2 storage for policy-retained LLM request bodies.
@@ -289,8 +290,8 @@ not bypass policy bindings.
 }
 ```
 
-`GET /v1/session` reports the verified Access session and carries the console
-bootstrap entitlements/readiness payload when `POLICY_KV` is available.
+`GET /v1/session` reports the verified Access session and carries its
+policy-scoped entitlements/readiness payload.
 `GET /v1/entitlements` remains available for deployments that also protect that
 compatibility route. The admin UI can call admin routes through the same-origin
 Access session; the admin bearer token is only a fallback for automation or
@@ -315,8 +316,8 @@ POST /v1/admin/assignment-rules/reconcile
 omitted fields. `PUT /v1/admin/access-user-grants/<email>` atomically updates
 the identity and replaces its complete direct-policy set.
 
-The authoritative record is stored in `ACCESS_CONTROL` and mirrored to
-`POLICY_KV` at `access/users/<email>` for compatibility:
+The authoritative record is stored in `ACCESS_CONTROL`. A pre-existing
+`POLICY_KV` record at `access/users/<email>` is imported once during migration:
 
 ```json
 {
@@ -328,8 +329,8 @@ The authoritative record is stored in `ACCESS_CONTROL` and mirrored to
 ```
 
 Bindings are indexed in `ACCESS_CONTROL` by principal so the request path reads
-only the signed-in user and their groups. `POLICY_KV` keeps compatibility
-copies:
+only the signed-in user and their groups. Pre-existing `POLICY_KV` records are
+one-time migration input:
 
 ```json
 {
@@ -344,8 +345,10 @@ copies:
 Lower priority numbers win when multiple bindings allow the same provider.
 
 Automatic assignment rules are stored separately from users and manual
-bindings. Exact-email and verified email-domain rules reconcile on first
-Cloudflare Access login and through the admin reconcile endpoint. Policy grants
+bindings. Authentication performs at most one assignment-state migration;
+unchanged sessions are read-only. Saving a rule reconciles known users, and the
+admin endpoint supports explicit reconciliation with verified external
+evidence. Policy grants
 use a rule-owned `assignment.<rule-id>` group, so reconciliation never replaces
 manual direct user bindings. GitHub organization/team rules require explicit
 verified GitHub evidence for one user; a reconcile without GitHub evidence
@@ -387,6 +390,7 @@ secret manager; only its SHA-256 hash belongs in the Worker and GitHub Actions.
 
 ```text
 GET /v1/admin/overview
+GET /v1/admin/bootstrap
 GET /v1/admin/tenants
 GET /v1/admin/usage
 GET /v1/admin/policies
@@ -434,12 +438,12 @@ API materializes a same-id policy and credential and accepts the same shape as
 `pnpm cf:key:put`, but with `secretSha256` instead of a raw key secret.
 
 Access user records are not role-grant records. Cloudflare Access creates the
-identity, `access/users/<email>` stores tenant/status/groups, policy bindings
+identity, `ACCESS_CONTROL` stores tenant/status/groups, policy bindings
 grant service access, and ClawRouter admin rights come from the Access admin
 email/domain allowlist configured on the Worker. `ACCESS_CONTROL` makes
 policies, credentials, user status, binding mutations, and session grant
-resolution strongly consistent. Provider kill switches use one authority object
-per provider so proxy traffic does not serialize through a global object.
+resolution strongly consistent. Provider kill switches use the same serialized
+authority; provider requests only resolve the selected connection.
 
 ## Keys and Revocation
 

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -10,11 +10,14 @@ const persistence = `.wrangler/e2e-${process.pid}`;
 const adminToken = "local-e2e-admin-token";
 const proxySecret = "secret_1234";
 const proxyKey = `clawrouter-live-migrate-${proxySecret}`;
+const legacySecret = "legacy_secret_1234";
+const legacyKey = `clawrouter-live-legacy-${legacySecret}`;
 const generation = "migration_e2e";
 writeFileSync(config, `${readFileSync("wrangler.toml", "utf8").trim()}\n\n[[kv_namespaces]]\nbinding = "POLICY_KV"\nid = "local-e2e"\n`);
 mkdirSync(persistence, { recursive: true });
 putLocalKv("policies/migrate", { enabled: true, generation, providers: ["firecrawl", "replicate"], tenantId: "default", tokenRole: "service", retainRequestContent: true });
 putLocalKv("credentials/migrate", { enabled: true, secretSha256: sha256(proxySecret), policyId: "migrate", policyGeneration: generation });
+putLocalKv("keys/legacy", { enabled: true, secretSha256: sha256(legacySecret), generation: "legacy", providers: ["firecrawl"], tenantId: "default", retainRequestContent: true });
 
 const child = spawn("pnpm", ["exec", "wrangler", "dev", "--local", "--ip", "127.0.0.1", "--port", String(port), "--persist-to", persistence, "--config", config, "--var", `CLAWROUTER_ADMIN_TOKEN_SHA256:${sha256(adminToken)}`, "--log-level", "info"], {
   cwd: process.cwd(),
@@ -47,6 +50,17 @@ try {
   const inspectionBody = await inspection.json();
   assert.equal(inspection.status, 200, JSON.stringify(inspectionBody));
   assert.equal(inspectionBody.verification, "verified", "KV-only credential migrates into authority on first use");
+  const bootstrap = await fetch(`${base}/v1/admin/bootstrap`, { headers: { authorization: `Bearer ${adminToken}` } });
+  assert.equal(bootstrap.status, 200);
+  const bootstrapBody = await bootstrap.json();
+  assert.ok(bootstrapBody.policies.some((policy) => policy.policyId === "migrate"));
+  assert.ok(bootstrapBody.credentials.some((credential) => credential.credentialId === "migrate"));
+  assert.ok(bootstrapBody.policies.some((policy) => policy.policyId === "legacy"));
+  assert.ok(bootstrapBody.credentials.some((credential) => credential.credentialId === "legacy"));
+  assert.equal(bootstrapBody.providers.length, 20);
+  assert.equal(new Set(bootstrapBody.providers.map((provider) => provider.id)).size, 20);
+  const legacyInspection = await fetch(`${base}/v1/key/inspect`, { headers: { authorization: `Bearer ${legacyKey}` } });
+  assert.equal(legacyInspection.status, 200, "bootstrap imports genuine combined legacy keys before setting migration markers");
   const clientCatalog = await fetch(`${base}/v1/catalog`, { headers: { authorization: `Bearer ${proxyKey}` } });
   assert.equal(clientCatalog.status, 200);
   assert.deepEqual((await clientCatalog.json()).providers.map((provider) => provider.id), ["firecrawl", "replicate"]);

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -1,0 +1,208 @@
+export interface ProviderRow {
+  id: string;
+  display_name: string;
+  class: string;
+  service_kind: string;
+  meter?: string | null;
+  capabilities: Array<{ id: string }>;
+  auth?: { authorization?: { grantKind?: "oauth" | "subscription" } | null };
+}
+
+export interface ProviderResponse { providers: ProviderRow[] }
+
+export interface RouteCatalog {
+  openaiCompatible: Array<{ provider: string; models: Array<{ id: string; capabilities: string[]; endpoints: string[] }>; modelPrefixes?: string[]; endpoints: string[] }>;
+  manifestProxy: Array<{ provider: string; endpoint: string; route: string; methods: string[]; pathParams?: string[]; requestFormat?: string; responseFormat?: string; sampleModel?: string | null; models?: Array<{ id: string; capabilities: string[] }>; streaming?: boolean | null }>;
+}
+
+export interface AccessPolicy {
+  policyId: string;
+  enabled: boolean;
+  providers: string[];
+  tenantId?: string | null;
+  tokenRole?: string | null;
+  monthlyBudgetMicros?: number | null;
+  requestCostMicros?: number | null;
+  retainRequestContent: boolean;
+}
+
+export interface ProxyCredential {
+  credentialId: string;
+  policyId: string;
+  enabled: boolean;
+  policyEnabled?: boolean;
+  generationMatches?: boolean;
+  active?: boolean;
+  principalId?: string | null;
+}
+
+export interface ProviderConnection { providerId: string; enabled: boolean; label?: string | null }
+
+export interface UpstreamGrant {
+  key: string;
+  scope: "policies" | "tenants";
+  scopeId: string;
+  tokenRef: string;
+  version: number;
+  enabled: boolean;
+  kind: "api_key" | "oauth" | "subscription";
+  provider?: string | null;
+  label?: string | null;
+  tokenType: string;
+  expiresAt?: string | null;
+  scopes: string[];
+  accountId?: string | null;
+  subscription?: { plan?: string | null; subject?: string | null } | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  revokedAt?: string | null;
+  hasCredential: boolean;
+  credentialFields: string[];
+  hasAccessToken: boolean;
+  hasRefreshToken: boolean;
+  refreshConfigured: boolean;
+  usable: boolean;
+}
+
+export interface AssignmentRule {
+  ruleId: string;
+  version: number;
+  enabled: boolean;
+  kind: "exact_email" | "email_domain" | "github_org" | "github_team";
+  subject: string;
+  groups: string[];
+  policyIds: string[];
+  priority: number;
+  revokeOnLoss: boolean;
+  provenance: string;
+  generatedGroup: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export type AccessRole = "admin" | "user";
+export interface ContentRetention { enabled: boolean; retentionDays: number; policyEnabled: boolean; userExempt: boolean }
+export interface SessionResponse {
+  authenticated: boolean;
+  auth: string;
+  role: AccessRole;
+  email?: string | null;
+  subject?: string | null;
+  tenantId?: string | null;
+  groups?: string[];
+  entitlements?: { providers: ProviderAccess[] } | null;
+  entitlementsError?: string | null;
+  contentRetention?: ContentRetention;
+}
+
+export interface ProviderReadiness {
+  id: string;
+  displayName: string;
+  class: string;
+  serviceKind: string;
+  requiredConfig: string[];
+  optionalConfig: string[];
+  missingConfig: string[];
+  configPresent: boolean;
+  oauthGrantRequired: boolean;
+  oauthGrantCount: number;
+  upstreamGrantCount: number;
+  openaiCompatible: boolean;
+  manifestRoutes: number;
+  executableEndpoints?: string[];
+  modelCount: number;
+  connectionEnabled?: boolean;
+  verified?: boolean;
+  lastCheckedAt?: string | null;
+  latencyMs?: number | null;
+  executable: boolean;
+  status: string;
+  reasons: string[];
+}
+
+export interface ProviderAccess { provider: string; displayName: string; serviceKind: string; allowed: boolean; policies: string[]; readiness: ProviderReadiness }
+export interface EntitlementsResponse { session: SessionResponse; providers: ProviderAccess[]; contentRetention: ContentRetention }
+export interface AccessUser { email: string; role: AccessRole; tenantId: string; enabled: boolean; groups: string[]; contentRetentionDisabled: boolean }
+export interface PolicyBinding { policyId: string; principalType: "user" | "group"; principalId: string; enabled: boolean; priority: number }
+
+export interface AdminOverview {
+  policiesTotal?: number;
+  policiesActive?: number;
+  keysTotal: number;
+  keysActive: number;
+  tenantsTotal: number;
+  providerCount: number;
+  openaiCompatibleProviders: number;
+  manifestRoutes: number;
+  monthlyBudgetMicros: number;
+  requestCostMicros: number;
+}
+
+export interface AdminTenantSummary {
+  tenantId: string;
+  policies?: number;
+  activePolicies?: number;
+  keys: number;
+  activeKeys: number;
+  providers: string[];
+  allProviders?: boolean;
+  monthlyBudgetMicros: number;
+  requestCostMicros: number;
+}
+
+export interface BudgetStatus { configured: boolean; ledger: string; windowKey?: string | null; limitMicros?: number | null; spentMicros?: number | null; remainingMicros?: number | null }
+export interface AdminUsageRow { policyId?: string; kid: string; tenantId: string; enabled: boolean; providers: string[]; tokenRole?: string | null; monthlyBudgetMicros?: number | null; requestCostMicros?: number | null; budget: BudgetStatus }
+export interface UsageSummary { requestCount: number; successCount: number; errorCount: number; inputTokens: number; outputTokens: number; totalTokens: number; actualCostMicros: number }
+export interface ProviderUsageSummary { provider: string; requestCount: number; successCount: number; errorCount: number; totalTokens: number; actualCostMicros: number }
+export interface UsageAuditEvent {
+  id: string;
+  type: string;
+  occurred_at_ms: number;
+  tenant_id: string;
+  policy_id?: string | null;
+  credential_id?: string | null;
+  principal_id?: string | null;
+  auth_type?: string | null;
+  session_id?: string | null;
+  agent_id?: string | null;
+  parent_agent_id?: string | null;
+  project_id?: string | null;
+  client?: string | null;
+  key_id?: string | null;
+  request_id?: string | null;
+  provider: string;
+  capability?: string | null;
+  model?: string | null;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
+  cached_input_tokens?: number | null;
+  cache_write_input_tokens?: number | null;
+  reserved_cost_micros: number;
+  actual_cost_micros: number;
+  reserved_input_tokens?: number | null;
+  reserved_output_tokens?: number | null;
+  pricing_ref?: string | null;
+  pricing_effective_at?: string | null;
+  cost_basis?: string | null;
+  status_code?: number | null;
+  duration_ms?: number | null;
+  status: string;
+  content_retained?: boolean;
+  content_ref?: string | null;
+}
+export interface UsageSnapshot { ledger: string; summary: UsageSummary; providers: ProviderUsageSummary[]; events: UsageAuditEvent[] }
+export interface RetainedRequestContent { requestId: string; occurredAtMs: number; expiresAtMs: number; principalId?: string | null; provider: string; capability: string; model?: string | null; body: unknown }
+
+export interface AdminBootstrapResponse {
+  policies: AccessPolicy[];
+  credentials: ProxyCredential[];
+  connections: ProviderConnection[];
+  users: AccessUser[];
+  bindings: PolicyBinding[];
+  providers: ProviderReadiness[];
+  grants: UpstreamGrant[];
+  rules: AssignmentRule[];
+  overview: AdminOverview;
+  tenants: AdminTenantSummary[];
+}

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -24,12 +24,10 @@ export async function verifiedAccessSession(headers: Headers, env: Env): Promise
   const role = adminRole(email, env) ? "admin" : "user";
   let user = (await resolveUsers(env, [email]))[0];
   if (!user) {
-    const fromKv = await env.POLICY_KV.get<AccessControlUser["record"]>(`access/users/${email}`, "json");
-    user = { email, record: fromKv ?? { role: "user", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } };
+    user = { email, record: { role: "user", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } };
     await authorityCall(env, "/users/put", user);
-    await env.POLICY_KV.put(`access/users/${email}`, JSON.stringify(user.record));
   }
-  user = await reconcileEmailAssignments(user, env);
+  if (!user.record.assignmentState) user = (await reconcileUserAssignments(user, await listAssignmentRules(env), env)).user;
   if (user.record.enabled === false) return null;
   return {
     authenticated: true,
@@ -113,10 +111,6 @@ function adminRole(email: string, env: Env): boolean {
   if (commaSet(env.CLAWROUTER_ACCESS_ADMIN_EMAILS).has(email)) return true;
   const domain = email.split("@")[1];
   return !!domain && commaSet(env.CLAWROUTER_ACCESS_ADMIN_DOMAINS).has(domain);
-}
-
-async function reconcileEmailAssignments(user: AccessControlUser, env: Env): Promise<AccessControlUser> {
-  return (await reconcileUserAssignments(user, await listAssignmentRules(env), env)).user;
 }
 
 async function selectProviderPolicy(entries: AccessPolicyEntry[], providerId: string, tenantId: string, env: Env): Promise<AccessPolicyEntry> {

--- a/worker/accounting.ts
+++ b/worker/accounting.ts
@@ -1,0 +1,67 @@
+import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
+import { HttpError, randomId } from "./utils.ts";
+
+export interface BudgetReservation {
+  reservationId: string | null;
+  reservedMicros: number;
+}
+
+export interface EstimatedCost {
+  reserveMicros: number;
+  basis: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+}
+
+export async function reserveBudget(env: Env, auth: AuthorizedIdentity, capability: string, cost: EstimatedCost): Promise<BudgetReservation> {
+  const limit = auth.policy.monthlyBudgetMicros;
+  if (limit == null) return { reservationId: null, reservedMicros: 0 };
+  if (limit === 0) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
+  if (cost.basis === "flat_fallback") throw new HttpError(400, "pricing_required", "budgeted requests require versioned manifest pricing or a fixed policy request price");
+  const reservationId = randomId("budget");
+  const tenant = auth.policy.tenantId ?? "default";
+  const policyId = `${tenant}/${auth.policyId}`;
+  const request: BudgetReserveRequest = {
+    policyId,
+    windowKey: `${policyId}/${new Date().toISOString().slice(0, 7)}`,
+    limitMicros: limit,
+    costMicros: cost.reserveMicros,
+    reservationId,
+    capability,
+  };
+  const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(`${tenant}:${auth.policyId}`));
+  const response = await stub.fetch("https://clawrouter.internal/reserve", { method: "POST", body: JSON.stringify(request) });
+  if (!response.ok) throw new Error(`budget reserve returned ${response.status}`);
+  const result = await response.json<{ allowed: boolean; chargedMicros: number }>();
+  if (!result.allowed) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
+  return { reservationId, reservedMicros: result.chargedMicros };
+}
+
+export async function finalizeAccounting(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number, event: UsageEvent): Promise<void> {
+  const results = await Promise.allSettled([
+    settleBudget(env, auth, reservation, actualCostMicros),
+    enqueueUsage(env, event),
+  ]);
+  for (const result of results) {
+    if (result.status === "rejected") console.error("accounting finalization failed", result.reason instanceof Error ? result.reason.message : String(result.reason));
+  }
+}
+
+export async function settleBudget(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number): Promise<void> {
+  if (!reservation.reservationId) return;
+  const tenant = auth.policy.tenantId ?? "default";
+  const body: BudgetSettleRequest = { reservationId: reservation.reservationId, actualCostMicros };
+  const job: QueueMessage = { kind: "budget_settlement", tenant_id: tenant, policy_id: auth.policyId, request: body };
+  try {
+    const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(`${tenant}:${auth.policyId}`));
+    const response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(body) });
+    if (response.ok) return;
+  } catch {
+    // The durable queue is the recovery boundary for thrown and non-2xx ledger failures.
+  }
+  await env.USAGE_QUEUE.send(job);
+}
+
+export async function enqueueUsage(env: Env, event: UsageEvent): Promise<void> {
+  await env.USAGE_QUEUE.send(event satisfies QueueMessage);
+}

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,15 +1,16 @@
 import { authorizeAdmin } from "./access";
 import {
-  authorityCall, listBindings, listCredentials, listPolicies, listUsers, resolveConnections,
+  authorityCall, listBindings, listConnections, listCredentials, listPolicies, listUsers,
 } from "./authority";
 import {
   listAssignmentRules, normalizeAssignmentEvidence, reconcileUserAssignments,
   type AssignmentEvidence,
 } from "./assignments";
-import { usageSnapshot } from "./ledgers";
+import { contentKey } from "./content-retention";
+import { usageSnapshots } from "./ledgers";
 import { startOAuth } from "./oauth";
-import { contentKey } from "./proxy";
-import { listGrantRecords, listHealth, providerReadiness, refreshStoredGrant, snapshot } from "./providers";
+import { listGrantRecords, listHealth, providerReadiness, providerReadinessFromState, refreshStoredGrant, snapshot } from "./providers";
+import type { AdminBootstrapResponse } from "../shared/contracts";
 import type {
   AccessControlUser, AccessPolicy, AccessPolicyEntry, AssignmentRule, Env, PolicyBinding,
   ProviderConnection, ProxyCredential, ProxyCredentialEntry, UpstreamGrant,
@@ -23,6 +24,7 @@ export async function adminApi(request: Request, env: Env, path: string): Promis
   if (authorization instanceof Response) return authorization;
   try {
     if (request.method === "GET" && path === "/v1/admin/content") return getContent(request, env);
+    if (request.method === "GET" && path === "/v1/admin/bootstrap") return privateJson(await adminBootstrap(env));
     if (request.method === "GET" && path === "/v1/admin/overview") return privateJson(await overview(env));
     if (request.method === "GET" && ["/v1/admin/tenants", "/v1/admin/users"].includes(path)) return privateJson({ tenants: await tenants(env) });
     if (request.method === "GET" && path === "/v1/admin/usage") return adminUsage(env);
@@ -65,6 +67,10 @@ async function getContent(request: Request, env: Env): Promise<Response> {
 
 async function overview(env: Env) {
   const policies = await listPolicies(env), credentials = await listCredentials(env);
+  return overviewFrom(policies, credentials);
+}
+
+function overviewFrom(policies: AccessPolicyEntry[], credentials: ProxyCredentialEntry[]) {
   const active = new Map(policies.map((entry) => [entry.policyId, entry.policy.enabled]));
   return {
     policiesTotal: policies.length, policiesActive: policies.filter((entry) => entry.policy.enabled).length,
@@ -78,6 +84,10 @@ async function overview(env: Env) {
 
 async function tenants(env: Env) {
   const policies = await listPolicies(env), credentials = await listCredentials(env);
+  return tenantsFrom(policies, credentials);
+}
+
+function tenantsFrom(policies: AccessPolicyEntry[], credentials: ProxyCredentialEntry[]) {
   const groups = new Map<string, { tenantId: string; policies: number; activePolicies: number; keys: number; activeKeys: number; providers: Set<string>; allProviders: boolean; monthlyBudgetMicros: number; requestCostMicros: number }>();
   for (const entry of policies) {
     const id = entry.policy.tenantId ?? "default";
@@ -98,7 +108,7 @@ async function tenants(env: Env) {
 async function adminUsage(env: Env): Promise<Response> {
   const policies = await listPolicies(env);
   const rows = await Promise.all(policies.map(async (entry) => ({ ...legacyKeyResponse(entry), budget: await budgetStatus(env, entry) })));
-  return privateJson({ policies: rows, keys: rows, usage: await usageSnapshot(env, null) });
+  return privateJson({ policies: rows, keys: rows, usage: await usageSnapshots(env, policies.map((entry) => ({ policyId: entry.policyId, tenantId: entry.policy.tenantId ?? "default" }))) });
 }
 
 async function budgetStatus(env: Env, entry: AccessPolicyEntry) {
@@ -113,17 +123,51 @@ async function budgetStatus(env: Env, entry: AccessPolicyEntry) {
 }
 
 async function credentialResponses(env: Env) {
-  const policies = new Map((await listPolicies(env)).map((entry) => [entry.policyId, entry.policy]));
-  return (await listCredentials(env)).map((entry) => {
+  return credentialResponsesFrom(await listPolicies(env), await listCredentials(env));
+}
+
+function credentialResponsesFrom(policyEntries: AccessPolicyEntry[], credentialEntries: ProxyCredentialEntry[]) {
+  const policies = new Map(policyEntries.map((entry) => [entry.policyId, entry.policy]));
+  return credentialEntries.map((entry) => {
     const policy = policies.get(entry.credential.policyId), generationMatches = !!policy && entry.credential.policyGeneration === policy.generation;
     return { credentialId: entry.credentialId, policyId: entry.credential.policyId, enabled: entry.credential.enabled, policyEnabled: policy?.enabled ?? false, generationMatches, active: entry.credential.enabled && !!policy?.enabled && generationMatches, principalId: entry.credential.principalId ?? null };
   });
 }
 
 async function connections(env: Env): Promise<ProviderConnection[]> {
-  const stored = await resolveConnections(env, snapshot.providers.map((provider) => provider.id));
+  const stored = await listConnections(env, snapshot.providers.map((provider) => provider.id));
+  return connectionsFrom(stored);
+}
+
+function connectionsFrom(stored: ProviderConnection[]): ProviderConnection[] {
   const byId = new Map(stored.map((connection) => [connection.providerId, connection]));
   return snapshot.providers.map((provider) => byId.get(provider.id) ?? { providerId: provider.id, enabled: true, label: null });
+}
+
+async function adminBootstrap(env: Env): Promise<AdminBootstrapResponse> {
+  const [policies, credentials, users, bindings, storedConnections, grants, rules, health] = await Promise.all([
+    listPolicies(env),
+    listCredentials(env),
+    listUsers(env),
+    listBindings(env),
+    listConnections(env, snapshot.providers.map((provider) => provider.id)),
+    listGrantRecords(env),
+    assignmentRules(env),
+    listHealth(env),
+  ]);
+  const connectionRows = connectionsFrom(storedConnections);
+  return {
+    policies: policies.map(policyResponse),
+    credentials: credentialResponsesFrom(policies, credentials),
+    connections: connectionRows,
+    users: users.map(userResponse),
+    bindings,
+    providers: providerReadinessFromState(env, grants, connectionRows, health),
+    grants: grants.map(({ key, grant }) => grantResponse(key, grant)),
+    rules,
+    overview: overviewFrom(policies, credentials),
+    tenants: tenantsFrom(policies, credentials),
+  };
 }
 
 async function putBinding(request: Request, env: Env): Promise<Response> {
@@ -132,7 +176,6 @@ async function putBinding(request: Request, env: Env): Promise<Response> {
   const existing = (await listBindings(env)).filter((item) => item.principalType === binding.principalType && item.principalId === binding.principalId);
   const seed = { principal: { principalType: binding.principalType, principalId: binding.principalId }, bindings: existing };
   await authorityCall(env, "/mutate", { seed, binding });
-  await env.POLICY_KV.put(bindingKvKey(binding), JSON.stringify(binding));
   return privateJson(binding);
 }
 
@@ -140,7 +183,7 @@ async function putUser(request: Request, env: Env, encodedEmail: string): Promis
   const email = normalizeEmail(decodeURIComponent(encodedEmail)); if (!email) throw new HttpError(400, "invalid_access_user", "invalid access user email");
   const patch = await readJson<AccessControlUser["record"]>(request), existing = (await listUsers(env)).find((item) => item.email === email)?.record ?? {};
   const user: AccessControlUser = { email, record: { ...existing, ...patch, role: "user", groups: normalizeGroups(patch.groups ?? existing.groups ?? []) } };
-  await authorityCall(env, "/users/put", user); await env.POLICY_KV.put(`access/users/${email}`, JSON.stringify(user.record));
+  await authorityCall(env, "/users/put", user);
   return privateJson(userResponse(user));
 }
 
@@ -149,11 +192,10 @@ async function putUserGrants(request: Request, env: Env, encodedEmail: string): 
   const body = await readJson<AccessControlUser["record"] & { policyIds?: string[] }>(request);
   const ids = [...new Set(body.policyIds ?? [])];
   const known = new Set((await listPolicies(env)).map((entry) => entry.policyId)); if (ids.some((id) => !known.has(id))) throw new HttpError(404, "unknown_policy", "one or more policies do not exist");
-  const user: AccessControlUser = { email, record: { ...body, role: "user", groups: normalizeGroups(body.groups ?? []) } };
+  const existing = (await listUsers(env)).find((item) => item.email === email)?.record ?? {};
+  const user: AccessControlUser = { email, record: { ...existing, ...body, role: "user", groups: normalizeGroups(body.groups ?? existing.groups ?? []) } };
   const principal = { principalType: "user" as const, principalId: email }, bindings = (await listBindings(env)).filter((item) => item.principalType === "user" && item.principalId === email);
   const result = await authorityCall<{ bindings: PolicyBinding[] }>(env, "/users/put-bindings", { user, policyIds: ids, seed: { principal, bindings } });
-  await env.POLICY_KV.put(`access/users/${email}`, JSON.stringify(user.record));
-  await Promise.all(result.bindings.map((binding) => env.POLICY_KV.put(bindingKvKey(binding), JSON.stringify(binding))));
   return privateJson({ user: userResponse(user), bindings: result.bindings });
 }
 
@@ -165,7 +207,7 @@ async function policyMutation(request: Request, env: Env, rest: string): Promise
   if (revoke && request.method === "POST") { if (!existing) throw new HttpError(404, "unknown_policy", "policy not found"); policy = { ...existing, enabled: false }; }
   else if (request.method === "PUT") policy = normalizePolicy(await readJson<Partial<AccessPolicy> & { allProviders?: boolean }>(request), existing);
   else throw new HttpError(405, "method_not_allowed", "admin method is not allowed");
-  const entry = { policyId: id, policy }; await authorityCall(env, "/policies/put", entry); await env.POLICY_KV.put(`policies/${id}`, JSON.stringify(policy));
+  const entry = { policyId: id, policy }; await authorityCall(env, "/policies/put", entry);
   return privateJson(policyResponse(entry));
 }
 
@@ -180,14 +222,14 @@ async function credentialMutation(request: Request, env: Env, rest: string): Pro
     if (!body.secretSha256 || !/^[0-9a-f]{64}$/i.test(body.secretSha256)) throw new HttpError(400, "invalid_credential", "secretSha256 must be a SHA-256 hex digest");
     credential = { enabled: body.enabled ?? true, secretSha256: body.secretSha256.toLowerCase(), policyId: policy.policyId, policyGeneration: policy.policy.generation, principalId: body.principalId ?? null };
   } else throw new HttpError(405, "method_not_allowed", "admin method is not allowed");
-  const entry: ProxyCredentialEntry = { credentialId: id, credential }; await authorityCall(env, "/credentials/put", entry); await env.POLICY_KV.put(`credentials/${id}`, JSON.stringify(credential));
+  const entry: ProxyCredentialEntry = { credentialId: id, credential }; await authorityCall(env, "/credentials/put", entry);
   return privateJson((await credentialResponses(env)).find((item) => item.credentialId === id));
 }
 
 async function putConnection(request: Request, env: Env, encodedId: string): Promise<Response> {
   const id = decodeURIComponent(encodedId), provider = snapshot.providers.find((item) => item.id === id); if (!provider) throw new HttpError(404, "unknown_provider", "provider does not exist");
   const body = await readJson<Partial<ProviderConnection>>(request), connection: ProviderConnection = { providerId: id, enabled: body.enabled ?? true, label: body.label ?? null };
-  await authorityCall(env, "/connections/put", connection); await env.POLICY_KV.put(`connections/${id}`, JSON.stringify(connection)); return privateJson(connection);
+  await authorityCall(env, "/connections/put", connection); return privateJson(connection);
 }
 
 async function upstreamGrantMutation(request: Request, env: Env, rest: string): Promise<Response> {
@@ -221,6 +263,8 @@ async function putAssignmentRule(request: Request, env: Env, encodedId: string):
   if (rule.policyIds.some((policyId) => !known.has(policyId))) throw new HttpError(404, "unknown_policy", "one or more assignment policies do not exist");
   await env.POLICY_KV.put(key, JSON.stringify(rule));
   await syncAssignmentBindings(env, id, existing, rule);
+  const rules = await assignmentRules(env);
+  for (const user of await listUsers(env)) await reconcileUserAssignments(user, rules, env);
   return privateJson(assignmentResponse(id, rule));
 }
 
@@ -231,7 +275,6 @@ async function syncAssignmentBindings(env: Env, id: string, existing: Assignment
   for (const policyId of policyIds) {
     const binding: PolicyBinding = { ...principal, policyId, enabled: rule.enabled && rule.policyIds.includes(policyId), priority: rule.priority };
     await authorityCall(env, "/mutate", { seed: { principal, bindings: current }, binding });
-    await env.POLICY_KV.put(bindingKvKey(binding), JSON.stringify(binding));
   }
 }
 
@@ -247,7 +290,7 @@ async function reconcileAssignments(request: Request, env: Env): Promise<Respons
   const targets = body.all ? users : users.filter((user) => user.email === email);
   const rules = await assignmentRules(env), results = [];
   for (const user of targets) {
-    const result = await reconcileUserAssignments(user, rules, env, evidence);
+    const result = await reconcileUserAssignments(user, rules, env, evidence, true);
     results.push({ email: user.email, matchedRuleIds: result.matchedRuleIds, retainedRuleIds: result.retainedRuleIds, groups: result.user.record.groups ?? [] });
   }
   return privateJson({ results });
@@ -298,10 +341,8 @@ function revokeGrant(value: UpstreamGrant): UpstreamGrant { const { credential: 
 
 function policyResponse(entry: AccessPolicyEntry) { return { policyId: entry.policyId, enabled: entry.policy.enabled, providers: entry.policy.providers, tenantId: entry.policy.tenantId ?? null, tokenRole: entry.policy.tokenRole ?? null, monthlyBudgetMicros: entry.policy.monthlyBudgetMicros ?? null, requestCostMicros: entry.policy.requestCostMicros ?? null, retainRequestContent: entry.policy.retainRequestContent !== false }; }
 function legacyKeyResponse(entry: AccessPolicyEntry) { return { kid: entry.policyId, ...policyResponse(entry) }; }
-function userResponse(user: AccessControlUser) { return { email: user.email, role: "user", tenantId: user.record.tenantId ?? "default", enabled: user.record.enabled ?? true, groups: user.record.groups ?? [], contentRetentionDisabled: user.record.contentRetentionDisabled ?? false }; }
-function grantResponse(key: string, grant: UpstreamGrant) { const parts = key.split("/"), tenant = parts[1] === "tenants"; return { key, scope: tenant ? "tenants" : "policies", scopeId: tenant ? parts[2] : parts[1], tokenRef: tenant ? parts[3] : parts[2], version: grant.version ?? 1, enabled: grant.enabled ?? true, kind: grant.kind ?? "oauth", provider: grant.provider ?? null, label: grant.label ?? null, tokenType: grant.tokenType ?? "Bearer", expiresAt: grant.expiresAt ?? null, scopes: grant.scopes ?? [], accountId: grant.accountId ?? null, subscription: grant.subscription ?? null, createdAt: grant.createdAt ?? null, updatedAt: grant.updatedAt ?? null, revokedAt: grant.revokedAt ?? null, hasCredential: !!grant.credential || Object.keys(grant.credentials ?? {}).length > 0, credentialFields: Object.keys(grant.credentials ?? {}).sort(), hasAccessToken: !!grant.accessToken, hasRefreshToken: !!grant.refreshToken, refreshConfigured: !!grant.refresh, refreshTokenUrl: grant.refresh?.tokenUrl ?? null, clientIdConfig: grant.refresh?.clientIdConfig ?? null, clientSecretConfig: grant.refresh?.clientSecretConfig ?? null, usable: grant.enabled !== false && !!(grant.credential || grant.accessToken || Object.keys(grant.credentials ?? {}).length) }; }
+function userResponse(user: AccessControlUser) { return { email: user.email, role: "user" as const, tenantId: user.record.tenantId ?? "default", enabled: user.record.enabled ?? true, groups: user.record.groups ?? [], contentRetentionDisabled: user.record.contentRetentionDisabled ?? false }; }
+function grantResponse(key: string, grant: UpstreamGrant) { const parts = key.split("/"), tenant = parts[1] === "tenants"; return { key, scope: tenant ? "tenants" as const : "policies" as const, scopeId: tenant ? parts[2] : parts[1], tokenRef: tenant ? parts[3] : parts[2], version: grant.version ?? 1, enabled: grant.enabled ?? true, kind: grant.kind ?? "oauth", provider: grant.provider ?? null, label: grant.label ?? null, tokenType: grant.tokenType ?? "Bearer", expiresAt: grant.expiresAt ?? null, scopes: grant.scopes ?? [], accountId: grant.accountId ?? null, subscription: grant.subscription ?? null, createdAt: grant.createdAt ?? null, updatedAt: grant.updatedAt ?? null, revokedAt: grant.revokedAt ?? null, hasCredential: !!grant.credential || Object.keys(grant.credentials ?? {}).length > 0, credentialFields: Object.keys(grant.credentials ?? {}).sort(), hasAccessToken: !!grant.accessToken, hasRefreshToken: !!grant.refreshToken, refreshConfigured: !!grant.refresh, refreshTokenUrl: grant.refresh?.tokenUrl ?? null, clientIdConfig: grant.refresh?.clientIdConfig ?? null, clientSecretConfig: grant.refresh?.clientSecretConfig ?? null, usable: grant.enabled !== false && !!(grant.credential || grant.accessToken || Object.keys(grant.credentials ?? {}).length) }; }
 function assignmentResponse(ruleId: string, rule: AssignmentRule) { return { ruleId, ...rule, generatedGroup: `assignment.${ruleId}` }; }
-function assignmentRuleKey(id: string) { return `assignment/rules/${id}`; }
-function bindingKvKey(binding: PolicyBinding) { return `access/bindings/${binding.principalType}/${encodeURIComponent(binding.principalId)}/${binding.policyId}`; }
 function normalizeGroups(values: string[]) { return [...new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean))].sort(); }
 function sum(values: Array<number | null | undefined>) { return values.reduce<number>((total, value) => total + (value ?? 0), 0); }

--- a/worker/assignment-evaluator.ts
+++ b/worker/assignment-evaluator.ts
@@ -1,0 +1,78 @@
+import type { AccessControlUser, AssignmentRule, AssignmentState, AssignmentStateEntry } from "./types";
+
+export interface AssignmentEvidence {
+  source: string;
+  verified: boolean;
+  githubOrgs: string[];
+  githubTeams: string[];
+}
+
+export interface AssignmentRuleEntry extends AssignmentRule { ruleId: string; generatedGroup: string }
+
+export function withLegacyAssignmentState(user: AccessControlUser, legacy: Partial<AssignmentState> | null): AccessControlUser {
+  if (user.record.assignmentState || !legacy?.assignments || typeof legacy.assignments !== "object") return user;
+  const assignments = Object.fromEntries(Object.entries(legacy.assignments).flatMap(([ruleId, entry]) => {
+    if (!entry || !Array.isArray(entry.groups)) return [];
+    return [[ruleId, { groups: normalizeGroups(entry.groups), revokeOnLoss: entry.revokeOnLoss === true } satisfies AssignmentStateEntry]];
+  }));
+  return {
+    ...user,
+    record: {
+      ...user.record,
+      assignmentState: { version: 1, revision: "", assignments, updatedAt: typeof legacy.updatedAt === "string" ? legacy.updatedAt : null },
+    },
+  };
+}
+
+export function evaluateUserAssignments(user: AccessControlUser, rules: AssignmentRuleEntry[], evidence?: AssignmentEvidence, force = false) {
+  const revision = assignmentRulesRevision(rules);
+  const previous = user.record.assignmentState ?? { version: 1, revision: "", assignments: {}, updatedAt: null } satisfies AssignmentState;
+  if (!force && previous.revision === revision) return { changed: false as const, user, matchedRuleIds: Object.keys(previous.assignments).sort(), retainedRuleIds: [] as string[] };
+  const assignments: Record<string, AssignmentStateEntry> = {};
+  const matchedRuleIds: string[] = [], retainedRuleIds: string[] = [];
+  for (const rule of rules) {
+    const outcome = assignmentMatch(rule, user.email, evidence);
+    if (outcome === "match") {
+      assignments[rule.ruleId] = assignmentEntry(rule);
+      matchedRuleIds.push(rule.ruleId);
+    } else if (outcome === "unknown" || (outcome === "no_match" && rule.enabled && !rule.revokeOnLoss)) {
+      if (previous.assignments[rule.ruleId]) {
+        assignments[rule.ruleId] = previous.assignments[rule.ruleId];
+        retainedRuleIds.push(rule.ruleId);
+      }
+    }
+  }
+  const previousGroups = new Set(Object.values(previous.assignments).flatMap((entry) => entry.groups));
+  const manual = (user.record.groups ?? []).filter((group) => !previousGroups.has(group) && !group.startsWith("assignment."));
+  const groups = normalizeGroups([...manual, ...Object.values(assignments).flatMap((entry) => entry.groups)]);
+  const assignmentState: AssignmentState = { version: 1, revision, assignments, updatedAt: new Date().toISOString() };
+  const updated: AccessControlUser = { ...user, record: { ...user.record, role: "user", groups, assignmentState } };
+  return { changed: true as const, user: updated, matchedRuleIds, retainedRuleIds };
+}
+
+export function assignmentRulesRevision(rules: AssignmentRuleEntry[]): string {
+  return JSON.stringify(rules.map((rule) => ({ ruleId: rule.ruleId, version: rule.version, enabled: rule.enabled, kind: rule.kind, subject: rule.subject, groups: rule.groups, policyIds: rule.policyIds, priority: rule.priority, revokeOnLoss: rule.revokeOnLoss, provenance: rule.provenance })));
+}
+
+export function normalizeAssignmentEvidence(value: AssignmentEvidence | undefined): AssignmentEvidence | undefined {
+  if (!value) return undefined;
+  if (value.source?.trim().toLowerCase() !== "github" || value.verified !== true) throw new Error("GitHub assignment evidence must be explicitly verified");
+  return { source: "github", verified: true, githubOrgs: normalizeGroups(value.githubOrgs ?? []), githubTeams: normalizeGroups(value.githubTeams ?? []) };
+}
+
+export function assignmentGroup(ruleId: string) { return `assignment.${ruleId}`; }
+
+function assignmentMatch(rule: AssignmentRuleEntry, email: string, evidence?: AssignmentEvidence): "match" | "no_match" | "unknown" {
+  if (!rule.enabled) return "no_match";
+  if (rule.kind === "exact_email") return email === rule.subject ? "match" : "no_match";
+  if (rule.kind === "email_domain") return email.split("@")[1] === rule.subject ? "match" : "no_match";
+  if (!evidence) return "unknown";
+  const values = rule.kind === "github_org" ? evidence.githubOrgs : evidence.githubTeams;
+  return values.includes(rule.subject) ? "match" : "no_match";
+}
+
+function assignmentEntry(rule: AssignmentRuleEntry): AssignmentStateEntry {
+  return { groups: normalizeGroups([...rule.groups, ...(rule.policyIds.length ? [rule.generatedGroup] : [])]), revokeOnLoss: rule.revokeOnLoss };
+}
+
+function normalizeGroups(groups: string[]) { return [...new Set(groups.map((group) => group.trim().toLowerCase()).filter(Boolean))].sort(); }

--- a/worker/assignments.ts
+++ b/worker/assignments.ts
@@ -1,18 +1,16 @@
 import { authorityCall } from "./authority";
-import type { AccessControlUser, AssignmentRule, Env } from "./types";
-import { normalizeEmail, nowIso } from "./utils";
+import {
+  assignmentGroup,
+  evaluateUserAssignments,
+  normalizeAssignmentEvidence,
+  withLegacyAssignmentState,
+  type AssignmentEvidence,
+  type AssignmentRuleEntry,
+} from "./assignment-evaluator";
+import type { AccessControlUser, AssignmentRule, AssignmentState, Env } from "./types";
 
-export interface AssignmentEvidence {
-  source: string;
-  verified: boolean;
-  githubOrgs: string[];
-  githubTeams: string[];
-}
-
-export interface AssignmentRuleEntry extends AssignmentRule { ruleId: string; generatedGroup: string }
-
-interface AssignmentStateEntry { groups: string[]; revokeOnLoss: boolean }
-interface AssignmentState { version: number; assignments: Record<string, AssignmentStateEntry>; updatedAt: string | null }
+export { assignmentRulesRevision, normalizeAssignmentEvidence } from "./assignment-evaluator";
+export type { AssignmentEvidence, AssignmentRuleEntry } from "./assignment-evaluator";
 
 export async function listAssignmentRules(env: Env): Promise<AssignmentRuleEntry[]> {
   const entries: AssignmentRuleEntry[] = [];
@@ -30,57 +28,13 @@ export async function listAssignmentRules(env: Env): Promise<AssignmentRuleEntry
   return entries.sort((left, right) => left.priority - right.priority || left.ruleId.localeCompare(right.ruleId));
 }
 
-export async function reconcileUserAssignments(user: AccessControlUser, rules: AssignmentRuleEntry[], env: Env, evidence?: AssignmentEvidence): Promise<{ user: AccessControlUser; matchedRuleIds: string[]; retainedRuleIds: string[] }> {
-  const previous = await assignmentState(env, user.email);
-  const assignments: Record<string, AssignmentStateEntry> = {};
-  const matchedRuleIds: string[] = [], retainedRuleIds: string[] = [];
-  for (const rule of rules) {
-    const outcome = assignmentMatch(rule, user.email, evidence);
-    if (outcome === "match") {
-      assignments[rule.ruleId] = assignmentEntry(rule);
-      matchedRuleIds.push(rule.ruleId);
-    } else if (outcome === "unknown" || (outcome === "no_match" && rule.enabled && !rule.revokeOnLoss)) {
-      if (previous.assignments[rule.ruleId]) {
-        assignments[rule.ruleId] = previous.assignments[rule.ruleId];
-        retainedRuleIds.push(rule.ruleId);
-      }
-    }
-  }
-  const previousGroups = new Set(Object.values(previous.assignments).flatMap((entry) => entry.groups));
-  const manual = (user.record.groups ?? []).filter((group) => !previousGroups.has(group) && !group.startsWith("assignment."));
-  const groups = normalizeGroups([...manual, ...Object.values(assignments).flatMap((entry) => entry.groups)]);
-  const updated: AccessControlUser = { ...user, record: { ...user.record, role: "user", groups } };
-  await authorityCall(env, "/users/put", updated);
-  await Promise.all([
-    env.POLICY_KV.put(`access/users/${user.email}`, JSON.stringify(updated.record)),
-    env.POLICY_KV.put(assignmentStateKey(user.email), JSON.stringify({ version: 1, assignments, updatedAt: nowIso() } satisfies AssignmentState)),
-  ]);
-  return { user: updated, matchedRuleIds, retainedRuleIds };
+export async function reconcileUserAssignments(user: AccessControlUser, rules: AssignmentRuleEntry[], env: Env, evidence?: AssignmentEvidence, force = false): Promise<{ user: AccessControlUser; matchedRuleIds: string[]; retainedRuleIds: string[] }> {
+  const legacy = user.record.assignmentState
+    ? null
+    : await env.POLICY_KV.get<Partial<AssignmentState>>(`access/assignment-state/${user.email.trim().toLowerCase()}`, "json");
+  const candidate = withLegacyAssignmentState(user, legacy);
+  const evaluated = evaluateUserAssignments(candidate, rules, evidence, force);
+  if (!evaluated.changed) return { user, matchedRuleIds: evaluated.matchedRuleIds, retainedRuleIds: evaluated.retainedRuleIds };
+  await authorityCall(env, "/users/put", evaluated.user);
+  return { user: evaluated.user, matchedRuleIds: evaluated.matchedRuleIds, retainedRuleIds: evaluated.retainedRuleIds };
 }
-
-export function normalizeAssignmentEvidence(value: AssignmentEvidence | undefined): AssignmentEvidence | undefined {
-  if (!value) return undefined;
-  if (value.source?.trim().toLowerCase() !== "github" || value.verified !== true) throw new Error("GitHub assignment evidence must be explicitly verified");
-  return { source: "github", verified: true, githubOrgs: normalizeGroups(value.githubOrgs ?? []), githubTeams: normalizeGroups(value.githubTeams ?? []) };
-}
-
-function assignmentMatch(rule: AssignmentRuleEntry, email: string, evidence?: AssignmentEvidence): "match" | "no_match" | "unknown" {
-  if (!rule.enabled) return "no_match";
-  if (rule.kind === "exact_email") return email === rule.subject ? "match" : "no_match";
-  if (rule.kind === "email_domain") return email.split("@")[1] === rule.subject ? "match" : "no_match";
-  if (!evidence) return "unknown";
-  const values = rule.kind === "github_org" ? evidence.githubOrgs : evidence.githubTeams;
-  return values.includes(rule.subject) ? "match" : "no_match";
-}
-
-function assignmentEntry(rule: AssignmentRuleEntry): AssignmentStateEntry {
-  return { groups: normalizeGroups([...rule.groups, ...(rule.policyIds.length ? [rule.generatedGroup] : [])]), revokeOnLoss: rule.revokeOnLoss };
-}
-
-async function assignmentState(env: Env, email: string): Promise<AssignmentState> {
-  return await env.POLICY_KV.get<AssignmentState>(assignmentStateKey(email), "json") ?? { version: 1, assignments: {}, updatedAt: null };
-}
-
-function assignmentStateKey(email: string) { return `access/assignment-state/${normalizeEmail(email)}`; }
-function assignmentGroup(ruleId: string) { return `assignment.${ruleId}`; }
-function normalizeGroups(groups: string[]) { return [...new Set(groups.map((group) => group.trim().toLowerCase()).filter(Boolean))].sort(); }

--- a/worker/authority.ts
+++ b/worker/authority.ts
@@ -2,7 +2,7 @@ import type {
   AccessControlUser, AccessPolicyEntry, AccessUserRecord, Env, OAuthState, PolicyBinding,
   ProviderConnection, ProxyCredentialEntry,
 } from "./types";
-import { errorResponse, json, normalizeEmail, readJson } from "./utils";
+import { errorResponse, json, normalizeEmail, readJson } from "./utils.ts";
 
 type Principal = { principalType: "user" | "group"; principalId: string };
 type Seed = { principal: Principal; bindings: PolicyBinding[] };
@@ -19,12 +19,12 @@ export class PolicyBindingIndexObject implements DurableObject {
     const path = new URL(request.url).pathname;
     if (request.method !== "POST") return errorResponse("route_not_found", "route not found", 404);
     try {
-      if (path === "/resolve") return json(this.resolveBindings((await readJson<{ principals: Principal[] }>(request)).principals));
+      if (path === "/resolve") return json({ initialized: this.hasMeta("bindings_global_initialized"), ...this.resolveBindings((await readJson<{ principals: Principal[] }>(request)).principals) });
       if (path === "/initialize") { this.initializeBindings(await readJson<Seed[]>(request)); return new Response("initialized"); }
       if (path === "/initialize-all") { this.initializeAllBindings(await readJson<PolicyBinding[]>(request)); return new Response("initialized"); }
       if (path === "/mutate") { const body = await readJson<{ seed: Seed; binding: PolicyBinding }>(request); this.initializeBindings([body.seed]); this.putBinding(body.binding); return new Response("updated"); }
       if (path === "/list") return json({ initialized: this.hasMeta("bindings_global_initialized"), bindings: this.listBindings() });
-      if (path === "/users/resolve") return json(this.resolveUsers((await readJson<{ emails: string[] }>(request)).emails));
+      if (path === "/users/resolve") return json({ initialized: this.hasMeta("users_global_initialized"), ...this.resolveUsers((await readJson<{ emails: string[] }>(request)).emails) });
       if (path === "/users/initialize") { this.initializeUsers(await readJson<AccessControlUser[]>(request)); return new Response("initialized"); }
       if (path === "/users/initialize-all") { this.initializeUsers(await readJson<AccessControlUser[]>(request)); this.putMeta("users_global_initialized"); return new Response("initialized"); }
       if (path === "/users/put") { this.putUser(await readJson<AccessControlUser>(request)); return new Response("updated"); }
@@ -32,15 +32,18 @@ export class PolicyBindingIndexObject implements DurableObject {
       if (path === "/users/list") return json({ initialized: this.hasMeta("users_global_initialized"), users: this.listUsers() });
       if (path === "/policies/resolve") return json(this.resolvePolicies((await readJson<{ policyIds: string[] }>(request)).policyIds));
       if (path === "/policies/initialize") { this.initializePolicies(await readJson<AccessPolicyEntry[]>(request)); return new Response("initialized"); }
+      if (path === "/policies/initialize-all") { this.initializePolicies(await readJson<AccessPolicyEntry[]>(request)); this.putMeta("policies_global_initialized"); return new Response("initialized"); }
       if (path === "/policies/put") { this.putPolicy(await readJson<AccessPolicyEntry>(request)); return new Response("updated"); }
       if (path === "/policies/put-with-credential") { const body = await readJson<{ policy: AccessPolicyEntry; credential: ProxyCredentialEntry }>(request); this.putPolicy(body.policy); this.putCredential(body.credential); return new Response("updated"); }
-      if (path === "/policies/list") return json({ policies: this.listPolicies() });
+      if (path === "/policies/list") return json({ initialized: this.hasMeta("policies_global_initialized"), policies: this.listPolicies() });
       if (path === "/credentials/resolve") return json(this.resolveCredentials((await readJson<{ credentialIds: string[] }>(request)).credentialIds));
       if (path === "/credentials/initialize") { this.initializeCredentials(await readJson<ProxyCredentialEntry[]>(request)); return new Response("initialized"); }
+      if (path === "/credentials/initialize-all") { this.initializeCredentials(await readJson<ProxyCredentialEntry[]>(request)); this.putMeta("credentials_global_initialized"); return new Response("initialized"); }
       if (path === "/credentials/put") { this.putCredential(await readJson<ProxyCredentialEntry>(request)); return new Response("updated"); }
-      if (path === "/credentials/list") return json({ credentials: this.listCredentials() });
+      if (path === "/credentials/list") return json({ initialized: this.hasMeta("credentials_global_initialized"), credentials: this.listCredentials() });
       if (path === "/connections/resolve") return json(this.resolveConnections((await readJson<{ providerIds: string[] }>(request)).providerIds));
       if (path === "/connections/initialize") { this.initializeConnections(await readJson<ProviderConnection[]>(request)); return new Response("initialized"); }
+      if (path === "/connections/initialize-all") { this.initializeConnections(await readJson<ProviderConnection[]>(request)); this.putMeta("connections_global_initialized"); return new Response("initialized"); }
       if (path === "/connections/put") { this.putConnection(await readJson<ProviderConnection>(request)); return new Response("updated"); }
       if (path === "/oauth-states/put") { this.putOAuthState(await readJson<OAuthState>(request)); return new Response("updated"); }
       if (path === "/oauth-states/consume") return json({ state: this.consumeOAuthState(await readJson<{ state: string; actorEmail: string }>(request)) });
@@ -165,10 +168,10 @@ export class PolicyBindingIndexObject implements DurableObject {
     const row = rows<{ policy_json: string }>(this.sql.exec("SELECT policy_json FROM access_policies WHERE policy_id = ?", id))[0];
     return row ? { policyId: id, policy: JSON.parse(row.policy_json) } : null;
   }
-  private resolvePolicies(ids: string[]): { policies: AccessPolicyEntry[]; missingPolicyIds: string[] } {
+  private resolvePolicies(ids: string[]): { initialized: boolean; policies: AccessPolicyEntry[]; missingPolicyIds: string[] } {
     const policies: AccessPolicyEntry[] = [], missingPolicyIds: string[] = [];
     for (const id of [...new Set(ids)]) { const entry = this.getPolicy(id); if (entry) policies.push(entry); else missingPolicyIds.push(id); }
-    return { policies, missingPolicyIds };
+    return { initialized: this.hasMeta("policies_global_initialized"), policies, missingPolicyIds };
   }
   private listPolicies(): AccessPolicyEntry[] {
     return rows<{ policy_id: string; policy_json: string }>(this.sql.exec("SELECT policy_id, policy_json FROM access_policies ORDER BY policy_id")).map((row) => ({ policyId: row.policy_id, policy: JSON.parse(row.policy_json) }));
@@ -182,10 +185,10 @@ export class PolicyBindingIndexObject implements DurableObject {
     const row = rows<{ credential_json: string }>(this.sql.exec("SELECT credential_json FROM proxy_credentials WHERE credential_id = ?", id))[0];
     return row ? { credentialId: id, credential: JSON.parse(row.credential_json) } : null;
   }
-  private resolveCredentials(ids: string[]): { credentials: ProxyCredentialEntry[]; missingCredentialIds: string[] } {
+  private resolveCredentials(ids: string[]): { initialized: boolean; credentials: ProxyCredentialEntry[]; missingCredentialIds: string[] } {
     const credentials: ProxyCredentialEntry[] = [], missingCredentialIds: string[] = [];
     for (const id of [...new Set(ids)]) { const entry = this.getCredential(id); if (entry) credentials.push(entry); else missingCredentialIds.push(id); }
-    return { credentials, missingCredentialIds };
+    return { initialized: this.hasMeta("credentials_global_initialized"), credentials, missingCredentialIds };
   }
   private listCredentials(): ProxyCredentialEntry[] {
     return rows<{ credential_id: string; credential_json: string }>(this.sql.exec("SELECT credential_id, credential_json FROM proxy_credentials ORDER BY credential_id")).map((row) => ({ credentialId: row.credential_id, credential: JSON.parse(row.credential_json) }));
@@ -199,10 +202,10 @@ export class PolicyBindingIndexObject implements DurableObject {
     const row = rows<{ connection_json: string }>(this.sql.exec("SELECT connection_json FROM provider_connections WHERE provider_id = ?", id))[0];
     return row ? JSON.parse(row.connection_json) : null;
   }
-  private resolveConnections(ids: string[]): { connections: ProviderConnection[]; missingProviderIds: string[] } {
+  private resolveConnections(ids: string[]): { initialized: boolean; connections: ProviderConnection[]; missingProviderIds: string[] } {
     const connections: ProviderConnection[] = [], missingProviderIds: string[] = [];
     for (const id of [...new Set(ids)]) { const entry = this.getConnection(id); if (entry) connections.push(entry); else missingProviderIds.push(id); }
-    return { connections, missingProviderIds };
+    return { initialized: this.hasMeta("connections_global_initialized"), connections, missingProviderIds };
   }
 
   private putOAuthState(value: OAuthState): void {
@@ -228,43 +231,52 @@ export async function authorityCall<T>(env: Env, path: string, body: unknown, ob
 }
 
 export async function listPolicies(env: Env): Promise<AccessPolicyEntry[]> {
-  const authoritative = (await authorityCall<{ policies: AccessPolicyEntry[] }>(env, "/policies/list", {})).policies;
+  const result = await authorityCall<{ initialized: boolean; policies: AccessPolicyEntry[] }>(env, "/policies/list", {});
+  const authoritative = result.policies;
+  if (result.initialized) return authoritative;
   const byId = new Map(authoritative.map((entry) => [entry.policyId, entry]));
   for (const [key, value] of await listKvJson<Record<string, unknown>>(env, "policies/")) {
     const policyId = key.slice("policies/".length);
     if (!byId.has(policyId)) byId.set(policyId, { policyId, policy: normalizePolicyRecord(value) });
   }
-  const missing = [...byId.values()].filter((entry) => !authoritative.some((current) => current.policyId === entry.policyId));
-  if (missing.length) await authorityCall(env, "/policies/initialize", missing);
+  for (const [policyId, value] of await listGenuineLegacyKeys(env)) {
+    if (!byId.has(policyId)) byId.set(policyId, { policyId, policy: normalizePolicyRecord(value) });
+  }
+  await authorityCall(env, "/policies/initialize-all", [...byId.values()]);
   return [...byId.values()].sort((a, b) => a.policyId.localeCompare(b.policyId));
 }
 export async function listCredentials(env: Env): Promise<ProxyCredentialEntry[]> {
-  const authoritative = (await authorityCall<{ credentials: ProxyCredentialEntry[] }>(env, "/credentials/list", {})).credentials;
+  const result = await authorityCall<{ initialized: boolean; credentials: ProxyCredentialEntry[] }>(env, "/credentials/list", {});
+  const authoritative = result.credentials;
+  if (result.initialized) return authoritative;
   const byId = new Map(authoritative.map((entry) => [entry.credentialId, entry]));
   for (const [key, value] of await listKvJson<Record<string, unknown>>(env, "credentials/")) {
     const credentialId = key.slice("credentials/".length);
     if (!byId.has(credentialId)) byId.set(credentialId, { credentialId, credential: normalizeCredentialRecord(value) });
   }
-  const missing = [...byId.values()].filter((entry) => !authoritative.some((current) => current.credentialId === entry.credentialId));
-  if (missing.length) await authorityCall(env, "/credentials/initialize", missing);
+  for (const [credentialId, value] of await listGenuineLegacyKeys(env)) {
+    if (!byId.has(credentialId)) byId.set(credentialId, { credentialId, credential: normalizeCredentialRecord(value, credentialId) });
+  }
+  await authorityCall(env, "/credentials/initialize-all", [...byId.values()]);
   return [...byId.values()].sort((a, b) => a.credentialId.localeCompare(b.credentialId));
 }
 export async function listUsers(env: Env): Promise<AccessControlUser[]> {
   const result = await authorityCall<{ initialized: boolean; users: AccessControlUser[] }>(env, "/users/list", {});
   if (result.initialized) return result.users;
   const users = (await listKvJson<AccessUserRecord>(env, "access/users/")).map(([key, record]) => ({ email: key.slice("access/users/".length), record }));
-  if (users.length) await authorityCall(env, "/users/initialize-all", users);
-  return users.length ? users : result.users;
+  await authorityCall(env, "/users/initialize-all", users);
+  return (await authorityCall<{ users: AccessControlUser[] }>(env, "/users/list", {})).users;
 }
 export async function listBindings(env: Env): Promise<PolicyBinding[]> {
   const result = await authorityCall<{ initialized: boolean; bindings: PolicyBinding[] }>(env, "/list", {});
   if (result.initialized) return result.bindings;
   const bindings = (await listKvJson<PolicyBinding>(env, "access/bindings/")).map(([, binding]) => binding);
-  if (bindings.length) await authorityCall(env, "/initialize-all", bindings);
-  return bindings.length ? sortBindings(bindings) : result.bindings;
+  await authorityCall(env, "/initialize-all", bindings);
+  return (await authorityCall<{ bindings: PolicyBinding[] }>(env, "/list", {})).bindings;
 }
 export async function resolvePolicies(env: Env, ids: string[]): Promise<AccessPolicyEntry[]> {
-  const result = await authorityCall<{ policies: AccessPolicyEntry[]; missingPolicyIds: string[] }>(env, "/policies/resolve", { policyIds: ids });
+  const result = await authorityCall<{ initialized: boolean; policies: AccessPolicyEntry[]; missingPolicyIds: string[] }>(env, "/policies/resolve", { policyIds: ids });
+  if (result.initialized) return result.policies;
   const seeded: AccessPolicyEntry[] = [];
   for (const policyId of result.missingPolicyIds) {
     const value = await env.POLICY_KV.get<Record<string, unknown>>(`policies/${policyId}`, "json") ?? await genuineLegacyKey(env, policyId);
@@ -274,7 +286,8 @@ export async function resolvePolicies(env: Env, ids: string[]): Promise<AccessPo
   return [...result.policies, ...seeded];
 }
 export async function resolveCredentials(env: Env, ids: string[]): Promise<ProxyCredentialEntry[]> {
-  const result = await authorityCall<{ credentials: ProxyCredentialEntry[]; missingCredentialIds: string[] }>(env, "/credentials/resolve", { credentialIds: ids });
+  const result = await authorityCall<{ initialized: boolean; credentials: ProxyCredentialEntry[]; missingCredentialIds: string[] }>(env, "/credentials/resolve", { credentialIds: ids });
+  if (result.initialized) return result.credentials;
   const seeded: ProxyCredentialEntry[] = [];
   for (const credentialId of result.missingCredentialIds) {
     const value = await env.POLICY_KV.get<Record<string, unknown>>(`credentials/${credentialId}`, "json") ?? await genuineLegacyKey(env, credentialId);
@@ -284,7 +297,8 @@ export async function resolveCredentials(env: Env, ids: string[]): Promise<Proxy
   return [...result.credentials, ...seeded];
 }
 export async function resolveUsers(env: Env, emails: string[]): Promise<AccessControlUser[]> {
-  const result = await authorityCall<{ users: AccessControlUser[]; missingEmails: string[] }>(env, "/users/resolve", { emails });
+  const result = await authorityCall<{ initialized: boolean; users: AccessControlUser[]; missingEmails: string[] }>(env, "/users/resolve", { emails });
+  if (result.initialized) return result.users;
   const seeded: AccessControlUser[] = [];
   for (const email of result.missingEmails) {
     const record = await env.POLICY_KV.get<AccessUserRecord>(`access/users/${email}`, "json");
@@ -294,8 +308,8 @@ export async function resolveUsers(env: Env, emails: string[]): Promise<AccessCo
   return [...result.users, ...seeded];
 }
 export async function resolveBindings(env: Env, principals: Principal[]): Promise<PolicyBinding[]> {
-  const result = await authorityCall<{ bindings: PolicyBinding[]; missingPrincipals: Principal[] }>(env, "/resolve", { principals });
-  if (!result.missingPrincipals.length) return result.bindings;
+  const result = await authorityCall<{ initialized: boolean; bindings: PolicyBinding[]; missingPrincipals: Principal[] }>(env, "/resolve", { principals });
+  if (result.initialized || !result.missingPrincipals.length) return result.bindings;
   const seeds: Seed[] = [];
   for (const principal of result.missingPrincipals) {
     const prefix = `access/bindings/${principal.principalType}/${encodeURIComponent(principal.principalId)}/`;
@@ -306,10 +320,21 @@ export async function resolveBindings(env: Env, principals: Principal[]): Promis
 }
 export async function resolveConnections(env: Env, providerIds: string[]): Promise<ProviderConnection[]> {
   const ids = [...new Set(providerIds)];
-  const result = await authorityCall<{ connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
+  const result = await authorityCall<{ initialized: boolean; connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
+  if (result.initialized) return result.connections;
   const seeded = (await Promise.all(result.missingProviderIds.map((id) => env.POLICY_KV.get<ProviderConnection>(`connections/${id}`, "json")))).filter(Boolean) as ProviderConnection[];
   if (seeded.length) await authorityCall(env, "/connections/initialize", seeded);
   return [...result.connections, ...seeded];
+}
+
+export async function listConnections(env: Env, providerIds: string[]): Promise<ProviderConnection[]> {
+  const ids = [...new Set(providerIds)];
+  const result = await authorityCall<{ initialized: boolean; connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
+  if (result.initialized) return result.connections;
+  const seeded = (await Promise.all(result.missingProviderIds.map((id) => env.POLICY_KV.get<ProviderConnection>(`connections/${id}`, "json")))).filter(Boolean) as ProviderConnection[];
+  const connections = [...result.connections, ...seeded];
+  await authorityCall(env, "/connections/initialize-all", connections);
+  return connections;
 }
 
 export async function resolveConnection(env: Env, providerId: string): Promise<ProviderConnection | null> {
@@ -330,6 +355,13 @@ async function listKvJson<T>(env: Env, prefix: string): Promise<Array<[string, T
 async function genuineLegacyKey(env: Env, id: string): Promise<Record<string, unknown> | null> {
   const value = await env.POLICY_KV.get<Record<string, unknown>>(`keys/${id}`, "json");
   return value && (value.generation == null || value.generation === "legacy") ? value : null;
+}
+
+async function listGenuineLegacyKeys(env: Env): Promise<Array<[string, Record<string, unknown>]>> {
+  return (await listKvJson<Record<string, unknown>>(env, "keys/")).flatMap(([key, value]) => {
+    const id = key.slice("keys/".length);
+    return id && !id.includes("/") && (value.generation == null || value.generation === "legacy") ? [[id, value]] : [];
+  });
 }
 
 function normalizePolicyRecord(value: Record<string, unknown>): AccessPolicyEntry["policy"] {
@@ -373,7 +405,7 @@ function normalizeBinding(value: PolicyBinding): PolicyBinding {
 function normalizeUser(value: AccessControlUser): AccessControlUser {
   const email = normalizeEmail(value.email);
   if (!email) throw new Error("invalid access user email");
-  return { email, record: { role: value.record.role ?? "user", tenantId: value.record.tenantId ?? "default", enabled: value.record.enabled ?? true, groups: [...new Set(value.record.groups ?? [])].map((item) => item.trim().toLowerCase()).filter(Boolean).sort(), contentRetentionDisabled: value.record.contentRetentionDisabled ?? false } };
+  return { email, record: { role: value.record.role ?? "user", tenantId: value.record.tenantId ?? "default", enabled: value.record.enabled ?? true, groups: [...new Set(value.record.groups ?? [])].map((item) => item.trim().toLowerCase()).filter(Boolean).sort(), contentRetentionDisabled: value.record.contentRetentionDisabled ?? false, assignmentState: value.record.assignmentState } };
 }
 function sortBindings(values: PolicyBinding[]): PolicyBinding[] {
   return values.map(normalizeBinding).sort((a, b) => a.priority - b.priority || a.principalType.localeCompare(b.principalType) || a.principalId.localeCompare(b.principalId) || a.policyId.localeCompare(b.policyId));

--- a/worker/content-retention.ts
+++ b/worker/content-retention.ts
@@ -1,0 +1,43 @@
+import type { AuthorizedIdentity, CompiledModel, ContentRecord, Env } from "./types";
+import { randomId } from "./utils.ts";
+
+interface RetainedSelection {
+  provider: { id: string };
+  model: CompiledModel | null;
+  capability: string;
+  body: Record<string, unknown>;
+}
+
+export function retentionRequired(auth: AuthorizedIdentity, capability: string): boolean {
+  return auth.policy.retainRequestContent !== false && !auth.contentRetentionDisabled && capability.startsWith("llm.");
+}
+
+export async function retainRequestContent(env: Env, auth: AuthorizedIdentity, selection: RetainedSelection, requestId: string): Promise<string | null> {
+  if (!retentionRequired(auth, selection.capability)) return null;
+  const contentRef = randomId("content");
+  const occurredAtMs = Date.now();
+  const record: ContentRecord = {
+    version: "clawrouter.retained-request.v1",
+    contentRef,
+    requestId,
+    occurredAtMs,
+    expiresAtMs: occurredAtMs + 30 * 86_400_000,
+    tenantId: auth.policy.tenantId ?? "default",
+    policyId: auth.policyId,
+    credentialId: auth.credentialId,
+    principalId: auth.principalId,
+    provider: selection.provider.id,
+    capability: selection.capability,
+    model: selection.model?.id ?? null,
+    body: selection.body,
+  };
+  await env.CONTENT_ARCHIVE.put(contentKey(record.tenantId, contentRef), JSON.stringify(record), {
+    httpMetadata: { contentType: "application/json" },
+    customMetadata: { expiresAt: String(record.expiresAtMs) },
+  });
+  return contentRef;
+}
+
+export function contentKey(tenant: string, ref: string): string {
+  return `v1/${encodeURIComponent(tenant)}/${encodeURIComponent(ref)}.json`;
+}

--- a/worker/discovery.ts
+++ b/worker/discovery.ts
@@ -1,6 +1,6 @@
 import { publicSession, sessionPolicies, verifiedAccessSession } from "./access";
 import { authenticateProxyKey } from "./proxy";
-import { providerReadiness, snapshot, type Readiness } from "./providers";
+import { providerReadinessForPolicies, snapshot, type Readiness } from "./providers";
 import type { AccessPolicyEntry, AccessSession, AuthorizedIdentity, CompiledProvider, Env } from "./types";
 import { errorResponse, privateJson, sha256Hex } from "./utils";
 
@@ -94,7 +94,7 @@ async function entitlementRows(session: AccessSession, env: Env): Promise<Entitl
 }
 
 async function entitlementRowsForEntries(entries: AccessPolicyEntry[], env: Env): Promise<EntitlementRow[]> {
-  const readiness = await providerReadiness(env);
+  const readiness = await providerReadinessForPolicies(env, entries);
   return snapshot.providers.map((provider) => {
     const policies = entries.filter((entry) => entry.policy.enabled && (!entry.policy.providers.length || entry.policy.providers.includes(provider.id))).map((entry) => entry.policyId);
     return { provider: provider.id, displayName: provider.display_name, serviceKind: provider.service_kind, allowed: policies.length > 0, policies, readiness: readiness.find((row) => row.id === provider.id)! };

--- a/worker/grant-scope.ts
+++ b/worker/grant-scope.ts
@@ -1,0 +1,15 @@
+import type { AccessPolicyEntry, UpstreamGrant } from "./types";
+
+export interface GrantRecord {
+  key: string;
+  grant: UpstreamGrant;
+}
+
+export function grantsVisibleToPolicies(grants: GrantRecord[], policies: AccessPolicyEntry[]): GrantRecord[] {
+  const prefixes = new Set<string>();
+  for (const entry of policies) {
+    prefixes.add(`oauth/${entry.policyId}/`);
+    prefixes.add(`oauth/tenants/${entry.policy.tenantId ?? "default"}/`);
+  }
+  return grants.filter((entry) => [...prefixes].some((prefix) => entry.key.startsWith(prefix)));
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -3,7 +3,7 @@ import { adminApi } from "./admin";
 import {
   avatarResponse, catalogResponse, entitlementResponse, meResponse, modelsResponse, sessionResponse,
 } from "./discovery";
-import { budgetStatus, BudgetLedgerObject, queue, UsageLedgerObject, usageSnapshot } from "./ledgers";
+import { budgetStatus, BudgetLedgerObject, queue, UsageLedgerObject, usageSnapshot, usageSnapshots } from "./ledgers";
 import { oauthCallback } from "./oauth";
 import { routeCatalog, snapshot } from "./providers";
 import { authenticateProxyKey, inspectKey, proxyManifest, proxyNative, proxyOpenAi } from "./proxy";
@@ -79,33 +79,16 @@ async function dashboardShell(request: Request, env: Env): Promise<Response> {
 async function userUsage(request: Request, env: Env): Promise<Response> {
   const auth = await authenticateProxyKey(request.headers, env);
   if (auth instanceof Response) return auth;
-  return privateJson({ policyId: auth.policyId, budget: await budgetStatus(env, auth.policyId, auth.policy), usage: await usageSnapshot(env, auth.policyId) });
+  return privateJson({ policyId: auth.policyId, budget: await budgetStatus(env, auth.policyId, auth.policy), usage: await usageSnapshot(env, auth.policy.tenantId ?? "default", auth.policyId) });
 }
 
 async function sessionUsage(request: Request, env: Env): Promise<Response> {
   const session = await verifiedAccessSession(request.headers, env);
   if (!session) return errorResponse("access_session_required", "a verified Cloudflare Access session is required", 401);
   const policies = await sessionPolicies(session, env);
-  const snapshots = await Promise.all(policies.map((entry) => usageSnapshot(env, entry.policyId)));
-  const usage = mergeUsage(snapshots as UsageSnapshot[]);
+  const usage = await usageSnapshots(env, policies.map((entry) => ({ policyId: entry.policyId, tenantId: entry.policy.tenantId ?? session.tenantId })));
   const policyRows = await Promise.all(policies.map(async (entry) => ({ policyId: entry.policyId, kid: entry.policyId, tenantId: entry.policy.tenantId ?? session.tenantId, enabled: entry.policy.enabled, providers: entry.policy.providers, tokenRole: entry.policy.tokenRole ?? null, monthlyBudgetMicros: entry.policy.monthlyBudgetMicros ?? null, requestCostMicros: entry.policy.requestCostMicros ?? null, budget: await budgetStatus(env, entry.policyId, entry.policy) })));
   return privateJson({ session: publicSession(session), policies: policyRows, usage });
-}
-
-interface UsageSnapshot { ledger: string; summary: Record<string, number>; providers: Array<Record<string, number | string>>; events: Array<Record<string, unknown>> }
-
-function mergeUsage(values: UsageSnapshot[]): UsageSnapshot {
-  const summary: Record<string, number> = { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 };
-  const providers = new Map<string, Record<string, number | string>>();
-  for (const value of values) {
-    for (const [key, amount] of Object.entries(value.summary)) summary[key] = (summary[key] ?? 0) + amount;
-    for (const row of value.providers) {
-      const id = String(row.provider), target = providers.get(id) ?? { provider: id, requestCount: 0, successCount: 0, errorCount: 0, totalTokens: 0, actualCostMicros: 0 };
-      for (const [key, amount] of Object.entries(row)) if (key !== "provider") target[key] = Number(target[key] ?? 0) + Number(amount);
-      providers.set(id, target);
-    }
-  }
-  return { ledger: "durable_object", summary, providers: [...providers.values()], events: [] };
 }
 
 function sameOrigin(request: Request): boolean { const url = new URL(request.url), origin = request.headers.get("origin"), site = request.headers.get("sec-fetch-site"); return origin === url.origin || (!origin && (!site || ["same-origin", "same-site", "none"].includes(site))); }
@@ -119,7 +102,7 @@ function serviceIndex() {
       health: "/v1/health", providers: "/v1/providers", routes: "/v1/routes", session: "/v1/session", entitlements: "/v1/entitlements",
       sessionUsage: "/v1/session/usage", me: "/v1/me", usage: "/v1/usage", models: "/v1/models", catalog: "/v1/catalog",
       anthropicMessages: "/v1/messages", anthropicCountTokens: "/v1/messages/count_tokens", keyInspect: "/v1/key/inspect",
-      adminOverview: "/v1/admin/overview", adminUsers: "/v1/admin/users", adminUsage: "/v1/admin/usage", adminPolicies: "/v1/admin/policies",
+      adminBootstrap: "/v1/admin/bootstrap", adminOverview: "/v1/admin/overview", adminUsers: "/v1/admin/users", adminUsage: "/v1/admin/usage", adminPolicies: "/v1/admin/policies",
       adminCredentials: "/v1/admin/credentials", adminConnections: "/v1/admin/connections", adminAccessUsers: "/v1/admin/access-users",
       adminAssignmentRules: "/v1/admin/assignment-rules", oauthCallback: "/v1/oauth/callback",
       openaiCompatible: ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"], manifestProxy: "/v1/proxy/{provider}/{endpoint}", nativeProxy: "/v1/native/{provider}/{provider-native-path}",

--- a/worker/ledgers.ts
+++ b/worker/ledgers.ts
@@ -1,14 +1,18 @@
 import type { BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
-import { errorResponse, json } from "./utils";
+import { emptyUsageSnapshot, mergeUsageSnapshots, usageShardName, type UsageSnapshot } from "./usage-sharding.ts";
+import { errorResponse, json } from "./utils.ts";
 
 const reservationLeaseMs = 15 * 60 * 1_000;
 const chargeRetentionMs = 45 * 86_400_000;
 const usageRetentionMs = 30 * 86_400_000;
+const legacyUsageReadUntilMs = Date.parse("2026-07-23T00:00:00.000Z");
 
 export class BudgetLedgerObject implements DurableObject {
   private sql: SqlStorage;
+  private state: DurableObjectState;
 
-  constructor(private state: DurableObjectState) {
+  constructor(state: DurableObjectState) {
+    this.state = state;
     this.sql = state.storage.sql;
     this.ensureSchema();
   }
@@ -96,7 +100,8 @@ export class BudgetLedgerObject implements DurableObject {
 
 export class UsageLedgerObject implements DurableObject {
   private sql: SqlStorage;
-  constructor(private state: DurableObjectState) { this.sql = state.storage.sql; this.ensureSchema(); }
+  private state: DurableObjectState;
+  constructor(state: DurableObjectState) { this.state = state; this.sql = state.storage.sql; this.ensureSchema(); }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -105,7 +110,7 @@ export class UsageLedgerObject implements DurableObject {
       if (!(await this.state.storage.getAlarm())) await this.state.storage.setAlarm(Date.now() + 86_400_000);
       return new Response("accepted");
     }
-    if (request.method === "GET" && url.pathname === "/snapshot") return json(this.snapshot(url.searchParams.get("policy_id"), Math.min(100, Number(url.searchParams.get("limit")) || 100)));
+    if (request.method === "GET" && url.pathname === "/snapshot") return json(this.snapshot(url.searchParams.getAll("policy_id"), Math.min(100, Number(url.searchParams.get("limit")) || 100)));
     return errorResponse("route_not_found", "route not found", 404);
   }
 
@@ -125,11 +130,12 @@ export class UsageLedgerObject implements DurableObject {
     this.cleanup();
   }
 
-  private snapshot(policyId: string | null, limit: number) {
+  private snapshot(policyIds: string[], limit: number) {
     this.cleanup();
     const cutoff = Date.now() - usageRetentionMs;
-    const where = policyId ? "policy_id = ? AND occurred_at_ms >= ?" : "occurred_at_ms >= ?";
-    const params = policyId ? [policyId, cutoff] : [cutoff];
+    const uniquePolicyIds = [...new Set(policyIds.filter(Boolean))];
+    const where = uniquePolicyIds.length ? `policy_id IN (${uniquePolicyIds.map(() => "?").join(", ")}) AND occurred_at_ms >= ?` : "occurred_at_ms >= ?";
+    const params = [...uniquePolicyIds, cutoff];
     const events = rows<{ event_json: string }>(this.sql.exec(`SELECT event_json FROM usage_events WHERE ${where} ORDER BY occurred_at_ms DESC LIMIT ?`, ...params, limit)).map((row) => JSON.parse(row.event_json));
     const summary = first<SummaryRow>(this.sql.exec(`SELECT COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) AS success_count, COALESCE(SUM(CASE WHEN status != 'success' THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(input_tokens), 0) AS input_tokens, COALESCE(SUM(output_tokens), 0) AS output_tokens, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(actual_cost_micros), 0) AS actual_cost_micros FROM usage_events WHERE ${where}`, ...params) as unknown as Iterable<SummaryRow>) ?? emptySummary();
     const providers = rows<ProviderRow>(this.sql.exec(`SELECT provider, COUNT(*) AS request_count, COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) AS success_count, COALESCE(SUM(CASE WHEN status != 'success' THEN 1 ELSE 0 END), 0) AS error_count, COALESCE(SUM(total_tokens), 0) AS total_tokens, COALESCE(SUM(actual_cost_micros), 0) AS actual_cost_micros FROM usage_events WHERE ${where} GROUP BY provider ORDER BY request_count DESC`, ...params) as unknown as Iterable<ProviderRow>);
@@ -147,23 +153,43 @@ export class UsageLedgerObject implements DurableObject {
 export async function queue(batch: MessageBatch<QueueMessage>, env: Env): Promise<void> {
   for (const message of batch.messages) {
     try {
-      if ("type" in message.body) await usageStub(env).fetch("https://clawrouter.internal/ingest", { method: "POST", body: JSON.stringify(message.body) });
+      let response: Response;
+      if ("type" in message.body) response = await usageStub(env, message.body.tenant_id, message.body.policy_id).fetch("https://clawrouter.internal/ingest", { method: "POST", body: JSON.stringify(message.body) });
       else {
         const job = message.body;
         const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(`${job.tenant_id}:${job.policy_id}`));
-        await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(job.request) });
+        response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(job.request) });
       }
+      if (!response.ok) throw new Error(`ledger queue write returned ${response.status}`);
       message.ack();
     } catch { message.retry(); }
   }
 }
 
-export async function usageSnapshot(env: Env, policyId: string | null, limit = 100) {
+export async function usageSnapshot(env: Env, tenantId: string, policyId: string, limit = 100): Promise<UsageSnapshot> {
+  return usageSnapshots(env, [{ tenantId, policyId }], limit);
+}
+
+export async function usageSnapshots(env: Env, policies: Array<{ policyId: string; tenantId: string }>, limit = 100): Promise<UsageSnapshot> {
+  if (!policies.length) return emptyUsageSnapshot();
+  const current = await Promise.all(policies.map((policy) => currentUsageSnapshot(env, policy.tenantId, policy.policyId, limit)));
+  if (Date.now() >= legacyUsageReadUntilMs) return mergeUsageSnapshots(current, limit);
   const url = new URL("https://clawrouter.internal/snapshot");
-  if (policyId) url.searchParams.set("policy_id", policyId);
+  for (const policyId of [...new Set(policies.map((policy) => policy.policyId))]) url.searchParams.append("policy_id", policyId);
   url.searchParams.set("limit", String(limit));
-  const response = await usageStub(env).fetch(url);
-  return response.json();
+  const legacyResponse = await legacyUsageStub(env).fetch(url);
+  if (!legacyResponse.ok) return mergeUsageSnapshots(current, limit);
+  const legacy = await legacyResponse.json<UsageSnapshot>();
+  return mergeUsageSnapshots([legacy, ...current], limit);
+}
+
+async function currentUsageSnapshot(env: Env, tenantId: string, policyId: string, limit: number): Promise<UsageSnapshot> {
+  const url = new URL("https://clawrouter.internal/snapshot");
+  url.searchParams.set("policy_id", policyId);
+  url.searchParams.set("limit", String(limit));
+  const response = await usageStub(env, tenantId, policyId).fetch(url);
+  if (!response.ok) throw new Error(`usage snapshot returned ${response.status}`);
+  return response.json<UsageSnapshot>();
 }
 
 export async function budgetStatus(env: Env, policyId: string, policy: { tenantId?: string | null; monthlyBudgetMicros?: number | null }) {
@@ -184,7 +210,8 @@ export async function budgetStatus(env: Env, policyId: string, policy: { tenantI
   }
 }
 
-export function usageStub(env: Env): DurableObjectStub { return env.USAGE_LEDGER.get(env.USAGE_LEDGER.idFromName("global")); }
+export function usageStub(env: Env, tenantId: string, policyId: string): DurableObjectStub { return env.USAGE_LEDGER.get(env.USAGE_LEDGER.idFromName(usageShardName(tenantId, policyId))); }
+function legacyUsageStub(env: Env): DurableObjectStub { return env.USAGE_LEDGER.get(env.USAGE_LEDGER.idFromName("global")); }
 
 function numberParam(url: URL, name: string): number | null { const value = Number(url.searchParams.get(name)); return Number.isSafeInteger(value) && value >= 0 ? value : null; }
 function rows<T>(cursor: Iterable<T>): T[] { return [...cursor]; }

--- a/worker/providers.ts
+++ b/worker/providers.ts
@@ -1,7 +1,8 @@
 import snapshotJson from "./generated/provider-snapshot.json";
-import { resolveConnection, resolveConnections } from "./authority";
+import { listConnections, resolveConnection } from "./authority";
+import { grantsVisibleToPolicies, type GrantRecord } from "./grant-scope";
 import type {
-  AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, Env,
+  AccessPolicyEntry, AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, Env,
   ProviderConnection, ProviderHealth, ProviderSnapshot, UpstreamGrant,
 } from "./types";
 import { HttpError } from "./utils";
@@ -109,19 +110,33 @@ export function routeCatalog() {
 }
 
 export async function providerReadiness(env: Env): Promise<Readiness[]> {
-  const [grants, health, storedConnections] = await Promise.all([
-    listGrantRecords(env), listHealth(env), resolveConnections(env, snapshot.providers.map((provider) => provider.id)),
-  ]);
+  const { grants, health, connections } = await readinessInputs(env);
+  return providerReadinessFromState(env, grants, [...connections.values()], health);
+}
+
+export async function providerReadinessForPolicies(env: Env, policies: AccessPolicyEntry[]): Promise<Readiness[]> {
+  const { grants, health, connections } = await readinessInputs(env);
+  const visibleGrants = grantsVisibleToPolicies(grants, policies);
+  return providerReadinessFromState(env, visibleGrants, [...connections.values()], health);
+}
+
+export function providerReadinessFromState(env: Env, grants: GrantRecord[], storedConnections: ProviderConnection[], health: Map<string, ProviderHealth>): Readiness[] {
   const connections = new Map(storedConnections.map((connection) => [connection.providerId, connection]));
   return snapshot.providers.map((provider) => readinessFor(provider, env, grants, connections.get(provider.id) ?? { providerId: provider.id, enabled: true }, health.get(provider.id)));
 }
 
+async function readinessInputs(env: Env) {
+  const [grants, health, storedConnections] = await Promise.all([listGrantRecords(env), listHealth(env), listConnections(env, snapshot.providers.map((provider) => provider.id))]);
+  const connections = new Map(storedConnections.map((connection) => [connection.providerId, connection]));
+  return { grants, health, connections };
+}
+
 export async function readinessForIdentity(env: Env, auth: AuthorizedIdentity): Promise<Readiness[]> {
-  const all = await providerReadiness(env);
+  const all = await providerReadinessForPolicies(env, [{ policyId: auth.policyId, policy: auth.policy }]);
   return all.filter((row) => auth.policy.providers.length === 0 || auth.policy.providers.includes(row.id));
 }
 
-function readinessFor(provider: CompiledProvider, env: Env, grants: GrantEntry[], connection: ProviderConnection, health?: ProviderHealth): Readiness {
+function readinessFor(provider: CompiledProvider, env: Env, grants: GrantRecord[], connection: ProviderConnection, health?: ProviderHealth): Readiness {
   const optionalConfig = provider.auth.schemes.every((scheme) => scheme.type === "bearer" && scheme.required === false) ? provider.config_keys.filter((key) => secretConfigKey(key)) : [];
   const requiredConfig = provider.config_keys.filter((key) => !optionalConfig.includes(key));
   const providerGrants = grants.filter((entry) => entry.grant.enabled !== false && entry.grant.provider === provider.id && grantUsable(entry.grant));
@@ -266,8 +281,8 @@ export async function signSigV4(provider: CompiledProvider, url: URL, method: st
   headers.delete("host");
 }
 
-export async function listGrantRecords(env: Env): Promise<GrantEntry[]> {
-  const entries: GrantEntry[] = [];
+export async function listGrantRecords(env: Env): Promise<GrantRecord[]> {
+  const entries: GrantRecord[] = [];
   let cursor: string | undefined;
   do {
     const page = await env.POLICY_KV.list({ prefix: "oauth/", cursor });
@@ -289,8 +304,6 @@ export async function listHealth(env: Env): Promise<Map<string, ProviderHealth>>
   }
   return result;
 }
-
-interface GrantEntry { key: string; grant: UpstreamGrant }
 
 async function grantFor(provider: CompiledProvider, auth: AuthorizedIdentity, env: Env): Promise<UpstreamGrant | null> {
   const tokenRef = provider.auth.schemes.find((scheme) => scheme.type === "oauth")?.tokenRef ?? provider.id;
@@ -349,7 +362,7 @@ function grantUsable(grant: UpstreamGrant): boolean {
   return !!(grant.credential || grant.accessToken || Object.keys(grant.credentials ?? {}).length);
 }
 
-function grantSatisfiesConfig(key: string, grants: GrantEntry[]): boolean {
+function grantSatisfiesConfig(key: string, grants: GrantRecord[]): boolean {
   if (secretConfigKey(key)) return grants.length > 0;
   const fields: Record<string, string> = { AWS_ACCESS_KEY_ID: "accessKeyId", AWS_SECRET_ACCESS_KEY: "secretAccessKey", AWS_SESSION_TOKEN: "sessionToken" };
   const field = fields[key];

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -1,14 +1,13 @@
 import { accessIdentity } from "./access";
+import { finalizeAccounting, reserveBudget, type BudgetReservation, type EstimatedCost } from "./accounting";
 import { resolveCredentials, resolvePolicies, resolveUsers } from "./authority";
+import { retainRequestContent } from "./content-retention";
 import {
   assertProviderAccess, capabilityForPath, copyRequestHeaders, endpointForPath, modelRoute, providerById,
   resolveTemplate, signSigV4, transformRequestBody, upstreamAuth, upstreamPath,
 } from "./providers";
 import { actualModelCost, estimateModelCost } from "./pricing";
-import type {
-  AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, CompiledEndpoint,
-  CompiledModel, CompiledProvider, ContentRecord, Env, QueueMessage, UsageEvent,
-} from "./types";
+import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, Env, UsageEvent } from "./types";
 import {
   clampAudit, errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
 } from "./utils";
@@ -23,11 +22,6 @@ interface ProxySelection {
   body: Record<string, unknown>;
   pathParams: Record<string, string>;
   method: string;
-}
-
-interface BudgetReservation {
-  reservationId: string | null;
-  reservedMicros: number;
 }
 
 export async function proxyOpenAi(request: Request, env: Env, context: ExecutionContext, path: string, mode: AuthMode): Promise<Response> {
@@ -148,22 +142,33 @@ export async function inspectKey(headers: Headers, env: Env): Promise<Response> 
 async function proxySelected(request: Request, env: Env, context: ExecutionContext, mode: AuthMode, selection: ProxySelection, queryInput: Record<string, unknown> = {}, preauthenticated: AuthorizedIdentity | null = null): Promise<Response> {
   const auth = preauthenticated ?? (mode === "access" ? await accessIdentity(request.headers, env, selection.provider.id) : await authenticateProxyKey(request.headers, env));
   if (auth instanceof Response) return auth;
-  try { await assertProviderAccess(selection.provider, auth, env); }
-  catch (error) { return error instanceof HttpError ? errorResponse(error.code, error.message, error.status) : errorResponse("provider_unavailable", "provider authorization failed", 503); }
   const requestId = request.headers.get("x-request-id") ?? randomId("req");
   const started = Date.now();
+  const cost = estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability);
+  try { await assertProviderAccess(selection.provider, auth, env); }
+  catch (error) {
+    const failure = error instanceof HttpError ? error : new HttpError(503, "provider_unavailable", "provider authorization failed");
+    auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, failure.status === 403 ? "denied" : "provider_error");
+    return errorResponse(failure.code, failure.message, failure.status);
+  }
   let upstream;
   try { upstream = await upstreamAuth(selection.provider, selection.endpoint, auth, env); }
-  catch (error) { return error instanceof HttpError ? errorResponse(error.code, error.message, error.status) : errorResponse("provider_not_configured", "provider is not configured", 503); }
-  const cost = estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability);
+  catch (error) {
+    const failure = error instanceof HttpError ? error : new HttpError(503, "provider_not_configured", "provider is not configured");
+    auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, "provider_error");
+    return errorResponse(failure.code, failure.message, failure.status);
+  }
   let reservation: BudgetReservation;
   try { reservation = await reserveBudget(env, auth, selection.capability, cost); }
-  catch (error) { return error instanceof HttpError ? errorResponse(error.code, error.message, error.status) : errorResponse("budget_store_unavailable", "budget ledger is unavailable", 503); }
+  catch (error) {
+    const failure = error instanceof HttpError ? error : new HttpError(503, "budget_store_unavailable", "budget ledger is unavailable");
+    auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, failure.status === 402 ? "denied" : failure.status < 500 ? "client_error" : "provider_error");
+    return errorResponse(failure.code, failure.message, failure.status);
+  }
   let content: string | null;
-  try { content = await retainContent(env, auth, selection, requestId); }
+  try { content = await retainRequestContent(env, auth, selection, requestId); }
   catch {
-    await settleBudget(env, auth, reservation, 0);
-    await enqueueUsage(env, usageEvent(auth, selection, request, requestId, started, 503, null, cost, reservation, null, "provider_error"));
+    context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, 503, null, cost, reservation, null, "provider_error")));
     return errorResponse("content_retention_unavailable", "required request-content retention is temporarily unavailable", 503);
   }
   const headers = new Headers(upstream.headers);
@@ -179,8 +184,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
   try { await signSigV4(selection.provider, url, selection.method, requestBody, headers, env, upstream.grant); }
   catch (error) {
     clearTimeout(timeout);
-    await settleBudget(env, auth, reservation, 0);
-    await enqueueUsage(env, usageEvent(auth, selection, request, requestId, started, 503, null, cost, reservation, content, "provider_error"));
+    context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, 503, null, cost, reservation, content, "provider_error")));
     return error instanceof HttpError ? errorResponse(error.code, error.message, error.status) : errorResponse("provider_not_configured", "provider signing configuration is invalid", 503);
   }
   let response: Response;
@@ -188,8 +192,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     response = await fetch(url, { method: selection.method, headers, body: requestBody, signal: controller.signal });
   } catch (error) {
     clearTimeout(timeout);
-    await settleBudget(env, auth, reservation, 0);
-    await enqueueUsage(env, usageEvent(auth, selection, request, requestId, started, 502, null, cost, reservation, content, error instanceof DOMException && error.name === "AbortError" ? "timeout" : "provider_error"));
+    context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, 502, null, cost, reservation, content, error instanceof DOMException && error.name === "AbortError" ? "timeout" : "provider_error")));
     return errorResponse("provider_unavailable", `upstream request to provider ${selection.provider.id} failed`, 502, undefined);
   }
   clearTimeout(timeout);
@@ -200,6 +203,11 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
   outputHeaders.set("x-clawrouter-upstream-provider", selection.provider.id);
   outputHeaders.set("x-clawrouter-content-retention", auth.policy.retainRequestContent !== false && !auth.contentRetentionDisabled ? "on; retention-days=30" : "off");
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers: outputHeaders });
+}
+
+function auditFailure(context: ExecutionContext, env: Env, auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, cost: Cost, statusCode: number, status: UsageEvent["status"]): void {
+  const reservation = { reservationId: null, reservedMicros: 0 };
+  context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, statusCode, null, cost, reservation, null, status)));
 }
 
 async function preauthenticate(request: Request, env: Env, mode: AuthMode, providerId?: string): Promise<AuthorizedIdentity | Response | null> {
@@ -216,11 +224,10 @@ async function finalizeResponse(response: Response, env: Env, auth: AuthorizedId
   } catch { /* usage is best-effort; reservation stays conservative */ }
   const measured = tokens ? actualCost(selection.model, tokens, auth.policy.requestCostMicros) : null;
   const actual = response.ok && measured != null ? measured : response.ok ? estimated.reserveMicros : 0;
-  await settleBudget(env, auth, reservation, actual);
-  await enqueueUsage(env, usageEvent(auth, selection, request, requestId, started, response.status, tokens, estimated, reservation, content, response.ok ? "success" : response.status < 500 ? "client_error" : "provider_error", actual));
+  await finalizeAccounting(env, auth, reservation, actual, usageEvent(auth, selection, request, requestId, started, response.status, tokens, estimated, reservation, content, response.ok ? "success" : response.status < 500 ? "client_error" : "provider_error", actual));
 }
 
-interface Cost { reserveMicros: number; basis: string; inputTokens: number | null; outputTokens: number | null }
+type Cost = EstimatedCost;
 interface Tokens { input: number | null; output: number | null; total: number | null; cached: number | null; cacheWrite: number | null; cacheWrite5m: number | null; cacheWrite1h: number | null }
 
 function estimateCost(model: CompiledModel | null, body: Record<string, unknown>, fixed: number | null | undefined, capability: string): Cost {
@@ -239,47 +246,6 @@ function actualCost(model: CompiledModel | null, tokens: Tokens, fixed: number |
   return actualModelCost(pricing, tokens);
 }
 
-async function reserveBudget(env: Env, auth: AuthorizedIdentity, capability: string, cost: Cost): Promise<BudgetReservation> {
-  const limit = auth.policy.monthlyBudgetMicros;
-  if (limit == null) return { reservationId: null, reservedMicros: 0 };
-  if (limit === 0) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
-  if (cost.basis === "flat_fallback") throw new HttpError(400, "pricing_required", "budgeted requests require versioned manifest pricing or a fixed policy request price");
-  const reservationId = randomId("budget");
-  const tenant = auth.policy.tenantId ?? "default";
-  const policyId = `${tenant}/${auth.policyId}`;
-  const request: BudgetReserveRequest = { policyId, windowKey: `${policyId}/${new Date().toISOString().slice(0, 7)}`, limitMicros: limit, costMicros: cost.reserveMicros, reservationId, capability };
-  const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(`${tenant}:${auth.policyId}`));
-  const response = await stub.fetch("https://clawrouter.internal/reserve", { method: "POST", body: JSON.stringify(request) });
-  const result = await response.json<{ allowed: boolean; chargedMicros: number }>();
-  if (!result.allowed) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
-  return { reservationId, reservedMicros: result.chargedMicros };
-}
-
-async function settleBudget(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number): Promise<void> {
-  if (!reservation.reservationId) return;
-  const tenant = auth.policy.tenantId ?? "default";
-  const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(`${tenant}:${auth.policyId}`));
-  const body: BudgetSettleRequest = { reservationId: reservation.reservationId, actualCostMicros };
-  const response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(body) });
-  if (!response.ok) await env.USAGE_QUEUE.send({ kind: "budget_settlement", tenant_id: tenant, policy_id: auth.policyId, request: body });
-}
-
-async function retainContent(env: Env, auth: AuthorizedIdentity, selection: ProxySelection, requestId: string): Promise<string | null> {
-  if (auth.policy.retainRequestContent === false || auth.contentRetentionDisabled || !selection.capability.startsWith("llm.")) return null;
-  const contentRef = randomId("content");
-  const occurredAtMs = Date.now();
-  const record: ContentRecord = {
-    version: "clawrouter.retained-request.v1", contentRef, requestId, occurredAtMs, expiresAtMs: occurredAtMs + 30 * 86_400_000,
-    tenantId: auth.policy.tenantId ?? "default", policyId: auth.policyId, credentialId: auth.credentialId,
-    principalId: auth.principalId, provider: selection.provider.id, capability: selection.capability,
-    model: selection.model?.id ?? null, body: selection.body,
-  };
-  await env.CONTENT_ARCHIVE.put(contentKey(record.tenantId, contentRef), JSON.stringify(record), { httpMetadata: { contentType: "application/json" }, customMetadata: { expiresAt: String(record.expiresAtMs) } });
-  return contentRef;
-}
-
-export function contentKey(tenant: string, ref: string): string { return `v1/${encodeURIComponent(tenant)}/${encodeURIComponent(ref)}.json`; }
-
 function usageEvent(auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, statusCode: number, tokens: Tokens | null, cost: Cost, reservation: BudgetReservation, contentRef: string | null, status: UsageEvent["status"], actual = 0): UsageEvent {
   return {
     id: randomId("usage"), type: "clawrouter.usage.v1", occurred_at_ms: Date.now(), tenant_id: auth.policy.tenantId ?? "default",
@@ -296,8 +262,6 @@ function usageEvent(auth: AuthorizedIdentity, selection: ProxySelection, request
     duration_ms: Date.now() - started, content_retained: !!contentRef, content_ref: contentRef, status,
   };
 }
-
-async function enqueueUsage(env: Env, event: UsageEvent): Promise<void> { await env.USAGE_QUEUE.send(event satisfies QueueMessage); }
 
 function extractTokens(value: unknown): Tokens | null {
   if (!value || typeof value !== "object") return null;

--- a/worker/test/accounting.test.mjs
+++ b/worker/test/accounting.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { finalizeAccounting, settleBudget } from "../accounting.ts";
+
+const auth = {
+  credentialId: "credential",
+  principalId: "user@example.com",
+  authType: "proxy_key",
+  policyId: "policy",
+  policy: { enabled: true, generation: "v1", providers: [], tenantId: "tenant", retainRequestContent: true },
+  contentRetentionDisabled: false,
+};
+const reservation = { reservationId: "reservation", reservedMicros: 100 };
+const event = { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy" };
+
+test("thrown ledger settlement queues a retry", async () => {
+  const sent = [];
+  const env = mockEnv(async (message) => { sent.push(message); });
+  await settleBudget(env, auth, reservation, 42);
+  assert.deepEqual(sent, [{ kind: "budget_settlement", tenant_id: "tenant", policy_id: "policy", request: { reservationId: "reservation", actualCostMicros: 42 } }]);
+});
+
+test("settlement retry failure does not suppress the usage event", async () => {
+  const sent = [];
+  const env = mockEnv(async (message) => {
+    if (message.kind === "budget_settlement") throw new Error("queue settlement unavailable");
+    sent.push(message);
+  });
+  const errors = [];
+  const original = console.error;
+  console.error = (...values) => errors.push(values.join(" "));
+  try {
+    await finalizeAccounting(env, auth, reservation, 42, event);
+  } finally {
+    console.error = original;
+  }
+  assert.deepEqual(sent, [event]);
+  assert.match(errors.join("\n"), /queue settlement unavailable/);
+});
+
+function mockEnv(send) {
+  return {
+    BUDGET_LEDGER: {
+      idFromName: (name) => name,
+      get: () => ({ fetch: async () => { throw new Error("ledger unavailable"); } }),
+    },
+    USAGE_QUEUE: { send },
+  };
+}

--- a/worker/test/assignments.test.mjs
+++ b/worker/test/assignments.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assignmentRulesRevision, evaluateUserAssignments, withLegacyAssignmentState } from "../assignment-evaluator.ts";
+
+const rule = {
+  ruleId: "members",
+  generatedGroup: "assignment.members",
+  version: 1,
+  enabled: true,
+  kind: "email_domain",
+  subject: "example.com",
+  groups: ["members"],
+  policyIds: ["policy"],
+  priority: 10,
+  revokeOnLoss: true,
+  provenance: "cloudflare_access",
+};
+
+test("unchanged assignment revision performs no authority write", async () => {
+  const revision = assignmentRulesRevision([rule]);
+  const user = { email: "member@example.com", record: { groups: ["assignment.members", "members"], assignmentState: { version: 1, revision, assignments: { members: { groups: ["assignment.members", "members"], revokeOnLoss: true } }, updatedAt: "2026-06-22T00:00:00.000Z" } } };
+  const result = evaluateUserAssignments(user, [rule]);
+  assert.equal(result.user, user);
+  assert.equal(result.changed, false);
+});
+
+test("changed assignment rules update the canonical user once", async () => {
+  const user = { email: "member@example.com", record: { groups: ["manual"] } };
+  const result = evaluateUserAssignments(user, [rule]);
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.user.record.groups, ["assignment.members", "manual", "members"]);
+  assert.equal(result.user.record.assignmentState.revision, assignmentRulesRevision([rule]));
+});
+
+test("legacy GitHub assignment state survives first reconciliation without evidence", () => {
+  const githubRule = { ...rule, ruleId: "org", generatedGroup: "assignment.org", kind: "github_org", subject: "openclaw", groups: ["maintainers"] };
+  const user = { email: "member@example.com", record: { groups: ["assignment.org", "maintainers", "manual"] } };
+  const migrated = withLegacyAssignmentState(user, { version: 1, assignments: { org: { groups: ["assignment.org", "maintainers"], revokeOnLoss: true } }, updatedAt: "2026-06-01T00:00:00.000Z" });
+  const result = evaluateUserAssignments(migrated, [githubRule]);
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.retainedRuleIds, ["org"]);
+  assert.deepEqual(result.user.record.groups, ["assignment.org", "maintainers", "manual"]);
+  assert.equal(result.user.record.assignmentState.revision, assignmentRulesRevision([githubRule]));
+});

--- a/worker/test/content-retention.test.mjs
+++ b/worker/test/content-retention.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { contentKey, retainRequestContent, retentionRequired } from "../content-retention.ts";
+
+const auth = {
+  credentialId: "credential",
+  principalId: "user@example.com",
+  authType: "proxy_key",
+  policyId: "policy",
+  policy: { enabled: true, generation: "v1", providers: [], tenantId: "tenant/name", retainRequestContent: true },
+  contentRetentionDisabled: false,
+};
+const selection = { provider: { id: "openai" }, model: { id: "openai/model" }, capability: "llm.chat", body: { messages: [{ role: "user", content: "hello" }] } };
+
+test("retention is default-on for LLM requests and stores a bounded record", async () => {
+  const writes = [];
+  const ref = await retainRequestContent({ CONTENT_ARCHIVE: { put: async (...args) => writes.push(args) } }, auth, selection, "request");
+  assert.match(ref, /^content_/);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0][0], contentKey("tenant/name", ref));
+  const record = JSON.parse(writes[0][1]);
+  assert.deepEqual(record.body, selection.body);
+  assert.equal(record.requestId, "request");
+  assert.equal(record.expiresAtMs - record.occurredAtMs, 30 * 86_400_000);
+  assert.equal(writes[0][2].customMetadata.expiresAt, String(record.expiresAtMs));
+});
+
+test("policy opt-out, user exemption, and non-LLM traffic bypass retention", async () => {
+  assert.equal(retentionRequired({ ...auth, policy: { ...auth.policy, retainRequestContent: false } }, "llm.chat"), false);
+  assert.equal(retentionRequired({ ...auth, contentRetentionDisabled: true }, "llm.chat"), false);
+  assert.equal(retentionRequired(auth, "web.search"), false);
+  let writes = 0;
+  const ref = await retainRequestContent({ CONTENT_ARCHIVE: { put: async () => { writes += 1; } } }, { ...auth, contentRetentionDisabled: true }, selection, "request");
+  assert.equal(ref, null);
+  assert.equal(writes, 0);
+});

--- a/worker/test/grant-scope.test.mjs
+++ b/worker/test/grant-scope.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { grantsVisibleToPolicies } from "../grant-scope.ts";
+
+const policies = [
+  { policyId: "policy_a", policy: { tenantId: "tenant_a" } },
+  { policyId: "policy_b", policy: { tenantId: "tenant_b" } },
+];
+const grants = [
+  { key: "oauth/policy_a/openai", grant: { provider: "openai" } },
+  { key: "oauth/tenants/tenant_b/anthropic", grant: { provider: "anthropic" } },
+  { key: "oauth/policy_other/openai", grant: { provider: "openai" } },
+  { key: "oauth/tenants/tenant_other/openai", grant: { provider: "openai" } },
+];
+
+test("readiness grants are limited to the current policies and tenants", () => {
+  assert.deepEqual(grantsVisibleToPolicies(grants, policies), grants.slice(0, 2));
+});
+
+test("similarly prefixed policy and tenant ids do not cross scope", () => {
+  const visible = grantsVisibleToPolicies([
+    { key: "oauth/policy_a_extra/openai", grant: { provider: "openai" } },
+    { key: "oauth/tenants/tenant_a_extra/openai", grant: { provider: "openai" } },
+  ], policies.slice(0, 1));
+  assert.deepEqual(visible, []);
+});

--- a/worker/test/ledger-queue.test.mjs
+++ b/worker/test/ledger-queue.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { queue } from "../ledgers.ts";
+
+test("usage delivery targets its policy shard and acknowledges success", async () => {
+  const calls = [], message = queueMessage(usageEvent());
+  await queue({ messages: [message] }, mockEnv(calls, new Response("accepted")));
+  assert.deepEqual(calls.map((call) => call.name), ["policy:tenant:policy"]);
+  assert.equal(message.ackCount, 1);
+  assert.equal(message.retryCount, 0);
+});
+
+test("non-2xx usage and settlement writes retry instead of being acknowledged", async () => {
+  for (const body of [usageEvent(), { kind: "budget_settlement", tenant_id: "tenant", policy_id: "policy", request: { reservationId: "r1", actualCostMicros: 2 } }]) {
+    const message = queueMessage(body);
+    await queue({ messages: [message] }, mockEnv([], new Response("failed", { status: 503 })));
+    assert.equal(message.ackCount, 0);
+    assert.equal(message.retryCount, 1);
+  }
+});
+
+function usageEvent() { return { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy" }; }
+function queueMessage(body) {
+  return { body, ackCount: 0, retryCount: 0, ack() { this.ackCount += 1; }, retry() { this.retryCount += 1; } };
+}
+function mockEnv(calls, response) {
+  const namespace = { idFromName: (name) => name, get: (name) => ({ fetch: async (url) => { calls.push({ name, url }); return response.clone(); } }) };
+  return { USAGE_LEDGER: namespace, BUDGET_LEDGER: namespace };
+}

--- a/worker/test/usage-sharding.test.mjs
+++ b/worker/test/usage-sharding.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mergeUsageSnapshots, usageShardName } from "../usage-sharding.ts";
+
+test("usage shards are isolated by tenant and policy", () => {
+  assert.equal(usageShardName("tenant_a", "policy"), "policy:tenant_a:policy");
+  assert.notEqual(usageShardName("tenant_a", "policy"), usageShardName("tenant_b", "policy"));
+});
+
+test("usage snapshots aggregate counters and deduplicate ordered events", () => {
+  const first = { ledger: "legacy", summary: { requestCount: 1, totalTokens: 10 }, providers: [{ provider: "openai", requestCount: 1, totalTokens: 10 }], events: [{ id: "a", occurred_at_ms: 1 }] };
+  const second = { ledger: "shard", summary: { requestCount: 2, totalTokens: 20 }, providers: [{ provider: "openai", requestCount: 2, totalTokens: 20 }], events: [{ id: "b", occurred_at_ms: 3 }, { id: "a", occurred_at_ms: 1 }] };
+  const merged = mergeUsageSnapshots([first, second]);
+  assert.equal(merged.summary.requestCount, 3);
+  assert.equal(merged.summary.totalTokens, 30);
+  assert.equal(merged.providers[0].requestCount, 3);
+  assert.deepEqual(merged.events.map((event) => event.id), ["b", "a"]);
+});

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -90,7 +90,11 @@ export interface AccessUserRecord {
   enabled?: boolean | null;
   groups?: string[];
   contentRetentionDisabled?: boolean;
+  assignmentState?: AssignmentState;
 }
+
+export interface AssignmentStateEntry { groups: string[]; revokeOnLoss: boolean }
+export interface AssignmentState { version: 1; revision: string; assignments: Record<string, AssignmentStateEntry>; updatedAt: string | null }
 
 export interface AccessControlUser { email: string; record: AccessUserRecord }
 

--- a/worker/usage-sharding.ts
+++ b/worker/usage-sharding.ts
@@ -1,0 +1,41 @@
+export interface UsageSnapshot {
+  ledger: string;
+  summary: Record<string, number>;
+  providers: Array<Record<string, number | string>>;
+  events: Array<Record<string, unknown>>;
+}
+
+export function usageShardName(tenantId: string, policyId: string): string {
+  return `policy:${tenantId}:${policyId}`;
+}
+
+export function emptyUsageSnapshot(ledger = "durable_object_sharded"): UsageSnapshot {
+  return {
+    ledger,
+    summary: { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 },
+    providers: [],
+    events: [],
+  };
+}
+
+export function mergeUsageSnapshots(values: UsageSnapshot[], limit = 100): UsageSnapshot {
+  const merged = emptyUsageSnapshot();
+  const providers = new Map<string, Record<string, number | string>>();
+  const events = new Map<string, Record<string, unknown>>();
+  for (const value of values) {
+    for (const [key, amount] of Object.entries(value.summary)) merged.summary[key] = (merged.summary[key] ?? 0) + amount;
+    for (const row of value.providers) {
+      const id = String(row.provider);
+      const target = providers.get(id) ?? { provider: id, requestCount: 0, successCount: 0, errorCount: 0, totalTokens: 0, actualCostMicros: 0 };
+      for (const [key, amount] of Object.entries(row)) if (key !== "provider") target[key] = Number(target[key] ?? 0) + Number(amount);
+      providers.set(id, target);
+    }
+    for (const event of value.events) {
+      const id = typeof event.id === "string" ? event.id : JSON.stringify(event);
+      if (!events.has(id)) events.set(id, event);
+    }
+  }
+  merged.providers = [...providers.values()].sort((left, right) => Number(right.requestCount) - Number(left.requestCount));
+  merged.events = [...events.values()].sort((left, right) => Number(right.occurred_at_ms ?? 0) - Number(left.occurred_at_ms ?? 0)).slice(0, limit);
+  return merged;
+}


### PR DESCRIPTION
## Summary

- make Durable Object authority canonical after bounded KV migration, preserve legacy combined keys and assignment state, and keep established authentication sessions read-only
- isolate budget settlement, usage delivery, request retention, scoped readiness, and tenant/policy usage sharding with regression coverage
- add one coherent admin bootstrap contract, stop polling immutable catalog data, split Access administration into focused hooks, and derive demo models from the canonical provider snapshot
- document control-plane ownership, migration, refresh, and failure boundaries

## Verification

- `pnpm build`
- `pnpm check` (24 Worker, 19 admin, 43 script tests)
- `pnpm worker:e2e`
- `autoreview --mode local` clean after accepted migration and partial-failure fixes
- existing-Chrome UI E2E: admin/user dashboards, 20-provider catalog, GPT-5.5 / Claude Opus 4.8 / GLM-5.2 picker paths, chat turn inspection, all Access tabs, Users, Usage, retention disclosure, 500px responsive width, clean console

## Deployment status

Not deployed from this branch. Production build and local Wrangler Worker E2E are green.

## Remaining risk

The sharded usage reader includes a bounded compatibility read from the former global ledger through 2026-07-23. Remove that bridge after the retained 30-day history expires.
