### PR TITLE
fix: reject unknown upstream providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject upstream grants for providers absent from the compiled catalog.
 - Reject empty or malformed upstream credential bundles instead of reporting unusable grants as ready.
 - Honor manifest-declared optional provider bindings in readiness so valid configurations are not reported as incomplete.
 - Preserve stored multi-field upstream credential bundles when editing grant metadata.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -99,6 +99,9 @@ try {
   const invalidBundledGrant = await fetch(`${base}/v1/admin/upstream-grants/policies/migrate/invalid_bundle`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "aws-bedrock", kind: "api_key", credentials: invalidCredentials }) });
   assert.equal(invalidBundledGrant.status, 400, "partially empty upstream credential fields are rejected");
   assert.equal((await invalidBundledGrant.json()).error.code, "invalid_upstream_grant");
+  const unknownProviderGrant = await fetch(`${base}/v1/admin/upstream-grants/policies/migrate/unknown_provider`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ provider: "missing-provider", kind: "api_key", credential: "local" }) });
+  assert.equal(unknownProviderGrant.status, 400, "upstream grants require a catalog provider");
+  assert.equal((await unknownProviderGrant.json()).error.code, "unknown_provider");
   const missingPathParam = await fetch(`${base}/v1/proxy/replicate/prediction`, { headers: { authorization: `Bearer ${proxyKey}` } });
   assert.equal(missingPathParam.status, 400);
   assert.equal((await missingPathParam.json()).error.code, "missing_path_param");

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -343,6 +343,7 @@ function normalizeBinding(value: PolicyBinding): PolicyBinding {
 function normalizeGrant(value: UpstreamGrant, existing: UpstreamGrant | null): UpstreamGrant {
   const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? existing?.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };
   if (!grant.provider) throw new HttpError(400, "invalid_upstream_grant", "provider is required");
+  if (!snapshot.providers.some((provider) => provider.id === grant.provider)) throw new HttpError(400, "unknown_provider", "upstream grant provider is not registered");
   if (!validCredentialBundle(grant.credentials) || [grant.credential, grant.accessToken, grant.refreshToken].some((secret) => secret != null && (typeof secret !== "string" || !secret.trim().length))) throw new HttpError(400, "invalid_upstream_grant", "grant credentials must use non-empty string values");
   if (!grantUsable(grant)) throw new HttpError(400, "invalid_upstream_grant", "grant credential is required");
   return grant;


### PR DESCRIPTION
## Summary

- reject manual upstream grants for providers absent from the compiled catalog
- keep unusable orphan grants out of KV

## Proof

- local Wrangler Worker reproduced `200` before the fix and `400 unknown_provider` after
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- autoreview clean
