### PR TITLE
fix: validate proxy credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and canonicalize proxy-credential policy, digest, state, and owner fields before activation.
 - Validate and canonicalize provider-connection flags and labels before persistence.
 - Validate and canonicalize access-user identity and policy-grant payloads before persistence.
 - Validate and canonicalize policy-binding principals, flags, and priorities before persistence.

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -227,6 +227,28 @@ try {
   const connectionsAfterMutation = await fetch(`${base}/v1/admin/connections`, { headers: userHeaders });
   assert.equal(connectionsAfterMutation.status, 200);
   assert.deepEqual((await connectionsAfterMutation.json()).connections.find((connection) => connection.providerId === "openai"), { providerId: "openai", enabled: false, label: "Ops" });
+  const invalidCredentialUrl = `${base}/v1/admin/credentials/invalid_shape`;
+  const credentialDigest = sha256("credential-shape");
+  for (const [credentialMutationId, body] of [
+    ["invalid_null_body", null],
+    ["invalid_array_body", []],
+    ["invalid_policy_id", { policyId: {}, secretSha256: credentialDigest }],
+    ["invalid_enabled", { policyId: "migrate", secretSha256: credentialDigest, enabled: "false" }],
+    ["invalid_null_enabled", { policyId: "migrate", secretSha256: credentialDigest, enabled: null }],
+    ["invalid_digest", { policyId: "migrate", secretSha256: "not-a-digest" }],
+    ["invalid_principal", { policyId: "migrate", secretSha256: credentialDigest, principalId: {} }],
+    ["invalid_principal_email", { policyId: "migrate", secretSha256: credentialDigest, principalId: "not-an-email" }],
+  ]) {
+    const invalidCredential = await fetch(invalidCredentialUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify(body) });
+    assert.equal(invalidCredential.status, 400, `malformed proxy credential ${credentialMutationId} is rejected`);
+    assert.equal((await invalidCredential.json()).error.code, "invalid_credential");
+  }
+  const canonicalCredential = await fetch(`${base}/v1/admin/credentials/shape_credential`, { method: "PUT", headers: userHeaders, body: JSON.stringify({ policyId: " migrate ", secretSha256: credentialDigest.toUpperCase(), enabled: false, principalId: " Owner@Example.com ", policyGeneration: "injected", ignored: true }) });
+  assert.equal(canonicalCredential.status, 200);
+  assert.deepEqual(await canonicalCredential.json(), { credentialId: "shape_credential", policyId: "migrate", enabled: false, policyEnabled: true, generationMatches: true, active: false, principalId: "owner@example.com" });
+  const credentialsAfterMutation = await fetch(`${base}/v1/admin/credentials`, { headers: userHeaders });
+  assert.equal(credentialsAfterMutation.status, 200);
+  assert.deepEqual((await credentialsAfterMutation.json()).credentials.find((credential) => credential.credentialId === "shape_credential"), { credentialId: "shape_credential", policyId: "migrate", enabled: false, policyEnabled: true, generationMatches: true, active: false, principalId: "owner@example.com" });
   console.log(`local Worker smoke passed on ${base}`);
 } catch (error) {
   throw new Error(`${error instanceof Error ? error.message : String(error)}\nwrangler output:\n${output}`);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -217,10 +217,9 @@ async function credentialMutation(request: Request, env: Env, rest: string): Pro
   let credential: ProxyCredential;
   if (revoke && request.method === "POST") { if (!existing) throw new HttpError(404, "unknown_credential", "credential not found"); credential = { ...existing, enabled: false }; }
   else if (request.method === "PUT") {
-    const body = await readJson<Partial<ProxyCredential>>(request); const policy = (await listPolicies(env)).find((entry) => entry.policyId === body.policyId);
+    const body = normalizeCredential(await readJson<unknown>(request)); const policy = (await listPolicies(env)).find((entry) => entry.policyId === body.policyId);
     if (!policy) throw new HttpError(404, "unknown_policy", "credential policy does not exist");
-    if (!body.secretSha256 || !/^[0-9a-f]{64}$/i.test(body.secretSha256)) throw new HttpError(400, "invalid_credential", "secretSha256 must be a SHA-256 hex digest");
-    credential = { enabled: body.enabled ?? true, secretSha256: body.secretSha256.toLowerCase(), policyId: policy.policyId, policyGeneration: policy.policy.generation, principalId: body.principalId ?? null };
+    credential = { ...body, policyId: policy.policyId, policyGeneration: policy.policy.generation };
   } else throw new HttpError(405, "method_not_allowed", "admin method is not allowed");
   const entry: ProxyCredentialEntry = { credentialId: id, credential }; await authorityCall(env, "/credentials/put", entry);
   return privateJson((await credentialResponses(env)).find((item) => item.credentialId === id));
@@ -403,6 +402,27 @@ function normalizeConnection(value: unknown, providerId: string): ProviderConnec
   if (body.label !== undefined && body.label !== null && typeof body.label !== "string") throw new HttpError(400, "invalid_provider_connection", "label must be a string or null");
   const label = typeof body.label === "string" ? body.label.trim() || null : null;
   return { providerId, enabled, label };
+}
+
+function normalizeCredential(value: unknown): Omit<ProxyCredential, "policyGeneration"> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new HttpError(400, "invalid_credential", "credential must be an object");
+  const body = value as Record<string, unknown>;
+  if (typeof body.policyId !== "string") throw new HttpError(400, "invalid_credential", "policyId must be a string");
+  const policyId = cleanId(body.policyId);
+  if (!policyId) throw new HttpError(400, "invalid_credential", "policyId is invalid");
+  if (typeof body.secretSha256 !== "string" || !/^[0-9a-f]{64}$/i.test(body.secretSha256)) throw new HttpError(400, "invalid_credential", "secretSha256 must be a SHA-256 hex digest");
+  const enabled = body.enabled === undefined ? true : body.enabled;
+  if (typeof enabled !== "boolean") throw new HttpError(400, "invalid_credential", "enabled must be a boolean");
+  let principalId: string | null = null;
+  if (body.principalId !== undefined && body.principalId !== null) {
+    if (typeof body.principalId !== "string") throw new HttpError(400, "invalid_credential", "principalId must be an email or null");
+    const candidate = body.principalId.trim();
+    if (candidate) {
+      principalId = normalizeEmail(candidate);
+      if (!principalId) throw new HttpError(400, "invalid_credential", "principalId must be a valid email");
+    }
+  }
+  return { enabled, secretSha256: body.secretSha256.toLowerCase(), policyId, principalId };
 }
 
 function normalizeUserMutation(value: unknown, existing: AccessControlUser["record"], includePolicyIds = false): { record: AccessControlUser["record"]; policyIds: string[] } {


### PR DESCRIPTION
## Summary

- validate credential roots, policies, digests, flags, and owner emails before activation
- derive policy generation server-side and strip client-controlled metadata
- cover malformed requests, canonical response state, and secret-free readback

## Proof

- local before: JSON `null` returned `500`; malformed flags/owner metadata crossed runtime unchecked
- local after: behavior contract K1-K4 passed
- `pnpm worker:e2e`
- `pnpm check`
- `pnpm build`
- `git diff --check`
- autoreview clean (0.94 confidence)

