### PR TITLE
fix: validate policy bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and canonicalize policy-binding principals, flags, and priorities before persistence.
 - Validate policy wildcard, provider, boolean, and metadata shapes before granting access.
 - Validate assignment-rule kinds, collections, booleans, and priorities before persisting them.
 - Reject upstream grants for providers absent from the compiled catalog.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -151,6 +151,31 @@ try {
     assert.equal(invalidPolicy.status, 400, `malformed policy ${policyId} is rejected`);
     assert.equal((await invalidPolicy.json()).error.code, "invalid_policy");
   }
+  const normalizedBinding = await fetch(`${base}/v1/admin/policy-bindings`, { method: "PUT", headers: userHeaders, body: JSON.stringify({ policyId: " migrate ", principalType: "group", principalId: " Members ", priority: 10, ignored: true }) });
+  assert.equal(normalizedBinding.status, 200);
+  assert.deepEqual(await normalizedBinding.json(), { policyId: "migrate", principalType: "group", principalId: "members", enabled: true, priority: 10 });
+  for (const [bindingId, body] of [
+    ["invalid_null_body", null],
+    ["invalid_array_body", []],
+    ["invalid_principal_type", { policyId: "migrate", principalType: "service", principalId: "bot" }],
+    ["invalid_principal_id", { policyId: "migrate", principalType: "group", principalId: {} }],
+    ["invalid_user_email", { policyId: "migrate", principalType: "user", principalId: "not-an-email" }],
+    ["invalid_empty_group", { policyId: "migrate", principalType: "group", principalId: "   " }],
+    ["invalid_policy_id", { policyId: {}, principalType: "group", principalId: "members" }],
+    ["invalid_enabled", { policyId: "migrate", principalType: "group", principalId: "members", enabled: "false" }],
+    ["invalid_null_enabled", { policyId: "migrate", principalType: "group", principalId: "members", enabled: null }],
+    ["invalid_priority", { policyId: "migrate", principalType: "group", principalId: "members", priority: -1 }],
+    ["invalid_fractional_priority", { policyId: "migrate", principalType: "group", principalId: "members", priority: 1.5 }],
+    ["invalid_string_priority", { policyId: "migrate", principalType: "group", principalId: "members", priority: "10" }],
+  ]) {
+    const invalidBinding = await fetch(`${base}/v1/admin/policy-bindings`, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidBinding.status, 400, `malformed policy binding ${bindingId} is rejected`);
+    assert.equal((await invalidBinding.json()).error.code, "invalid_policy_binding");
+  }
+  const bindingsAfterInvalid = await fetch(`${base}/v1/admin/policy-bindings`, { headers: userHeaders });
+  assert.equal(bindingsAfterInvalid.status, 200);
+  const retainedBinding = (await bindingsAfterInvalid.json()).bindings.find((binding) => binding.principalType === "group" && binding.principalId === "members" && binding.policyId === "migrate");
+  assert.deepEqual(retainedBinding, { policyId: "migrate", principalType: "group", principalId: "members", enabled: true, priority: 10 }, "rejected binding payloads do not overwrite the stored canonical binding");
   console.log(`local Worker smoke passed on ${base}`);
 } catch (error) {
   throw new Error(`${error instanceof Error ? error.message : String(error)}\nwrangler output:\n${output}`);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -378,9 +378,22 @@ function validatedGrantResponse(key: string, grant: UpstreamGrant) {
   return { ...grantResponse(key, grant), hasCredential: (typeof grant.credential === "string" && grant.credential.trim().length > 0) || credentialFields.length > 0, credentialFields, ["hasAccess" + "Token"]: accessFlag, ["hasRefresh" + "Token"]: refreshFlag, usable: grant.enabled !== false && grantUsable(grant) };
 }
 
-function normalizeBinding(value: PolicyBinding): PolicyBinding {
-  const principalId = value.principalType === "user" ? normalizeEmail(value.principalId) : value.principalId.trim().toLowerCase();
-  if (!principalId || !cleanId(value.policyId)) throw new HttpError(400, "invalid_policy_binding", "invalid policy binding"); return { ...value, principalId, enabled: value.enabled ?? true, priority: value.priority ?? 100 };
+function normalizeBinding(value: unknown): PolicyBinding {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new HttpError(400, "invalid_policy_binding", "policy binding must be an object");
+  const binding = value as Partial<PolicyBinding>;
+  const principalType = binding.principalType;
+  if (principalType !== "user" && principalType !== "group") throw new HttpError(400, "invalid_policy_binding", "principalType must be user or group");
+  if (typeof binding.principalId !== "string") throw new HttpError(400, "invalid_policy_binding", "principalId must be a string");
+  const principalId = principalType === "user" ? normalizeEmail(binding.principalId) : binding.principalId.trim().toLowerCase();
+  if (!principalId) throw new HttpError(400, "invalid_policy_binding", "principalId is invalid");
+  if (typeof binding.policyId !== "string") throw new HttpError(400, "invalid_policy_binding", "policyId must be a string");
+  const policyId = cleanId(binding.policyId);
+  if (!policyId) throw new HttpError(400, "invalid_policy_binding", "policyId is invalid");
+  const enabled = binding.enabled === undefined ? true : binding.enabled;
+  if (typeof enabled !== "boolean") throw new HttpError(400, "invalid_policy_binding", "enabled must be a boolean");
+  const priority = binding.priority === undefined ? 100 : binding.priority;
+  if (!Number.isSafeInteger(priority) || (priority as number) < 0) throw new HttpError(400, "invalid_policy_binding", "priority must be a non-negative safe integer");
+  return { policyId, principalType, principalId, enabled, priority: priority as number };
 }
 function normalizeGrant(value: UpstreamGrant, existing: UpstreamGrant | null): UpstreamGrant {
   const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? existing?.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };


### PR DESCRIPTION
## Summary

- validate policy-binding roots and persisted fields at the admin boundary
- canonicalize identifiers and strip unknown input properties
- reject malformed values before authority mutation and preserve stored bindings

## Proof

- local before: unsupported principal type returned `500`
- local after: behavior contract B1-B4 passed, including read-after-reject persistence
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- autoreview clean (0.96 confidence)

