### PR TITLE
fix: validate provider requests before reserving budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate provider request paths and templates before reserving budget so malformed manifest requests fail without temporarily consuming quota.
 - Automatically bind GitHub organization and team assignment rules from Cloudflare Access's verified same-origin identity on first sign-in, including existing users whose prior reconciliation lacked GitHub evidence.
 - Document first-party OpenClaw setup, plugin and model allowlists, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.
 - Join the console into a full-bleed racked frame with a flush header, connected hairlines, and one 16px alignment datum; make action buttons monochrome so copper is reserved for state, selection, and focus; calm right-rail notes, facts, and attention metrics; and replace the provider-usage list with a ranked share readout with per-provider error callouts.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -15,7 +15,7 @@ const legacyKey = `clawrouter-live-legacy-${legacySecret}`;
 const generation = "migration_e2e";
 writeFileSync(config, `${readFileSync("wrangler.toml", "utf8").trim()}\n\n[[kv_namespaces]]\nbinding = "POLICY_KV"\nid = "local-e2e"\n`);
 mkdirSync(persistence, { recursive: true });
-putLocalKv("policies/migrate", { enabled: true, generation, providers: ["firecrawl", "replicate"], tenantId: "default", tokenRole: "service", retainRequestContent: true });
+putLocalKv("policies/migrate", { enabled: true, generation, providers: ["firecrawl", "replicate"], tenantId: "default", tokenRole: "service", monthlyBudgetMicros: 10_000, requestCostMicros: 100, retainRequestContent: true });
 putLocalKv("credentials/migrate", { enabled: true, secretSha256: sha256(proxySecret), policyId: "migrate", policyGeneration: generation });
 putLocalKv("keys/legacy", { enabled: true, secretSha256: sha256(legacySecret), generation: "legacy", providers: ["firecrawl"], tenantId: "default", retainRequestContent: true });
 
@@ -73,6 +73,14 @@ try {
   const directManifestGet = await fetch(`${base}/v1/proxy/replicate/prediction?prediction_id=pred_123`, { headers: { authorization: `Bearer ${proxyKey}` } });
   assert.equal(directManifestGet.status, 503);
   assert.equal((await directManifestGet.json()).error.code, "provider_not_configured", "GET manifest routes parse path params without a JSON envelope");
+  const grant = await fetch(`${base}/v1/admin/upstream-grants/policies/migrate/replicate`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "replicate", kind: "api_key", credential: "local-e2e-token" }) });
+  assert.equal(grant.status, 200);
+  const missingPathParam = await fetch(`${base}/v1/proxy/replicate/prediction`, { headers: { authorization: `Bearer ${proxyKey}` } });
+  assert.equal(missingPathParam.status, 400);
+  assert.equal((await missingPathParam.json()).error.code, "missing_path_param");
+  const usageAfterInvalidRequest = await fetch(`${base}/v1/usage`, { headers: { authorization: `Bearer ${proxyKey}` } });
+  assert.equal(usageAfterInvalidRequest.status, 200);
+  assert.equal((await usageAfterInvalidRequest.json()).budget.spentMicros, 0, "invalid manifest requests must not reserve budget");
   const combined = await fetch(`${base}/v1/admin/keys/migrate`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ secretSha256: sha256("different_secret_1234"), providers: ["openai"], enabled: true }) });
   assert.equal(combined.status, 409);
   assert.equal((await combined.json()).error.code, "combined_policy_secret_rotation");

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -158,6 +158,21 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, "provider_error");
     return errorResponse(failure.code, failure.message, failure.status);
   }
+  let headers: Headers, url: URL, requestBody: string | undefined;
+  try {
+    headers = new Headers(upstream.headers);
+    copyRequestHeaders(request.headers, selection.provider, selection.endpoint, headers, env);
+    const path = upstreamPath(selection.provider, selection.endpoint, selection.pathParams, env, upstream);
+    url = new URL(`${upstream.baseUrl.replace(/\/$/, "")}${path}`);
+    upstream.query.forEach((value, name) => url.searchParams.set(name, value));
+    for (const [name, value] of Object.entries(selection.endpoint.query)) url.searchParams.set(name, resolveTemplate(selection.provider, value, env));
+    for (const [name, value] of Object.entries(queryInput)) if (value != null) url.searchParams.set(name, String(value));
+    requestBody = ["GET", "HEAD"].includes(selection.method) ? undefined : JSON.stringify(selection.body);
+  } catch (error) {
+    const failure = error instanceof HttpError ? error : new HttpError(503, "provider_request_invalid", "provider request configuration is invalid");
+    auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, failure.status < 500 ? "client_error" : "provider_error");
+    return errorResponse(failure.code, failure.message, failure.status);
+  }
   let reservation: BudgetReservation;
   try { reservation = await reserveBudget(env, auth, selection.capability, cost); }
   catch (error) {
@@ -171,16 +186,8 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, 503, null, cost, reservation, null, "provider_error")));
     return errorResponse("content_retention_unavailable", "required request-content retention is temporarily unavailable", 503);
   }
-  const headers = new Headers(upstream.headers);
-  copyRequestHeaders(request.headers, selection.provider, selection.endpoint, headers, env);
-  const path = upstreamPath(selection.provider, selection.endpoint, selection.pathParams, env, upstream);
-  const url = new URL(`${upstream.baseUrl.replace(/\/$/, "")}${path}`);
-  upstream.query.forEach((value, name) => url.searchParams.set(name, value));
-  for (const [name, value] of Object.entries(selection.endpoint.query)) url.searchParams.set(name, resolveTemplate(selection.provider, value, env));
-  for (const [name, value] of Object.entries(queryInput)) if (value != null) url.searchParams.set(name, String(value));
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), selection.endpoint.timeout_ms ?? 120_000);
-  const requestBody = ["GET", "HEAD"].includes(selection.method) ? undefined : JSON.stringify(selection.body);
   try { await signSigV4(selection.provider, url, selection.method, requestBody, headers, env, upstream.grant); }
   catch (error) {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- build and validate provider request paths, templates, headers, query parameters, and bodies before reserving budget
- audit malformed/provider-configuration failures without creating a temporary quota hold
- cover the budget invariant through the running local Wrangler Worker and Durable Object ledger

## Root cause

Manifest request preparation ran after budget reservation and outside failure accounting. A deterministic error such as a missing required path parameter returned `400 missing_path_param`, but left the reservation charged until its lease expired and emitted no failure audit.

## Verification

- `pnpm worker:e2e` — before fix: malformed request returned 400 and `spentMicros` became 100; after fix: same 400 with `spentMicros` remaining 0
- `pnpm check`
- `pnpm build`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings

## Deployment

Not deployed yet. After merge: deploy exact `main`, run production smoke, and verify the public health/catalog/Access gates.

## Remaining risk

Low. The refactor only moves deterministic request construction ahead of reservation; provider signing, retention, fetch, streaming, settlement, and response handling stay in their existing order.
