### PR TITLE
fix: validate policy shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate policy wildcard, provider, boolean, and metadata shapes before granting access.
 - Validate assignment-rule kinds, collections, booleans, and priorities before persisting them.
 - Reject upstream grants for providers absent from the compiled catalog.
 - Reject empty or malformed upstream credential bundles instead of reporting unusable grants as ready.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -138,6 +138,19 @@ try {
     assert.equal(invalidPolicy.status, 400);
     assert.equal((await invalidPolicy.json()).error.code, "invalid_policy");
   }
+  for (const [policyId, body] of [
+    ["invalid_wildcard", { providers: [], allProviders: "true" }],
+    ["invalid_null_wildcard", { providers: null, allProviders: true }],
+    ["invalid_mixed_scope", { providers: ["openai"], allProviders: true }],
+    ["invalid_enabled_policy", { providers: ["openai"], enabled: "false" }],
+    ["invalid_null_enabled", { providers: ["openai"], enabled: null }],
+    ["invalid_tenant", { providers: ["openai"], tenantId: {} }],
+    ["invalid_providers", { providers: {} }],
+  ]) {
+    const invalidPolicy = await fetch(`${base}/v1/admin/policies/${policyId}`, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidPolicy.status, 400, `malformed policy ${policyId} is rejected`);
+    assert.equal((await invalidPolicy.json()).error.code, "invalid_policy");
+  }
   console.log(`local Worker smoke passed on ${base}`);
 } catch (error) {
   throw new Error(`${error instanceof Error ? error.message : String(error)}\nwrangler output:\n${output}`);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -341,12 +341,29 @@ async function legacyKeyMutation(request: Request, env: Env, rest: string): Prom
 }
 
 function normalizePolicy(body: Partial<AccessPolicy> & { allProviders?: boolean }, existing?: AccessPolicy): AccessPolicy {
-  if (!body.providers && !body.allProviders) throw new HttpError(400, "invalid_policy", "providers or allProviders is required");
-  const providers = [...new Set(body.providers ?? [])].sort(); if (!providers.length && !body.allProviders) throw new HttpError(400, "invalid_policy", "empty provider scope requires allProviders");
+  if (body.providers !== undefined && (!Array.isArray(body.providers) || body.providers.some((id) => typeof id !== "string"))) throw new HttpError(400, "invalid_policy", "providers must be an array of strings");
+  if (body.allProviders !== undefined && typeof body.allProviders !== "boolean") throw new HttpError(400, "invalid_policy", "allProviders must be a boolean");
+  const allProviders = body.allProviders === true;
+  if (!body.providers && !allProviders) throw new HttpError(400, "invalid_policy", "providers or allProviders is required");
+  const providers = [...new Set(body.providers ?? [])].sort();
+  if (allProviders && providers.length) throw new HttpError(400, "invalid_policy", "allProviders requires an empty provider scope");
+  if (!providers.length && !allProviders) throw new HttpError(400, "invalid_policy", "empty provider scope requires allProviders");
   if (providers.some((id) => !snapshot.providers.some((provider) => provider.id === id))) throw new HttpError(400, "invalid_policy", "policy contains an unknown provider");
   const monthlyBudgetMicros = normalizeBudgetValue(body.monthlyBudgetMicros, "monthlyBudgetMicros");
   const requestCostMicros = normalizeBudgetValue(body.requestCostMicros, "requestCostMicros");
-  return { enabled: body.enabled ?? true, generation: existing?.generation ?? randomId("policy"), providers, tenantId: body.tenantId ?? "default", tokenRole: body.tokenRole ?? "service", monthlyBudgetMicros, requestCostMicros, retainRequestContent: body.retainRequestContent ?? true };
+  return { enabled: policyBoolean(body.enabled, "enabled", true), generation: existing?.generation ?? randomId("policy"), providers, tenantId: policyString(body.tenantId, "tenantId", "default"), tokenRole: policyString(body.tokenRole, "tokenRole", "service"), monthlyBudgetMicros, requestCostMicros, retainRequestContent: policyBoolean(body.retainRequestContent, "retainRequestContent", true) };
+}
+
+function policyBoolean(value: unknown, field: string, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new HttpError(400, "invalid_policy", `${field} must be a boolean`);
+  return value;
+}
+
+function policyString(value: unknown, field: string, fallback: string): string {
+  if (value == null) return fallback;
+  if (typeof value !== "string" || !value.trim()) throw new HttpError(400, "invalid_policy", `${field} must be a non-empty string`);
+  return value.trim();
 }
 
 function normalizeBudgetValue(value: number | null | undefined, field: string): number | null {


### PR DESCRIPTION
## Summary

- validate policy provider and wildcard shapes before normalization
- reject malformed boolean and string policy fields
- cover ambiguous, null, and erased-TypeScript payloads in local Worker smoke

## Proof

- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- autoreview clean (0.94 confidence)

