### PR TITLE
fix: validate access user mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and canonicalize access-user identity and policy-grant payloads before persistence.
 - Validate and canonicalize policy-binding principals, flags, and priorities before persistence.
 - Validate policy wildcard, provider, boolean, and metadata shapes before granting access.
 - Validate assignment-rule kinds, collections, booleans, and priorities before persisting them.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -176,6 +176,38 @@ try {
   assert.equal(bindingsAfterInvalid.status, 200);
   const retainedBinding = (await bindingsAfterInvalid.json()).bindings.find((binding) => binding.principalType === "group" && binding.principalId === "members" && binding.policyId === "migrate");
   assert.deepEqual(retainedBinding, { policyId: "migrate", principalType: "group", principalId: "members", enabled: true, priority: 10 }, "rejected binding payloads do not overwrite the stored canonical binding");
+  const invalidUserUrl = `${base}/v1/admin/access-users/invalid-shape%40example.com`;
+  const invalidGrantUrl = `${base}/v1/admin/access-user-grants/invalid-shape%40example.com`;
+  for (const [userMutationId, url, body] of [
+    ["invalid_null_body", invalidUserUrl, null],
+    ["invalid_array_body", invalidUserUrl, []],
+    ["invalid_enabled", invalidUserUrl, { enabled: "false" }],
+    ["invalid_tenant", invalidUserUrl, { tenantId: {} }],
+    ["invalid_groups", invalidUserUrl, { groups: "members" }],
+    ["invalid_null_groups", invalidUserUrl, { groups: null }],
+    ["invalid_group_entry", invalidUserUrl, { groups: [{}] }],
+    ["invalid_retention", invalidUserUrl, { contentRetentionDisabled: "false" }],
+    ["invalid_null_retention", invalidUserUrl, { contentRetentionDisabled: null }],
+    ["invalid_grant_null_body", invalidGrantUrl, null],
+    ["invalid_policy_ids", invalidGrantUrl, { policyIds: "migrate" }],
+    ["invalid_policy_ids_object", invalidGrantUrl, { policyIds: {} }],
+    ["invalid_policy_id_entry", invalidGrantUrl, { policyIds: [{}] }],
+    ["invalid_null_policy_ids", invalidGrantUrl, { policyIds: null }],
+  ]) {
+    const invalidUserMutation = await fetch(url, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidUserMutation.status, 400, `malformed access-user mutation ${userMutationId} is rejected`);
+    assert.equal((await invalidUserMutation.json()).error.code, "invalid_access_user");
+  }
+  const canonicalUserUrl = `${base}/v1/admin/access-users/shape%40example.com`;
+  const canonicalUser = await fetch(canonicalUserUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify({ tenantId: " Team ", enabled: false, groups: [" Members ", "members"], contentRetentionDisabled: true, role: "admin", assignmentState: { injected: true }, ignored: true }) });
+  assert.equal(canonicalUser.status, 200);
+  assert.deepEqual(await canonicalUser.json(), { email: "shape@example.com", role: "user", tenantId: "Team", enabled: false, groups: ["members"], contentRetentionDisabled: true });
+  const canonicalGrantUrl = `${base}/v1/admin/access-user-grants/shape%40example.com`;
+  const canonicalGrant = await fetch(canonicalGrantUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify({ enabled: true, policyIds: ["migrate", "migrate"] }) });
+  assert.equal(canonicalGrant.status, 200);
+  const canonicalGrantBody = await canonicalGrant.json();
+  assert.deepEqual(canonicalGrantBody.user, { email: "shape@example.com", role: "user", tenantId: "Team", enabled: true, groups: ["members"], contentRetentionDisabled: true }, "grant updates preserve omitted identity fields");
+  assert.deepEqual(canonicalGrantBody.bindings.filter((binding) => binding.enabled).map((binding) => binding.policyId), ["migrate"]);
   console.log(`local Worker smoke passed on ${base}`);
 } catch (error) {
   throw new Error(`${error instanceof Error ? error.message : String(error)}\nwrangler output:\n${output}`);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -182,19 +182,18 @@ async function putBinding(request: Request, env: Env): Promise<Response> {
 
 async function putUser(request: Request, env: Env, encodedEmail: string): Promise<Response> {
   const email = normalizeEmail(decodeURIComponent(encodedEmail)); if (!email) throw new HttpError(400, "invalid_access_user", "invalid access user email");
-  const patch = await readJson<AccessControlUser["record"]>(request), existing = (await listUsers(env)).find((item) => item.email === email)?.record ?? {};
-  const user: AccessControlUser = { email, record: { ...existing, ...patch, role: "user", groups: normalizeGroups(patch.groups ?? existing.groups ?? []) } };
+  const existing = (await listUsers(env)).find((item) => item.email === email)?.record ?? {};
+  const user: AccessControlUser = { email, record: normalizeUserMutation(await readJson<unknown>(request), existing).record };
   await authorityCall(env, "/users/put", user);
   return privateJson(userResponse(user));
 }
 
 async function putUserGrants(request: Request, env: Env, encodedEmail: string): Promise<Response> {
   const email = normalizeEmail(decodeURIComponent(encodedEmail)); if (!email) throw new HttpError(400, "invalid_access_user", "invalid access user email");
-  const body = await readJson<AccessControlUser["record"] & { policyIds?: string[] }>(request);
-  const ids = [...new Set(body.policyIds ?? [])];
-  const known = new Set((await listPolicies(env)).map((entry) => entry.policyId)); if (ids.some((id) => !known.has(id))) throw new HttpError(404, "unknown_policy", "one or more policies do not exist");
   const existing = (await listUsers(env)).find((item) => item.email === email)?.record ?? {};
-  const user: AccessControlUser = { email, record: { ...existing, ...body, role: "user", groups: normalizeGroups(body.groups ?? existing.groups ?? []) } };
+  const { record, policyIds: ids } = normalizeUserMutation(await readJson<unknown>(request), existing, true);
+  const known = new Set((await listPolicies(env)).map((entry) => entry.policyId)); if (ids.some((id) => !known.has(id))) throw new HttpError(404, "unknown_policy", "one or more policies do not exist");
+  const user: AccessControlUser = { email, record };
   const principal = { principalType: "user" as const, principalId: email }, bindings = (await listBindings(env)).filter((item) => item.principalType === "user" && item.principalId === email);
   const result = await authorityCall<{ bindings: PolicyBinding[] }>(env, "/users/put-bindings", { user, policyIds: ids, seed: { principal, bindings } });
   return privateJson({ user: userResponse(user), bindings: result.bindings });
@@ -394,6 +393,43 @@ function normalizeBinding(value: unknown): PolicyBinding {
   const priority = binding.priority === undefined ? 100 : binding.priority;
   if (!Number.isSafeInteger(priority) || (priority as number) < 0) throw new HttpError(400, "invalid_policy_binding", "priority must be a non-negative safe integer");
   return { policyId, principalType, principalId, enabled, priority: priority as number };
+}
+
+function normalizeUserMutation(value: unknown, existing: AccessControlUser["record"], includePolicyIds = false): { record: AccessControlUser["record"]; policyIds: string[] } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new HttpError(400, "invalid_access_user", "access user must be an object");
+  const body = value as Record<string, unknown>;
+  const tenantId = userTenant(body.tenantId, existing.tenantId);
+  const enabled = userBoolean(body.enabled, "enabled", existing.enabled ?? true, true);
+  const groups = body.groups === undefined ? normalizeGroups(existing.groups ?? []) : userGroups(body.groups);
+  const contentRetentionDisabled = userBoolean(body.contentRetentionDisabled, "contentRetentionDisabled", existing.contentRetentionDisabled ?? false);
+  const record: AccessControlUser["record"] = { role: "user", tenantId, enabled, groups, contentRetentionDisabled };
+  if (existing.assignmentState) record.assignmentState = existing.assignmentState;
+  let policyIds: string[] = [];
+  if (includePolicyIds) {
+    const requestedPolicyIds = body.policyIds === undefined ? [] : body.policyIds;
+    if (!Array.isArray(requestedPolicyIds) || requestedPolicyIds.some((id) => typeof id !== "string" || !cleanId(id))) throw new HttpError(400, "invalid_access_user", "policyIds must be an array of policy ids");
+    policyIds = [...new Set(requestedPolicyIds.map((id) => cleanId(id as string)!))];
+  }
+  return { record, policyIds };
+}
+
+function userTenant(value: unknown, existing: string | null | undefined): string {
+  if (value === undefined) return existing ?? "default";
+  if (value === null) return "default";
+  if (typeof value !== "string" || !value.trim()) throw new HttpError(400, "invalid_access_user", "tenantId must be a non-empty string or null");
+  return value.trim();
+}
+
+function userBoolean(value: unknown, field: string, fallback: boolean, allowNull = false): boolean {
+  if (value === undefined) return fallback;
+  if (value === null && allowNull) return true;
+  if (typeof value !== "boolean") throw new HttpError(400, "invalid_access_user", `${field} must be a boolean${allowNull ? " or null" : ""}`);
+  return value;
+}
+
+function userGroups(value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((group) => typeof group !== "string")) throw new HttpError(400, "invalid_access_user", "groups must be an array of strings");
+  return normalizeGroups(value as string[]);
 }
 function normalizeGrant(value: UpstreamGrant, existing: UpstreamGrant | null): UpstreamGrant {
   const now = nowIso(), grant = { ...existing, ...value, version: 1, enabled: value.enabled ?? true, kind: value.kind ?? "oauth", tokenType: value.tokenType ?? "Bearer", scopes: value.scopes ?? [], credentials: value.credentials ?? existing?.credentials ?? {}, createdAt: existing?.createdAt ?? now, updatedAt: now, revokedAt: null };


### PR DESCRIPTION
## Summary

- validate and canonicalize access-user mutations before authority writes
- whitelist user-editable identity fields while preserving assignment-owned state
- validate and deduplicate direct-policy replacements without dropping omitted identity fields

## Proof

- local before: JSON `null` returned `500`; malformed runtime types crossed the admin boundary
- local after: behavior contract U1-U4 passed, including malformed-shape probes and identity preservation
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- autoreview clean (0.94 confidence)

