### PR TITLE
fix: validate assignment rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate assignment-rule kinds, collections, booleans, and priorities before persisting them.
 - Reject upstream grants for providers absent from the compiled catalog.
 - Reject empty or malformed upstream credential bundles instead of reporting unusable grants as ready.
 - Honor manifest-declared optional provider bindings in readiness so valid configurations are not reported as incomplete.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -123,6 +123,16 @@ try {
   assert.equal((await fetch(ruleUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify({ ...rule, enabled: false }) })).status, 200);
   const secondReconcile = await fetch(`${base}/v1/admin/assignment-rules/reconcile`, { method: "POST", headers: userHeaders, body: JSON.stringify({ email: "member@example.com" }) });
   assert.deepEqual((await secondReconcile.json()).results[0].groups, ["manual"]);
+  for (const [ruleId, body] of [
+    ["invalid_kind", { ...rule, kind: "unsupported" }],
+    ["invalid_groups", { ...rule, groups: "members" }],
+    ["invalid_priority", { ...rule, priority: -1 }],
+    ["invalid_enabled", { ...rule, enabled: "yes" }],
+  ]) {
+    const invalidRule = await fetch(`${base}/v1/admin/assignment-rules/${ruleId}`, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidRule.status, 400, `malformed assignment rule ${ruleId} is rejected`);
+    assert.equal((await invalidRule.json()).error.code, "invalid_assignment_rule");
+  }
   for (const invalidBudget of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
     const invalidPolicy = await fetch(`${base}/v1/admin/policies/invalid-budget`, { method: "PUT", headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" }, body: JSON.stringify({ providers: ["openai"], monthlyBudgetMicros: invalidBudget }) });
     assert.equal(invalidPolicy.status, 400);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -257,9 +257,8 @@ async function assignmentRules(env: Env) {
 async function putAssignmentRule(request: Request, env: Env, encodedId: string): Promise<Response> {
   const id = cleanId(decodeURIComponent(encodedId)); if (!id) throw new HttpError(400, "invalid_assignment_rule", "invalid assignment rule id");
   const key = `access/assignment-rules/${id}`;
-  const body = await readJson<Partial<AssignmentRule>>(request), existing = await env.POLICY_KV.get<AssignmentRule>(key, "json"), now = nowIso();
-  const rule: AssignmentRule = { version: 1, enabled: body.enabled ?? true, kind: body.kind ?? "exact_email", subject: String(body.subject ?? "").trim().toLowerCase(), groups: normalizeGroups(body.groups ?? []), policyIds: [...new Set(body.policyIds ?? [])], priority: body.priority ?? 100, revokeOnLoss: body.revokeOnLoss ?? true, provenance: body.provenance ?? "cloudflare_access", createdAt: existing?.createdAt ?? now, updatedAt: now };
-  if (!rule.subject) throw new HttpError(400, "invalid_assignment_rule", "assignment rule subject is required");
+  const body = await readJson<Record<string, unknown>>(request), existing = await env.POLICY_KV.get<AssignmentRule>(key, "json"), now = nowIso();
+  const rule = normalizeAssignmentRule(body, existing, now);
   const known = new Set((await listPolicies(env)).map((entry) => entry.policyId));
   if (rule.policyIds.some((policyId) => !known.has(policyId))) throw new HttpError(404, "unknown_policy", "one or more assignment policies do not exist");
   await env.POLICY_KV.put(key, JSON.stringify(rule));
@@ -267,6 +266,32 @@ async function putAssignmentRule(request: Request, env: Env, encodedId: string):
   const rules = await assignmentRules(env);
   for (const user of await listUsers(env)) await reconcileUserAssignments(user, rules, env);
   return privateJson(assignmentResponse(id, rule));
+}
+
+function normalizeAssignmentRule(body: Record<string, unknown>, existing: AssignmentRule | null, now: string): AssignmentRule {
+  const kinds: AssignmentRule["kind"][] = ["exact_email", "email_domain", "github_org", "github_team"];
+  const kind = body.kind === undefined ? "exact_email" : body.kind;
+  if (typeof kind !== "string" || !kinds.includes(kind as AssignmentRule["kind"])) throw new HttpError(400, "invalid_assignment_rule", "assignment rule kind is invalid");
+  if (typeof body.subject !== "string" || !body.subject.trim()) throw new HttpError(400, "invalid_assignment_rule", "assignment rule subject is required");
+  const groups = assignmentRuleStrings(body.groups, "groups"), policyIds = assignmentRuleStrings(body.policyIds, "policyIds");
+  const priority = body.priority === undefined ? 100 : body.priority;
+  if (!Number.isSafeInteger(priority) || (priority as number) < 0) throw new HttpError(400, "invalid_assignment_rule", "assignment rule priority must be a non-negative safe integer");
+  const enabled = assignmentRuleBoolean(body.enabled, "enabled", true), revokeOnLoss = assignmentRuleBoolean(body.revokeOnLoss, "revokeOnLoss", true);
+  const provenance = body.provenance === undefined ? "cloudflare_access" : body.provenance;
+  if (typeof provenance !== "string" || !provenance.trim()) throw new HttpError(400, "invalid_assignment_rule", "assignment rule provenance is required");
+  return { version: 1, enabled, kind: kind as AssignmentRule["kind"], subject: body.subject.trim().toLowerCase(), groups: normalizeGroups(groups), policyIds: [...new Set(policyIds)], priority: priority as number, revokeOnLoss, provenance: provenance.trim(), createdAt: existing?.createdAt ?? now, updatedAt: now };
+}
+
+function assignmentRuleStrings(value: unknown, field: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) throw new HttpError(400, "invalid_assignment_rule", `assignment rule ${field} must be an array of strings`);
+  return value as string[];
+}
+
+function assignmentRuleBoolean(value: unknown, field: string, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new HttpError(400, "invalid_assignment_rule", `assignment rule ${field} must be a boolean`);
+  return value;
 }
 
 async function syncAssignmentBindings(env: Env, id: string, existing: AssignmentRule | null, rule: AssignmentRule): Promise<void> {


### PR DESCRIPTION
## Summary

- validate assignment-rule runtime enums and field shapes before persistence
- return stable `400 invalid_assignment_rule` responses instead of storing invalid rules or throwing `500`

## Proof

- local Wrangler Worker reproduced an unknown kind returning `200` before the fix
- local Worker now rejects invalid kind, groups, priority, and boolean shapes
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- autoreview clean
