### PR TITLE
fix: validate provider connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and canonicalize provider-connection flags and labels before persistence.
 - Validate and canonicalize access-user identity and policy-grant payloads before persistence.
 - Validate and canonicalize policy-binding principals, flags, and priorities before persistence.
 - Validate policy wildcard, provider, boolean, and metadata shapes before granting access.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -208,6 +208,25 @@ try {
   const canonicalGrantBody = await canonicalGrant.json();
   assert.deepEqual(canonicalGrantBody.user, { email: "shape@example.com", role: "user", tenantId: "Team", enabled: true, groups: ["members"], contentRetentionDisabled: true }, "grant updates preserve omitted identity fields");
   assert.deepEqual(canonicalGrantBody.bindings.filter((binding) => binding.enabled).map((binding) => binding.policyId), ["migrate"]);
+  const connectionUrl = `${base}/v1/admin/connections/openai`;
+  for (const [connectionMutationId, body] of [
+    ["invalid_null_body", null],
+    ["invalid_array_body", []],
+    ["invalid_enabled", { enabled: "false" }],
+    ["invalid_null_enabled", { enabled: null }],
+    ["invalid_label", { label: {} }],
+    ["invalid_array_label", { label: [] }],
+  ]) {
+    const invalidConnection = await fetch(connectionUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidConnection.status, 400, `malformed provider connection ${connectionMutationId} is rejected`);
+    assert.equal((await invalidConnection.json()).error.code, "invalid_provider_connection");
+  }
+  const canonicalConnection = await fetch(connectionUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify({ providerId: "missing", enabled: false, label: " Ops ", ignored: true }) });
+  assert.equal(canonicalConnection.status, 200);
+  assert.deepEqual(await canonicalConnection.json(), { providerId: "openai", enabled: false, label: "Ops" });
+  const connectionsAfterMutation = await fetch(`${base}/v1/admin/connections`, { headers: userHeaders });
+  assert.equal(connectionsAfterMutation.status, 200);
+  assert.deepEqual((await connectionsAfterMutation.json()).connections.find((connection) => connection.providerId === "openai"), { providerId: "openai", enabled: false, label: "Ops" });
   console.log(`local Worker smoke passed on ${base}`);
 } catch (error) {
   throw new Error(`${error instanceof Error ? error.message : String(error)}\nwrangler output:\n${output}`);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -228,7 +228,7 @@ async function credentialMutation(request: Request, env: Env, rest: string): Pro
 
 async function putConnection(request: Request, env: Env, encodedId: string): Promise<Response> {
   const id = decodeURIComponent(encodedId), provider = snapshot.providers.find((item) => item.id === id); if (!provider) throw new HttpError(404, "unknown_provider", "provider does not exist");
-  const body = await readJson<Partial<ProviderConnection>>(request), connection: ProviderConnection = { providerId: id, enabled: body.enabled ?? true, label: body.label ?? null };
+  const connection = normalizeConnection(await readJson<unknown>(request), id);
   await authorityCall(env, "/connections/put", connection); return privateJson(connection);
 }
 
@@ -393,6 +393,16 @@ function normalizeBinding(value: unknown): PolicyBinding {
   const priority = binding.priority === undefined ? 100 : binding.priority;
   if (!Number.isSafeInteger(priority) || (priority as number) < 0) throw new HttpError(400, "invalid_policy_binding", "priority must be a non-negative safe integer");
   return { policyId, principalType, principalId, enabled, priority: priority as number };
+}
+
+function normalizeConnection(value: unknown, providerId: string): ProviderConnection {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new HttpError(400, "invalid_provider_connection", "provider connection must be an object");
+  const body = value as Record<string, unknown>;
+  const enabled = body.enabled === undefined ? true : body.enabled;
+  if (typeof enabled !== "boolean") throw new HttpError(400, "invalid_provider_connection", "enabled must be a boolean");
+  if (body.label !== undefined && body.label !== null && typeof body.label !== "string") throw new HttpError(400, "invalid_provider_connection", "label must be a string or null");
+  const label = typeof body.label === "string" ? body.label.trim() || null : null;
+  return { providerId, enabled, label };
 }
 
 function normalizeUserMutation(value: unknown, existing: AccessControlUser["record"], includePolicyIds = false): { record: AccessControlUser["record"]; policyIds: string[] } {


### PR DESCRIPTION
## Summary

- validate provider-connection request roots, flags, and labels
- derive provider identity from the validated route and persist only canonical fields
- cover malformed payloads and read-after-write state in local Worker smoke

## Proof

- local before: JSON `null` returned `500`
- local after: behavior contract C1-C4 passed
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- autoreview clean (0.98 confidence)

