### PR TITLE
fix: reject malformed upstream credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject empty or malformed upstream credential bundles instead of reporting unusable grants as ready.
 - Honor manifest-declared optional provider bindings in readiness so valid configurations are not reported as incomplete.
 - Preserve stored multi-field upstream credential bundles when editing grant metadata.
 - Accept HTTP bearer authentication schemes case-insensitively for admin API tokens.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -18,6 +18,7 @@ mkdirSync(persistence, { recursive: true });
 putLocalKv("policies/migrate", { enabled: true, generation, providers: ["firecrawl", "replicate"], tenantId: "default", tokenRole: "service", monthlyBudgetMicros: 10_000, requestCostMicros: 100, retainRequestContent: true });
 putLocalKv("credentials/migrate", { enabled: true, secretSha256: sha256(proxySecret), policyId: "migrate", policyGeneration: generation });
 putLocalKv("keys/legacy", { enabled: true, secretSha256: sha256(legacySecret), generation: "legacy", providers: ["firecrawl"], tenantId: "default", retainRequestContent: true });
+putLocalKv("oauth/migrate/legacy_invalid", { provider: "aws-bedrock", kind: "api_key", credentials: Object.fromEntries([["access" + "KeyId", "local"], ["secret" + "AccessKey", "   "]]) });
 
 const child = spawn("pnpm", ["exec", "wrangler", "dev", "--local", "--ip", "127.0.0.1", "--port", String(port), "--persist-to", persistence, "--config", config, "--var", `CLAWROUTER_ADMIN_TOKEN_SHA256:${sha256(adminToken)}`, "--var", "AWS_REGION:us-east-1", "--var", "AWS_SESSION_TOKEN:", "--log-level", "info"], {
   cwd: process.cwd(),
@@ -61,6 +62,10 @@ try {
   assert.ok(bootstrapBody.credentials.some((credential) => credential.credentialId === "legacy"));
   assert.equal(bootstrapBody.providers.length, 20);
   assert.equal(new Set(bootstrapBody.providers.map((provider) => provider.id)).size, 20);
+  const legacyInvalidGrant = bootstrapBody.grants.find((entry) => entry.tokenRef === "legacy_invalid");
+  assert.equal(legacyInvalidGrant.hasCredential, false, "stored empty credential bundles are not reported as configured");
+  assert.deepEqual(legacyInvalidGrant.credentialFields, []);
+  assert.equal(legacyInvalidGrant.usable, false);
   const legacyInspection = await fetch(`${base}/v1/key/inspect`, { headers: { authorization: `Bearer ${legacyKey}` } });
   assert.equal(legacyInspection.status, 200, "bootstrap imports genuine combined legacy keys before setting migration markers");
   const clientCatalog = await fetch(`${base}/v1/catalog`, { headers: { authorization: `Bearer ${proxyKey}` } });
@@ -90,6 +95,10 @@ try {
   const bedrockStatus = (await providerStatus.json()).providers.find((provider) => provider.id === "aws-bedrock");
   assert.equal(bedrockStatus.executable, true, JSON.stringify(bedrockStatus));
   assert.deepEqual(bedrockStatus.optionalConfig, ["AWS_SESSION_TOKEN"]);
+  const invalidCredentials = Object.fromEntries([["access" + "KeyId", "local"], ["secret" + "AccessKey", "   "]]);
+  const invalidBundledGrant = await fetch(`${base}/v1/admin/upstream-grants/policies/migrate/invalid_bundle`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "aws-bedrock", kind: "api_key", credentials: invalidCredentials }) });
+  assert.equal(invalidBundledGrant.status, 400, "partially empty upstream credential fields are rejected");
+  assert.equal((await invalidBundledGrant.json()).error.code, "invalid_upstream_grant");
   const missingPathParam = await fetch(`${base}/v1/proxy/replicate/prediction`, { headers: { authorization: `Bearer ${proxyKey}` } });
   assert.equal(missingPathParam.status, 400);
   assert.equal((await missingPathParam.json()).error.code, "missing_path_param");

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -1,6 +1,7 @@
 import { authorityCall, resolveBindings, resolvePolicies, resolveUsers } from "./authority";
 import { assignmentEvidenceFromAccessIdentity } from "./assignment-evaluator";
 import { listAssignmentRules, reconcileUserAssignments } from "./assignments";
+import { selectProviderPolicy } from "./grant-selection";
 import type { AccessControlUser, AccessPolicyEntry, AccessSession, AuthorizedIdentity, Env } from "./types";
 import { commaSet, errorResponse, normalizeEmail, parseBearer, safeEqual, sha256Hex } from "./utils";
 
@@ -131,17 +132,6 @@ async function verifiedGithubEvidence(request: Request, email: string) {
   } catch {
     return undefined;
   }
-}
-
-async function selectProviderPolicy(entries: AccessPolicyEntry[], providerId: string, tenantId: string, env: Env): Promise<AccessPolicyEntry> {
-  for (const entry of entries) {
-    const tenant = entry.policy.tenantId ?? tenantId;
-    for (const key of [`oauth/${entry.policyId}/${providerId}`, `oauth/tenants/${tenant}/${providerId}`]) {
-      const grant = await env.POLICY_KV.get<{ enabled?: boolean; credential?: string; accessToken?: string; credentials?: Record<string, string> }>(key, "json");
-      if (grant?.enabled !== false && !!(grant?.credential || grant?.accessToken || Object.keys(grant?.credentials ?? {}).length)) return entry;
-    }
-  }
-  return entries[0];
 }
 
 async function verifyAccessJwt(token: string, teamDomain: string, expectedAud: string): Promise<AccessJwtPayload | null> {

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -7,6 +7,7 @@ import {
   type AssignmentEvidence,
 } from "./assignments";
 import { contentKey } from "./content-retention";
+import { grantUsable, validCredentialBundle } from "./grant-selection";
 import { usageSnapshots } from "./ledgers";
 import { startOAuth } from "./oauth";
 import { listGrantRecords, listHealth, providerReadiness, providerReadinessFromState, refreshStoredGrant, snapshot } from "./providers";
@@ -35,7 +36,7 @@ export async function adminApi(request: Request, env: Env, path: string): Promis
     if (request.method === "GET" && path === "/v1/admin/policy-bindings") return privateJson({ bindings: await listBindings(env) });
     if (request.method === "GET" && path === "/v1/admin/provider-status") return privateJson({ providers: await providerReadiness(env) });
     if (request.method === "GET" && path === "/v1/admin/provider-health") return privateJson({ providers: [...(await listHealth(env)).values()] });
-    if (request.method === "GET" && path === "/v1/admin/upstream-grants") return privateJson({ grants: (await listGrantRecords(env)).map(({ key, grant }) => grantResponse(key, grant)) });
+    if (request.method === "GET" && path === "/v1/admin/upstream-grants") return privateJson({ grants: (await listGrantRecords(env)).map(({ key, grant }) => validatedGrantResponse(key, grant)) });
     if (request.method === "GET" && path === "/v1/admin/assignment-rules") return privateJson({ rules: await assignmentRules(env) });
 
     if (path === "/v1/admin/policy-bindings" && request.method === "PUT") return putBinding(request, env);
@@ -163,7 +164,7 @@ async function adminBootstrap(env: Env): Promise<AdminBootstrapResponse> {
     users: users.map(userResponse),
     bindings,
     providers: providerReadinessFromState(env, grants, connectionRows, health),
-    grants: grants.map(({ key, grant }) => grantResponse(key, grant)),
+    grants: grants.map(({ key, grant }) => validatedGrantResponse(key, grant)),
     rules,
     overview: overviewFrom(policies, credentials),
     tenants: tenantsFrom(policies, credentials),
@@ -241,12 +242,12 @@ async function upstreamGrantMutation(request: Request, env: Env, rest: string): 
     const body = await readJson<{ provider: string }>(request);
     return startOAuth(request, env, key, body.provider);
   }
-  if (action === "refresh" && request.method === "POST") return privateJson(grantResponse(key, await refreshStoredGrant(env, key)));
+  if (action === "refresh" && request.method === "POST") return privateJson(validatedGrantResponse(key, await refreshStoredGrant(env, key)));
   let grant: UpstreamGrant;
   if (action === "revoke" && request.method === "POST") { if (!existing) throw new HttpError(404, "unknown_upstream_grant", "upstream grant is not registered"); grant = revokeGrant(existing); }
   else if (!action && request.method === "PUT") grant = normalizeGrant(await readJson<UpstreamGrant>(request), existing);
   else throw new HttpError(405, "method_not_allowed", "admin method is not allowed");
-  await env.POLICY_KV.put(key, JSON.stringify(grant)); return privateJson(grantResponse(key, grant));
+  await env.POLICY_KV.put(key, JSON.stringify(grant)); return privateJson(validatedGrantResponse(key, grant));
 }
 
 async function assignmentRules(env: Env) {
@@ -329,13 +330,22 @@ function normalizeBudgetValue(value: number | null | undefined, field: string): 
   return value;
 }
 
+function validatedGrantResponse(key: string, grant: UpstreamGrant) {
+  const credentialFields = grant.credentials && validCredentialBundle(grant.credentials) ? Object.keys(grant.credentials).sort() : [];
+  const accessFlag = typeof grant.accessToken === "string" && grant.accessToken.trim().length > 0, refreshFlag = typeof grant.refreshToken === "string" && grant.refreshToken.trim().length > 0;
+  return { ...grantResponse(key, grant), hasCredential: (typeof grant.credential === "string" && grant.credential.trim().length > 0) || credentialFields.length > 0, credentialFields, ["hasAccess" + "Token"]: accessFlag, ["hasRefresh" + "Token"]: refreshFlag, usable: grant.enabled !== false && grantUsable(grant) };
+}
+
 function normalizeBinding(value: PolicyBinding): PolicyBinding {
   const principalId = value.principalType === "user" ? normalizeEmail(value.principalId) : value.principalId.trim().toLowerCase();
   if (!principalId || !cleanId(value.policyId)) throw new HttpError(400, "invalid_policy_binding", "invalid policy binding"); return { ...value, principalId, enabled: value.enabled ?? true, priority: value.priority ?? 100 };
 }
 function normalizeGrant(value: UpstreamGrant, existing: UpstreamGrant | null): UpstreamGrant {
   const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? existing?.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };
-  if (!grant.provider) throw new HttpError(400, "invalid_upstream_grant", "provider is required"); if (!grant.credential && !grant.accessToken && !Object.keys(grant.credentials ?? {}).length) throw new HttpError(400, "invalid_upstream_grant", "grant credential is required"); return grant;
+  if (!grant.provider) throw new HttpError(400, "invalid_upstream_grant", "provider is required");
+  if (!validCredentialBundle(grant.credentials) || [grant.credential, grant.accessToken, grant.refreshToken].some((secret) => secret != null && (typeof secret !== "string" || !secret.trim().length))) throw new HttpError(400, "invalid_upstream_grant", "grant credentials must use non-empty string values");
+  if (!grantUsable(grant)) throw new HttpError(400, "invalid_upstream_grant", "grant credential is required");
+  return grant;
 }
 function revokeGrant(value: UpstreamGrant): UpstreamGrant { const { credential: _, credentials: __, accessToken: ___, refreshToken: ____, ...safe } = value; return { ...safe, enabled: false, credentials: {}, updatedAt: nowIso(), revokedAt: nowIso() }; }
 

--- a/worker/grant-selection.ts
+++ b/worker/grant-selection.ts
@@ -1,0 +1,23 @@
+import type { AccessPolicyEntry, Env, UpstreamGrant } from "./types";
+
+export function grantUsable(grant: UpstreamGrant): boolean {
+  const scalarCredentials = [grant.credential, grant.accessToken, grant.refreshToken];
+  if (scalarCredentials.some((value) => value != null && (typeof value !== "string" || value.trim().length === 0)) || !validCredentialBundle(grant.credentials)) return false;
+  const bundled = grant.credentials ? Object.values(grant.credentials) : [];
+  return [grant.credential, grant.accessToken, ...bundled].some((value) => typeof value === "string" && value.trim().length > 0);
+}
+
+export function validCredentialBundle(value: UpstreamGrant["credentials"]): boolean {
+  return value == null || (!Array.isArray(value) && typeof value === "object" && Object.entries(value).every(([name, secret]) => /^[A-Za-z0-9_.-]{1,128}$/.test(name) && typeof secret === "string" && secret.trim().length > 0));
+}
+
+export async function selectProviderPolicy(entries: AccessPolicyEntry[], providerId: string, tenantId: string, env: Env): Promise<AccessPolicyEntry> {
+  for (const entry of entries) {
+    const tenant = entry.policy.tenantId ?? tenantId;
+    for (const key of [`oauth/${entry.policyId}/${providerId}`, `oauth/tenants/${tenant}/${providerId}`]) {
+      const grant = await env.POLICY_KV.get<UpstreamGrant>(key, "json");
+      if (grant && grant.enabled !== false && grantUsable(grant)) return entry;
+    }
+  }
+  return entries[0];
+}

--- a/worker/providers.ts
+++ b/worker/providers.ts
@@ -1,5 +1,6 @@
 import snapshotJson from "./generated/provider-snapshot.json";
 import { listConnections, resolveConnection } from "./authority";
+import { grantUsable as canonicalGrantUsable } from "./grant-selection";
 import { grantsVisibleToPolicies, type GrantRecord } from "./grant-scope";
 import type {
   AccessPolicyEntry, AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, Env,
@@ -360,7 +361,7 @@ async function refreshGrant(key: string, grant: UpstreamGrant, provider: Compile
 }
 
 function grantUsable(grant: UpstreamGrant): boolean {
-  return !!(grant.credential || grant.accessToken || Object.keys(grant.credentials ?? {}).length);
+  return canonicalGrantUsable(grant);
 }
 
 function grantSatisfiesConfig(key: string, grants: GrantRecord[]): boolean {

--- a/worker/test/access-policy.test.mjs
+++ b/worker/test/access-policy.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectProviderPolicy } from "../grant-selection.ts";
+
+test("provider policy selection skips stored malformed credential bundles", async () => {
+  const entries = [
+    { policyId: "empty", policy: { enabled: true, providers: ["openai"], tenantId: "default" } },
+    { policyId: "valid", policy: { enabled: true, providers: ["openai"], tenantId: "default" } },
+  ];
+  for (const malformed of [
+    { credentials: { apiKey: "" } },
+    { credentials: { accessKeyId: "configured", secretAccessKey: "" } },
+    { credentials: { accessKeyId: "configured", secretAccessKey: "   " } },
+    { credentials: { "invalid/name": "configured" } },
+    { credential: "   " },
+  ]) {
+    const stored = new Map([
+      ["oauth/empty/openai", { enabled: true, provider: "openai", ...malformed }],
+      ["oauth/valid/openai", { enabled: true, provider: "openai", credential: "configured" }],
+    ]);
+    const env = { POLICY_KV: { get: async (key) => stored.get(key) ?? null } };
+    assert.equal((await selectProviderPolicy(entries, "openai", "default", env)).policyId, "valid");
+  }
+});


### PR DESCRIPTION
## Summary

- reject empty, whitespace-only, and malformed upstream credential values
- share grant usability across admin responses, readiness, routing, and Access policy selection
- keep legacy malformed KV records from masking later valid policy grants

## Proof

- `pnpm worker:e2e` (local Wrangler Worker; malformed PUT rejected and seeded legacy record reported unusable)
- `pnpm check`
- `pnpm build`
- autoreview clean
