### PR TITLE
feat: auto-assign verified GitHub members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Automatically bind GitHub organization and team assignment rules from Cloudflare Access's verified same-origin identity on first sign-in, including existing users whose prior reconciliation lacked GitHub evidence.
 - Document first-party OpenClaw setup, plugin and model allowlists, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.
 - Join the console into a full-bleed racked frame with a flush header, connected hairlines, and one 16px alignment datum; make action buttons monochrome so copper is reserved for state, selection, and focus; calm right-rail notes, facts, and attention metrics; and replace the provider-usage list with a ranked share readout with per-provider error callouts.
 - Redesign the console with the Patchboard visual system: copper-on-graphite dark and blueprint-paper light themes, bundled Archivo and Spline Sans Mono variable fonts, semantic stylesheet modules replacing the numbered append-only files, and higher-contrast status, focus, and selection states.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
 `provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
 Zero Trust Access apps and policies. The production default admits verified
 members of the `openclaw` GitHub organization through the configured GitHub
-identity provider. Real deploys also require KV write
+identity provider. GitHub organization and team assignment rules use that
+same-origin, verified Access identity to bind or revoke the user's managed
+policy; no browser-supplied organization claim is trusted. Real deploys also require KV write
 permission because Wrangler validates the Worker `POLICY_KV` binding while
 publishing. Keep `access_domain` set to the console hostname; `worker_url` is
 only the post-deploy smoke-test target.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -350,10 +350,14 @@ unchanged sessions are read-only. Saving a rule reconciles known users, and the
 admin endpoint supports explicit reconciliation with verified external
 evidence. Policy grants
 use a rule-owned `assignment.<rule-id>` group, so reconciliation never replaces
-manual direct user bindings. GitHub organization/team rules require explicit
-verified GitHub evidence for one user; a reconcile without GitHub evidence
-retains existing GitHub-derived assignments instead of treating unknown
-membership as loss.
+manual direct user bindings. On a GitHub Access sign-in, the Worker reads
+Cloudflare Access's same-origin identity endpoint, requires the identity email
+to match the verified Access JWT, and uses its organization/team records as
+verified evidence for enabled GitHub rules. This refresh also enforces
+`revokeOnLoss` when organization or team membership changes; unchanged evidence
+does not write authority state. The cookie and raw identity response are never stored. Explicit admin reconciliation remains
+available; a reconcile without GitHub evidence retains existing GitHub-derived
+assignments instead of treating unknown membership as loss.
 
 ```json
 {

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -1,4 +1,5 @@
 import { authorityCall, resolveBindings, resolvePolicies, resolveUsers } from "./authority";
+import { assignmentEvidenceFromAccessIdentity } from "./assignment-evaluator";
 import { listAssignmentRules, reconcileUserAssignments } from "./assignments";
 import type { AccessControlUser, AccessPolicyEntry, AccessSession, AuthorizedIdentity, Env } from "./types";
 import { commaSet, errorResponse, normalizeEmail, parseBearer, safeEqual, sha256Hex } from "./utils";
@@ -15,7 +16,8 @@ interface AccessJwtPayload {
 
 interface Jwk { kid?: string; kty?: string; n?: string; e?: string; alg?: string; use?: string }
 
-export async function verifiedAccessSession(headers: Headers, env: Env): Promise<AccessSession | null> {
+export async function verifiedAccessSession(request: Request, env: Env): Promise<AccessSession | null> {
+  const headers = request.headers;
   const assertion = headers.get("cf-access-jwt-assertion");
   if (!assertion || !env.CLAWROUTER_ACCESS_TEAM_DOMAIN || !env.CLAWROUTER_ACCESS_AUD) return null;
   const payload = await verifyAccessJwt(assertion, env.CLAWROUTER_ACCESS_TEAM_DOMAIN, env.CLAWROUTER_ACCESS_AUD);
@@ -27,7 +29,10 @@ export async function verifiedAccessSession(headers: Headers, env: Env): Promise
     user = { email, record: { role: "user", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } };
     await authorityCall(env, "/users/put", user);
   }
-  if (!user.record.assignmentState) user = (await reconcileUserAssignments(user, await listAssignmentRules(env), env)).user;
+  const rules = await listAssignmentRules(env);
+  const hasGithubRules = rules.some((rule) => rule.enabled && ["github_org", "github_team"].includes(rule.kind));
+  const evidence = hasGithubRules ? await verifiedGithubEvidence(request, email) : undefined;
+  if (!user.record.assignmentState || evidence) user = (await reconcileUserAssignments(user, rules, env, evidence, !!evidence)).user;
   if (user.record.enabled === false) return null;
   return {
     authenticated: true,
@@ -41,8 +46,8 @@ export async function verifiedAccessSession(headers: Headers, env: Env): Promise
   };
 }
 
-export async function accessIdentity(headers: Headers, env: Env, providerId?: string): Promise<AuthorizedIdentity | Response> {
-  const session = await verifiedAccessSession(headers, env);
+export async function accessIdentity(request: Request, env: Env, providerId?: string): Promise<AuthorizedIdentity | Response> {
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "a verified Cloudflare Access session is required", 401);
   const principals = [
     { principalType: "user" as const, principalId: session.email },
@@ -74,7 +79,7 @@ export async function sessionPolicies(session: AccessSession, env: Env): Promise
 }
 
 export async function authorizeAdmin(request: Request, env: Env): Promise<AccessSession | Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (session) {
     if (session.role !== "admin") return errorResponse("access_admin_required", "administrator access is required", 403);
     if (!["GET", "HEAD"].includes(request.method) && !sameOrigin(request)) return errorResponse("access_csrf_required", "same-origin browser request required", 403);
@@ -111,6 +116,21 @@ function adminRole(email: string, env: Env): boolean {
   if (commaSet(env.CLAWROUTER_ACCESS_ADMIN_EMAILS).has(email)) return true;
   const domain = email.split("@")[1];
   return !!domain && commaSet(env.CLAWROUTER_ACCESS_ADMIN_DOMAINS).has(domain);
+}
+
+async function verifiedGithubEvidence(request: Request, email: string) {
+  const cookie = request.headers.get("cookie");
+  if (!cookie) return undefined;
+  const url = new URL("/cdn-cgi/access/get-identity", request.url);
+  try {
+    const response = await fetch(url, { headers: { accept: "application/json", cookie }, redirect: "manual" });
+    if (!response.ok) return undefined;
+    const body = await response.text();
+    if (body.length > 64 * 1024) return undefined;
+    return assignmentEvidenceFromAccessIdentity(JSON.parse(body), email);
+  } catch {
+    return undefined;
+  }
 }
 
 async function selectProviderPolicy(entries: AccessPolicyEntry[], providerId: string, tenantId: string, env: Env): Promise<AccessPolicyEntry> {

--- a/worker/assignment-evaluator.ts
+++ b/worker/assignment-evaluator.ts
@@ -9,6 +9,32 @@ export interface AssignmentEvidence {
 
 export interface AssignmentRuleEntry extends AssignmentRule { ruleId: string; generatedGroup: string }
 
+export function assignmentEvidenceFromAccessIdentity(value: unknown, expectedEmail: string): AssignmentEvidence | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const identity = value as Record<string, unknown>;
+  const email = typeof identity.email === "string" ? identity.email.trim().toLowerCase() : "";
+  const idp = identity.idp && typeof identity.idp === "object" ? identity.idp as Record<string, unknown> : null;
+  if (!email || email !== expectedEmail.trim().toLowerCase() || idp?.type !== "github") return undefined;
+  if (!Array.isArray(identity.orgs) || !Array.isArray(identity.teams)) return undefined;
+
+  const organizations = records(identity.orgs);
+  const teams = records(identity.teams);
+  if (organizations.length !== identity.orgs.length || teams.length !== identity.teams.length) return undefined;
+  const namesById = new Map(organizations.flatMap((organization) => {
+    const id = scalarString(organization.id), name = scalarString(organization.name).toLowerCase();
+    return id && name ? [[id, name] as const] : [];
+  }));
+  if (namesById.size !== organizations.length) return undefined;
+  const githubOrgs = normalizeGroups(organizations.map((organization) => scalarString(organization.name)));
+  const githubTeams = normalizeGroups(teams.flatMap((team) => {
+    const organization = namesById.get(scalarString(team.org_id));
+    const name = scalarString(team.name).toLowerCase();
+    return organization && name ? [`${organization}/${name}`] : [];
+  }));
+  if (githubTeams.length !== teams.length) return undefined;
+  return { source: "github", verified: true, githubOrgs, githubTeams };
+}
+
 export function withLegacyAssignmentState(user: AccessControlUser, legacy: Partial<AssignmentState> | null): AccessControlUser {
   if (user.record.assignmentState || !legacy?.assignments || typeof legacy.assignments !== "object") return user;
   const assignments = Object.fromEntries(Object.entries(legacy.assignments).flatMap(([ruleId, entry]) => {
@@ -45,6 +71,9 @@ export function evaluateUserAssignments(user: AccessControlUser, rules: Assignme
   const previousGroups = new Set(Object.values(previous.assignments).flatMap((entry) => entry.groups));
   const manual = (user.record.groups ?? []).filter((group) => !previousGroups.has(group) && !group.startsWith("assignment."));
   const groups = normalizeGroups([...manual, ...Object.values(assignments).flatMap((entry) => entry.groups)]);
+  if (previous.revision === revision && JSON.stringify(previous.assignments) === JSON.stringify(assignments) && JSON.stringify(normalizeGroups(user.record.groups ?? [])) === JSON.stringify(groups)) {
+    return { changed: false as const, user, matchedRuleIds, retainedRuleIds };
+  }
   const assignmentState: AssignmentState = { version: 1, revision, assignments, updatedAt: new Date().toISOString() };
   const updated: AccessControlUser = { ...user, record: { ...user.record, role: "user", groups, assignmentState } };
   return { changed: true as const, user: updated, matchedRuleIds, retainedRuleIds };
@@ -76,3 +105,5 @@ function assignmentEntry(rule: AssignmentRuleEntry): AssignmentStateEntry {
 }
 
 function normalizeGroups(groups: string[]) { return [...new Set(groups.map((group) => group.trim().toLowerCase()).filter(Boolean))].sort(); }
+function records(value: unknown): Array<Record<string, unknown>> { return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => !!item && typeof item === "object") : []; }
+function scalarString(value: unknown): string { return typeof value === "string" || typeof value === "number" ? String(value).trim() : ""; }

--- a/worker/discovery.ts
+++ b/worker/discovery.ts
@@ -5,7 +5,7 @@ import type { AccessPolicyEntry, AccessSession, AuthorizedIdentity, CompiledProv
 import { errorResponse, privateJson, sha256Hex } from "./utils";
 
 export async function sessionResponse(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "a verified Cloudflare Access session is required", 401);
   let entitlements: { providers: EntitlementRow[] } | undefined;
   let entitlementsError: string | undefined;
@@ -15,13 +15,13 @@ export async function sessionResponse(request: Request, env: Env): Promise<Respo
 }
 
 export async function entitlementResponse(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "entitlements require a verified Cloudflare Access session", 401);
   return privateJson({ session: publicSession(session), providers: await entitlementRows(session, env), contentRetention: await retentionView(session, env) });
 }
 
 export async function avatarResponse(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "avatar access requires a verified Cloudflare Access session", 401);
   const hash = await sha256Hex(session.email.trim().toLowerCase());
   const upstream = await fetch(`https://www.gravatar.com/avatar/${hash}?s=60&d=identicon&r=g`);
@@ -73,7 +73,7 @@ export async function catalogResponse(request: Request, env: Env): Promise<Respo
 }
 
 export async function meResponse(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (session) return privateJson(publicSession(session));
   const auth = await authenticateProxyKey(request.headers, env);
   if (auth instanceof Response) return auth;
@@ -108,7 +108,7 @@ async function clientEntitlements(request: Request, env: Env): Promise<Entitleme
     if (auth instanceof Response) return auth;
     return entitlementRowsForEntries([{ policyId: auth.policyId, policy: auth.policy }], env);
   }
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   return session ? entitlementRows(session, env) : errorResponse("client_auth_required", "a valid ClawRouter proxy key or Cloudflare Access session is required", 401);
 }
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -68,7 +68,7 @@ async function route(request: Request, env: Env, context: ExecutionContext): Pro
 }
 
 async function dashboardShell(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "a verified Cloudflare Access session is required", 401);
   const url = new URL(request.url); url.pathname = "/";
   const response = await env.ASSETS.fetch(new Request(url, request));
@@ -83,7 +83,7 @@ async function userUsage(request: Request, env: Env): Promise<Response> {
 }
 
 async function sessionUsage(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "a verified Cloudflare Access session is required", 401);
   const policies = await sessionPolicies(session, env);
   const usage = await usageSnapshots(env, policies.map((entry) => ({ policyId: entry.policyId, tenantId: entry.policy.tenantId ?? session.tenantId })));

--- a/worker/oauth.ts
+++ b/worker/oauth.ts
@@ -26,7 +26,7 @@ export async function startOAuth(request: Request, env: Env, grantKey: string, p
 }
 
 export async function oauthCallback(request: Request, env: Env): Promise<Response> {
-  const session = await verifiedAccessSession(request.headers, env);
+  const session = await verifiedAccessSession(request, env);
   if (!session || session.role !== "admin") return errorResponse("access_admin_required", "OAuth callback requires a verified Access admin", 403);
   const url = new URL(request.url), stateId = url.searchParams.get("state"), code = url.searchParams.get("code"), providerError = url.searchParams.get("error");
   if (!stateId) return errorResponse("invalid_oauth_callback", "OAuth state is missing", 400);

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -140,7 +140,7 @@ export async function inspectKey(headers: Headers, env: Env): Promise<Response> 
 }
 
 async function proxySelected(request: Request, env: Env, context: ExecutionContext, mode: AuthMode, selection: ProxySelection, queryInput: Record<string, unknown> = {}, preauthenticated: AuthorizedIdentity | null = null): Promise<Response> {
-  const auth = preauthenticated ?? (mode === "access" ? await accessIdentity(request.headers, env, selection.provider.id) : await authenticateProxyKey(request.headers, env));
+  const auth = preauthenticated ?? (mode === "access" ? await accessIdentity(request, env, selection.provider.id) : await authenticateProxyKey(request.headers, env));
   if (auth instanceof Response) return auth;
   const requestId = request.headers.get("x-request-id") ?? randomId("req");
   const started = Date.now();
@@ -212,7 +212,7 @@ function auditFailure(context: ExecutionContext, env: Env, auth: AuthorizedIdent
 
 async function preauthenticate(request: Request, env: Env, mode: AuthMode, providerId?: string): Promise<AuthorizedIdentity | Response | null> {
   if (mode === "proxy_key") return authenticateProxyKey(request.headers, env);
-  return providerId ? accessIdentity(request.headers, env, providerId) : null;
+  return providerId ? accessIdentity(request, env, providerId) : null;
 }
 
 async function finalizeResponse(response: Response, env: Env, auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, estimated: Cost, reservation: BudgetReservation, content: string | null): Promise<void> {

--- a/worker/test/assignments.test.mjs
+++ b/worker/test/assignments.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { assignmentRulesRevision, evaluateUserAssignments, withLegacyAssignmentState } from "../assignment-evaluator.ts";
+import { assignmentEvidenceFromAccessIdentity, assignmentRulesRevision, evaluateUserAssignments, withLegacyAssignmentState } from "../assignment-evaluator.ts";
 
 const rule = {
   ruleId: "members",
@@ -41,4 +41,40 @@ test("legacy GitHub assignment state survives first reconciliation without evide
   assert.deepEqual(result.retainedRuleIds, ["org"]);
   assert.deepEqual(result.user.record.groups, ["assignment.org", "maintainers", "manual"]);
   assert.equal(result.user.record.assignmentState.revision, assignmentRulesRevision([githubRule]));
+});
+
+test("forced GitHub reconciliation skips an unchanged authority write", () => {
+  const githubRule = { ...rule, ruleId: "org", generatedGroup: "assignment.org", kind: "github_org", subject: "openclaw", groups: [] };
+  const revision = assignmentRulesRevision([githubRule]);
+  const user = { email: "member@example.com", record: { groups: ["assignment.org"], assignmentState: { version: 1, revision, assignments: { org: { groups: ["assignment.org"], revokeOnLoss: true } }, updatedAt: "2026-06-22T00:00:00.000Z" } } };
+  const evidence = { source: "github", verified: true, githubOrgs: ["openclaw"], githubTeams: [] };
+  const result = evaluateUserAssignments(user, [githubRule], evidence, true);
+  assert.equal(result.changed, false);
+  assert.equal(result.user, user);
+});
+
+test("verified GitHub membership loss revokes an existing managed assignment", () => {
+  const githubRule = { ...rule, ruleId: "org", generatedGroup: "assignment.org", kind: "github_org", subject: "openclaw", groups: ["maintainers"] };
+  const revision = assignmentRulesRevision([githubRule]);
+  const user = { email: "member@example.com", record: { groups: ["assignment.org", "maintainers", "manual"], assignmentState: { version: 1, revision, assignments: { org: { groups: ["assignment.org", "maintainers"], revokeOnLoss: true } }, updatedAt: "2026-06-22T00:00:00.000Z" } } };
+  const evidence = { source: "github", verified: true, githubOrgs: [], githubTeams: [] };
+  const result = evaluateUserAssignments(user, [githubRule], evidence, true);
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.user.record.groups, ["manual"]);
+  assert.deepEqual(result.user.record.assignmentState.assignments, {});
+});
+
+test("Cloudflare GitHub identity becomes normalized assignment evidence", () => {
+  const evidence = assignmentEvidenceFromAccessIdentity({
+    email: "Member@Example.com",
+    idp: { type: "github" },
+    orgs: [{ id: 7, name: "OpenClaw" }, { id: "8", name: "Example" }],
+    teams: [{ org_id: "7", name: "Maintainers" }, { org_id: 8, name: "Docs" }],
+  }, "member@example.com");
+  assert.deepEqual(evidence, { source: "github", verified: true, githubOrgs: ["example", "openclaw"], githubTeams: ["example/docs", "openclaw/maintainers"] });
+  assert.deepEqual(assignmentEvidenceFromAccessIdentity({ email: "member@example.com", idp: { type: "github" }, orgs: [], teams: [] }, "member@example.com"), { source: "github", verified: true, githubOrgs: [], githubTeams: [] });
+  assert.equal(assignmentEvidenceFromAccessIdentity({ email: "member@example.com", idp: { type: "github" }, orgs: [] }, "member@example.com"), undefined);
+  assert.equal(assignmentEvidenceFromAccessIdentity({ email: "member@example.com", idp: { type: "github" }, orgs: [{ id: 7, name: "OpenClaw" }], teams: [{ org_id: 8, name: "Maintainers" }] }, "member@example.com"), undefined);
+  assert.equal(assignmentEvidenceFromAccessIdentity({ email: "member@example.com", idp: { type: "google" }, orgs: [{ id: 7, name: "OpenClaw" }], teams: [] }, "member@example.com"), undefined);
+  assert.equal(assignmentEvidenceFromAccessIdentity({ email: "other@example.com", idp: { type: "github" }, orgs: [{ id: 7, name: "OpenClaw" }], teams: [] }, "member@example.com"), undefined);
 });


### PR DESCRIPTION
## Summary

- derive GitHub organization/team assignment evidence from Cloudflare Access's verified same-origin identity
- automatically grant matching managed policies on sign-in and enforce `revokeOnLoss`
- preserve assignments when identity evidence is unavailable or incomplete
- document the trust boundary and add regression coverage

## Validation

- `pnpm check`
- `pnpm build`
- `git diff --check`
- authenticated production identity-shape verification against Cloudflare Access
