### PR TITLE
fix: preserve upstream credential bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve stored multi-field upstream credential bundles when editing grant metadata.
 - Accept HTTP bearer authentication schemes case-insensitively for admin API tokens.
 - Validate provider request paths and templates before reserving budget so malformed manifest requests fail without temporarily consuming quota.
 - Automatically bind GitHub organization and team assignment rules from Cloudflare Access's verified same-origin identity on first sign-in, including existing users whose prior reconciliation lacked GitHub evidence.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -77,6 +77,12 @@ try {
   assert.equal((await directManifestGet.json()).error.code, "provider_not_configured", "GET manifest routes parse path params without a JSON envelope");
   const grant = await fetch(`${base}/v1/admin/upstream-grants/policies/migrate/replicate`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "replicate", kind: "api_key", credential: "local-e2e-token" }) });
   assert.equal(grant.status, 200);
+  const bundledGrantUrl = `${base}/v1/admin/upstream-grants/policies/migrate/aws_bundle`;
+  const bundledGrant = await fetch(bundledGrantUrl, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "aws-bedrock", kind: "api_key", label: "original", credentials: { AWS_ACCESS_KEY_ID: "local", AWS_SECRET_ACCESS_KEY: "local", AWS_REGION: "us-east-1" } }) });
+  assert.equal(bundledGrant.status, 200);
+  const updatedBundledGrant = await fetch(bundledGrantUrl, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "aws-bedrock", kind: "api_key", label: "updated" }) });
+  assert.equal(updatedBundledGrant.status, 200, "upstream grant metadata updates preserve stored credential bundles");
+  assert.deepEqual((await updatedBundledGrant.json()).credentialFields, ["AWS_ACCESS_KEY_ID", "AWS_REGION", "AWS_SECRET_ACCESS_KEY"]);
   const missingPathParam = await fetch(`${base}/v1/proxy/replicate/prediction`, { headers: { authorization: `Bearer ${proxyKey}` } });
   assert.equal(missingPathParam.status, 400);
   assert.equal((await missingPathParam.json()).error.code, "missing_path_param");

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -334,7 +334,7 @@ function normalizeBinding(value: PolicyBinding): PolicyBinding {
   if (!principalId || !cleanId(value.policyId)) throw new HttpError(400, "invalid_policy_binding", "invalid policy binding"); return { ...value, principalId, enabled: value.enabled ?? true, priority: value.priority ?? 100 };
 }
 function normalizeGrant(value: UpstreamGrant, existing: UpstreamGrant | null): UpstreamGrant {
-  const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };
+  const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? existing?.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };
   if (!grant.provider) throw new HttpError(400, "invalid_upstream_grant", "provider is required"); if (!grant.credential && !grant.accessToken && !Object.keys(grant.credentials ?? {}).length) throw new HttpError(400, "invalid_upstream_grant", "grant credential is required"); return grant;
 }
 function revokeGrant(value: UpstreamGrant): UpstreamGrant { const { credential: _, credentials: __, accessToken: ___, refreshToken: ____, ...safe } = value; return { ...safe, enabled: false, credentials: {}, updatedAt: nowIso(), revokedAt: nowIso() }; }


### PR DESCRIPTION
## Summary

- preserve an existing multi-field upstream credential bundle when a metadata-only grant update omits `credentials`
- retain explicit replacement and clearing semantics when `credentials` is supplied
- exercise the affected admin PUT path with an AWS-style credential bundle

## Root cause

Grant normalization defaulted every omitted `credentials` field to an empty object. The console intentionally omits stored secret values, so editing the label or enabled state of a bundle-only grant erased its credentials and failed with `400 invalid_upstream_grant`.

## Proof

- before: initial bundled grant PUT returned 200; metadata-only PUT returned 400
- after: both PUTs return 200 and the response retains all three credential field names
- `pnpm worker:e2e`
- `pnpm worker:check`
- `pnpm check`
- `pnpm build`
- autoreview: no accepted or actionable findings; correctness 0.97

Production deployment and smoke proof will follow exact-head CI and merge.
