### PR TITLE
docs: add OpenClaw integration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Document first-party OpenClaw setup, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.
 - Join the console into a full-bleed racked frame with a flush header, connected hairlines, and one 16px alignment datum; make action buttons monochrome so copper is reserved for state, selection, and focus; calm right-rail notes, facts, and attention metrics; and replace the provider-usage list with a ranked share readout with per-provider error callouts.
 - Redesign the console with the Patchboard visual system: copper-on-graphite dark and blueprint-paper light themes, bundled Archivo and Spline Sans Mono variable fonts, semantic stylesheet modules replacing the numbered append-only files, and higher-contrast status, focus, and selection states.
 - Make accounting finalization independently retryable, scope readiness to entitled policies, move canonical access state out of KV fallback paths, shard usage by tenant/policy, consolidate admin bootstrap refreshes, and split shared contracts and access controllers into focused modules.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Current implementation target:
 - Cloudflare KV-backed one-time migration seeds, version 1
   API-key/OAuth/subscription grants, assignment rules, and provider health
 
+## OpenClaw client
+
+OpenClaw includes a bundled `@openclaw/clawrouter` plugin. One policy-scoped
+credential discovers allowed models, routes supported OpenAI-compatible and
+native provider protocols, and reports managed budget usage without installing
+or authenticating every upstream provider plugin on the OpenClaw host.
+
+See [Use ClawRouter with OpenClaw](docs/openclaw.md) for credential setup,
+dynamic model discovery, multi-provider smoke tests, and quota verification.
+
 ## Provider Registry
 
 Provider support is data-driven. Most integrations are added by creating one file:

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -1,0 +1,114 @@
+# Use ClawRouter with OpenClaw
+
+OpenClaw can use one ClawRouter credential to discover and run every model
+allowed by its policy. Upstream provider keys stay in ClawRouter. The OpenClaw
+host does not need separate OpenAI, Anthropic, Google, or other provider
+credentials, and it does not need those companies' OpenClaw plugins.
+
+The bundled `@openclaw/clawrouter` plugin owns catalog discovery, request
+transport, model-id rewriting, tool compatibility, and quota reporting.
+
+## Prerequisites
+
+- a deployed ClawRouter origin, normally `https://clawrouter.openclaw.ai`;
+- enabled, ready upstream provider connections;
+- a policy granting the intended model services and budget; and
+- an active proxy credential bound to that policy.
+
+In the ClawRouter console, create the policy under **Access > Policies**, then
+issue its credential under **Access > Credentials**. The secret is revealed
+once. Store it in an approved secret manager before leaving the page.
+
+## Configure OpenClaw
+
+The plugin is included with OpenClaw and enabled by default.
+
+```sh
+export CLAWROUTER_API_KEY="<issued credential>"
+openclaw onboard --auth-choice clawrouter-api-key
+```
+
+For a self-hosted ClawRouter origin, configure the provider base URL:
+
+```json5
+{
+  models: {
+    providers: {
+      clawrouter: {
+        baseUrl: "https://router.example.com",
+      },
+    },
+  },
+}
+```
+
+The base URL may include `/v1`; the plugin normalizes it to the correct catalog,
+usage, and inference endpoints.
+
+## Discover and select models
+
+```sh
+openclaw models list --all --provider clawrouter
+openclaw models set clawrouter/<provider>/<model>
+```
+
+Use model refs exactly as returned. The first segment is always `clawrouter`;
+the remaining path preserves the upstream provider and model namespace.
+
+ClawRouter's credential-scoped `GET /v1/catalog` response is authoritative.
+OpenClaw advertises a model only when the policy grants its provider, the
+provider is ready, the model has an LLM capability, and its route maps to a
+supported transport:
+
+| Catalog contract | OpenClaw transport |
+| --- | --- |
+| OpenAI-compatible chat | `openai-completions` |
+| OpenAI-compatible Responses | `openai-responses` |
+| Native Anthropic Messages | `anthropic-messages` |
+| Native Google streaming content | `google-generative-ai` |
+
+Adding a model to a provider that already exposes one of these contracts needs
+no OpenClaw release. It appears on the next catalog refresh. A provider using a
+different request or stream envelope needs a new ClawRouter plugin transport;
+until then, OpenClaw fails closed and omits it.
+
+## Verify inference
+
+Choose refs from the live catalog rather than copying model names from this
+page. Exercise more than one transport family when the policy allows it:
+
+```sh
+openclaw agent \
+  --model clawrouter/<provider>/<model> \
+  --message "Reply exactly: CLAWROUTER_OK"
+```
+
+For a multi-provider smoke, run one OpenAI-compatible model, one native
+Anthropic model, and one native Google model. A successful catalog lookup alone
+does not prove upstream inference.
+
+## Verify budget and usage
+
+```sh
+openclaw status --usage
+openclaw models status
+```
+
+The plugin reads `GET /v1/usage` with the same credential. Budgeted policies
+show a monthly percentage window plus request, token, and spend totals.
+Unmetered policies show totals without a percentage. OpenClaw also exposes this
+snapshot through `/status` in chat and its usage UI.
+
+## Security boundaries
+
+- The proxy credential reaches only ClawRouter, never an upstream provider.
+- Upstream credentials remain server-side in Worker secrets or scoped grants.
+- Catalog and usage responses are policy-scoped.
+- OpenClaw attaches the proxy credential only when dispatching catalog, usage,
+  or inference requests; it is not model metadata.
+- Revoking the credential blocks that client. Disabling the policy blocks every
+  credential and principal bound to it.
+
+See the [OpenClaw ClawRouter provider page](https://docs.openclaw.ai/providers/clawrouter)
+for the client-facing reference and [Cloudflare deployment](deploy-cloudflare.md)
+for operator provisioning.


### PR DESCRIPTION
## Summary

- add a standalone OpenClaw integration guide
- document credential issuance, dynamic catalog behavior, supported transports, inference smoke tests, and quota surfaces
- link the guide from the README and changelog

## Verification

- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm check` on Node 24
- structured autoreview: clean, no actionable findings
- Markdown links and examples manually checked against the current ClawRouter and OpenClaw contracts

## Deployment

Docs-only change. No Worker deployment required.

## Risk

Low. No runtime or configuration behavior changes.
