### PR TITLE
docs: clarify OpenClaw plugin allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Document first-party OpenClaw setup, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.
+- Document first-party OpenClaw setup, plugin and model allowlists, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.
 - Join the console into a full-bleed racked frame with a flush header, connected hairlines, and one 16px alignment datum; make action buttons monochrome so copper is reserved for state, selection, and focus; calm right-rail notes, facts, and attention metrics; and replace the provider-usage list with a ranked share readout with per-provider error callouts.
 - Redesign the console with the Patchboard visual system: copper-on-graphite dark and blueprint-paper light themes, bundled Archivo and Spline Sans Mono variable fonts, semantic stylesheet modules replacing the numbered append-only files, and higher-contrast status, focus, and selection states.
 - Make accounting finalization independently retryable, scope readiness to entitled policies, move canonical access state out of KV fallback paths, shard usage by tenant/policy, consolidate admin bootstrap refreshes, and split shared contracts and access controllers into focused modules.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -21,12 +21,17 @@ once. Store it in an approved secret manager before leaving the page.
 
 ## Configure OpenClaw
 
-The plugin is included with OpenClaw and enabled by default.
+The plugin is bundled with OpenClaw. Enable it explicitly:
 
 ```sh
 export CLAWROUTER_API_KEY="<issued credential>"
 openclaw onboard --auth-choice clawrouter-api-key
+openclaw plugins enable clawrouter
 ```
+
+If your OpenClaw configuration sets `plugins.allow`, add `clawrouter` before
+enabling the plugin. OpenClaw can store the proxy credential in its auth
+profile; it does not need to remain in the shell environment after setup.
 
 For a self-hosted ClawRouter origin, configure the provider base URL:
 
@@ -54,6 +59,8 @@ openclaw models set clawrouter/<provider>/<model>
 
 Use model refs exactly as returned. The first segment is always `clawrouter`;
 the remaining path preserves the upstream provider and model namespace.
+If your OpenClaw configuration uses `agents.defaults.models` as an allowlist,
+add each selected ClawRouter ref to that map.
 
 ClawRouter's credential-scoped `GET /v1/catalog` response is authoritative.
 OpenClaw advertises a model only when the policy grants its provider, the


### PR DESCRIPTION
## Summary

- make bundled-plugin enablement explicit in the standalone OpenClaw guide
- document `plugins.allow`, auth-profile persistence, and `agents.defaults.models` allowlists
- keep the existing Unreleased documentation entry accurate

## Validation

- `git diff --check`
- docs-only review
