### PR TITLE
fix: accept case-insensitive admin bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept HTTP bearer authentication schemes case-insensitively for admin API tokens.
 - Validate provider request paths and templates before reserving budget so malformed manifest requests fail without temporarily consuming quota.
 - Automatically bind GitHub organization and team assignment rules from Cloudflare Access's verified same-origin identity on first sign-in, including existing users whose prior reconciliation lacked GitHub evidence.
 - Document first-party OpenClaw setup, plugin and model allowlists, credential-scoped dynamic model discovery, supported transports, multi-provider smoke testing, and quota reporting on a standalone integration page.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -50,6 +50,8 @@ try {
   const inspectionBody = await inspection.json();
   assert.equal(inspection.status, 200, JSON.stringify(inspectionBody));
   assert.equal(inspectionBody.verification, "verified", "KV-only credential migrates into authority on first use");
+  const lowercaseAdminAuth = await fetch(`${base}/v1/admin/overview`, { headers: { authorization: `bearer ${adminToken}` } });
+  assert.equal(lowercaseAdminAuth.status, 200, "HTTP bearer auth scheme matching is case-insensitive");
   const bootstrap = await fetch(`${base}/v1/admin/bootstrap`, { headers: { authorization: `Bearer ${adminToken}` } });
   assert.equal(bootstrap.status, 200);
   const bootstrapBody = await bootstrap.json();

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -75,7 +75,7 @@ export async function sha256Hex(value: string): Promise<string> {
 
 export function parseBearer(headers: Headers): string | null {
   const value = headers.get("authorization");
-  return value?.startsWith("Bearer ") ? value.slice(7).trim() : null;
+  return value?.match(/^Bearer[ \t]+(.+)$/i)?.[1].trim() || null;
 }
 
 export function parseProxyKey(input: string): { mode: "live" | "test"; kid: string; secret: string } | null {


### PR DESCRIPTION
## Summary

- accept the HTTP Bearer authentication scheme case-insensitively for admin API tokens
- preserve strict token extraction and rejection of missing or empty credentials
- cover lowercase `bearer` against the live local Wrangler Worker

## Root cause

`parseBearer` matched only the exact `Bearer ` spelling even though HTTP authentication schemes are case-insensitive. Valid clients using `bearer` received `401 unauthorized` from admin endpoints.

## Proof

- before: local Worker regression returned 401 for lowercase `bearer`
- after: `pnpm worker:e2e` passes and the same request returns 200
- `pnpm worker:check`
- `pnpm check`
- `pnpm build`
- autoreview: no accepted or actionable findings; correctness 0.98

Production deployment and smoke proof will follow exact-head CI and merge.
