### PR TITLE
feat: add canonical request correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add canonical request, W3C trace, and session correlation across OpenAI-compatible responses, CORS, metadata-only usage/status events, bounded error logs, and session-stable grant selection.
 - Wire FakeCo Access service-token identifiers into the staging deploy so Crabhelm automation receives the intended non-identity policy.
 - Make FakeCo first deploys fail closed with read-only pre-Access and provider-binding validation, exact preview-KV checks, stdin-only admin/provider/smoke-key bootstrap, authenticated service-token proof, and bounded custom-domain/admin readiness.
 - Add a confirmation-gated FakeCo teardown that deletes only the locked Access app, Worker and associated Durable Object storage, and queues while retaining KV, R2, service-token, GitHub Environment, and zone state.

--- a/README.md
+++ b/README.md
@@ -260,10 +260,12 @@ The Worker resolves `provider` and `endpoint` from the compiled provider
 snapshot, applies manifest path/query/header/auth mapping, forwards the request,
 and emits a usage event to `USAGE_QUEUE`. The same Worker consumes that queue
 into tenant/policy-sharded, bounded `USAGE_LEDGER` reporting Durable Objects and
-replays unsettled budget updates. Audit events retain
-identity, policy, credential, provider, route capability, model, timing,
-outcome, tokens when safely available, and cost for 30 days. Prompt and
-completion bodies are never stored in the usage ledger. LLM request bodies are stored separately for
+replays unsettled budget updates. Audit events retain identity, policy,
+credential, provider, route capability, model, timing, outcome, tokens when
+safely available, cost, the canonical request ID, and validated W3C trace/span
+IDs for 30 days. Every owned response echoes the canonical `X-Request-ID`, and
+CORS exposes it to browser clients. Prompt and completion bodies are never
+stored in the usage ledger. LLM request bodies are stored separately for
 30 days when the access policy enables request-content retention (the default)
 and the credential owner is not exempt; see [Content retention](docs/content-retention.md).
 `/v1/usage` returns the caller policy's

--- a/docs/agent-spend-control.md
+++ b/docs/agent-spend-control.md
@@ -161,7 +161,19 @@ model list.
 
 ## Shared attribution headers
 
-Clients and gateway adapters may send:
+Each model call may send `X-Request-ID`. ClawRouter trims and accepts a caller
+value only when it is a safe ASCII identifier no longer than 128 characters;
+otherwise it rejects the value and returns a generated safe ID with the owned
+error response. Missing IDs are generated. Every owned success or error echoes
+the canonical value, and CORS allows and exposes the header. Error logs include
+that bounded ID as their only request-specific metadata.
+
+A valid W3C `traceparent` contributes only its `trace_id` and parent `span_id`
+to usage/status metadata. Invalid, all-zero, uppercase, or oversized contexts
+are ignored. Request IDs and trace IDs remain event fields and are never metric
+labels.
+
+Clients and gateway adapters may separately send:
 
 - `X-ClawRouter-Session-Id`
 - `X-ClawRouter-Agent-Id`
@@ -170,10 +182,18 @@ Clients and gateway adapters may send:
 - `X-ClawRouter-Client`
 
 Explicit ClawRouter identifiers take precedence over client-native identifiers.
+For session attribution, `X-ClawRouter-Session-Id` wins, followed by the
+documented Claude Code `X-Claude-Code-Session-Id` and Codex `session-id`
+fallbacks. The selected value is normalized once and also drives policy session
+stickiness; request IDs never substitute for sessions. Selected attribution
+values must be safe ASCII identifiers no longer than 256 characters or the
+request is rejected before provider routing.
+
 Recent audit events include the resolved session, agent hierarchy, project,
-pricing version, reservation bounds, actual tokens, and settled cost. Prompts
-and completions are never stored by the spend-control path. Optional request-content
-retention is a separate policy-controlled R2 archive; see [Content retention](content-retention.md).
+request/trace lineage, pricing version, reservation bounds, actual tokens, and
+settled cost. Prompts, completions, tool bodies, credentials, and error payloads
+are never stored by the spend-control path. Optional request-content retention
+is a separate policy-controlled R2 archive; see [Content retention](content-retention.md).
 
 ## Current boundary
 

--- a/docs/fakeco.md
+++ b/docs/fakeco.md
@@ -232,6 +232,7 @@ Send bounded attribution on inference requests when available:
 
 ```text
 x-request-id
+traceparent
 x-clawrouter-session-id
 x-clawrouter-agent-id
 x-clawrouter-parent-agent-id
@@ -239,9 +240,13 @@ x-clawrouter-project-id
 x-clawrouter-client
 ```
 
-ClawRouter records those values with provider, model, capability, timing,
-status, token counts, and cost. It does not copy request or response bodies into
-usage events. FakeCo also defaults new policies and migrated records without an
+`x-request-id` is the per-model-call correlation ID; it remains separate from
+Client, Agent, Session, and Project attribution. ClawRouter echoes its canonical
+value on every owned response and records it with validated W3C trace/span IDs,
+provider, model, capability, timing, status, token counts, and cost. Explicit
+ClawRouter attribution headers retain precedence over documented client-native
+fallbacks. It does not copy request or response bodies into usage events.
+FakeCo also defaults new policies and migrated records without an
 explicit setting to `retainRequestContent=false`; completions are never
 retained. `x-clawrouter-content-retention: off` confirms the effective setting
 on an inference response. Enabling the separate R2 request archive requires an

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createTcpServer } from "node:net";
 
@@ -94,7 +94,12 @@ const child = spawn("pnpm", ["exec", "wrangler", "dev", "--local", "--ip", "127.
   stdio: ["ignore", "pipe", "pipe"],
 });
 let output = "";
-for (const stream of [child.stdout, child.stderr]) stream.on("data", (chunk) => { output = `${output}${chunk}`.slice(-12_000); });
+const externalLogFile = process.env.CLAWROUTER_E2E_LOG_FILE;
+if (externalLogFile) writeFileSync(externalLogFile, "", { mode: 0o600 });
+for (const stream of [child.stdout, child.stderr]) stream.on("data", (chunk) => {
+  output = `${output}${chunk}`.slice(-12_000);
+  if (externalLogFile) appendFileSync(externalLogFile, chunk, { mode: 0o600 });
+});
 
 try {
   const base = `http://127.0.0.1:${port}`;
@@ -120,6 +125,24 @@ try {
   const preflight = await fetch(`${base}/v1/chat/completions`, { method: "OPTIONS", headers: { origin: "https://client.example", "access-control-request-method": "POST", "access-control-request-headers": "authorization,content-type,x-stainless-retry-count,x-stainless-timeout,x-stainless-runtime" } });
   assert.equal(preflight.status, 204);
   for (const header of ["x-stainless-retry-count", "x-stainless-timeout", "x-stainless-runtime"]) assert.ok(preflight.headers.get("access-control-allow-headers")?.includes(header));
+  assert.match(preflight.headers.get("x-request-id"), /^req_[a-f0-9]{32}$/);
+  assert.ok(preflight.headers.get("access-control-allow-headers").split(",").map((value) => value.trim()).includes("x-request-id"));
+  assert.ok(preflight.headers.get("access-control-allow-headers").split(",").map((value) => value.trim()).includes("traceparent"));
+  assert.ok(preflight.headers.get("access-control-expose-headers").split(",").map((value) => value.trim()).includes("x-request-id"));
+  const suppliedRequestId = await fetch(`${base}/v1/health`, { headers: { "x-request-id": "caller-model-call-1" } });
+  assert.equal(suppliedRequestId.headers.get("x-request-id"), "caller-model-call-1");
+  const generatedRequestIdA = (await fetch(`${base}/v1/health`)).headers.get("x-request-id");
+  const generatedRequestIdB = (await fetch(`${base}/v1/health`)).headers.get("x-request-id");
+  assert.match(generatedRequestIdA, /^req_[a-f0-9]{32}$/);
+  assert.match(generatedRequestIdB, /^req_[a-f0-9]{32}$/);
+  assert.notEqual(generatedRequestIdA, generatedRequestIdB);
+  for (const [label, value] of [["whitespace", "bad id"], ["control", "bad\tid"], ["oversized", "x".repeat(129)]]) {
+    const invalidCorrelation = await fetch(`${base}/v1/health`, { headers: { "x-request-id": value } });
+    assert.equal(invalidCorrelation.status, 400, `${label} request id is rejected`);
+    assert.equal((await invalidCorrelation.json()).error.code, "invalid_request_id");
+    assert.match(invalidCorrelation.headers.get("x-request-id"), /^req_[a-f0-9]{32}$/);
+    assert.notEqual(invalidCorrelation.headers.get("x-request-id"), value);
+  }
   const root = await fetch(base, { redirect: "manual" });
   assert.equal(root.status, 302); assert.equal(root.headers.get("location"), "/dashboard");
   const dashboard = await fetch(`${base}/dashboard/home`);
@@ -484,8 +507,10 @@ try {
     ["manifest_method", `${base}/v1/proxy/replicate/prediction`, { method: 1 }],
     ["native_null", `${base}/v1/native/firecrawl/v2/scrape`, null],
   ]) {
-    const invalidProxyBody = await fetch(url, { method: "POST", headers: proxyHeaders, body: JSON.stringify(body) });
+    const invalidProxyBody = await fetch(url, { method: "POST", headers: { ...proxyHeaders, "x-request-id": `owned-${proxyMutationId}` }, body: JSON.stringify(body) });
     assert.equal(invalidProxyBody.status, 400, `malformed proxy request ${proxyMutationId} is rejected`);
+    assert.equal(invalidProxyBody.headers.get("x-request-id"), `owned-${proxyMutationId}`);
+    assert.ok(invalidProxyBody.headers.get("access-control-expose-headers").split(",").map((value) => value.trim()).includes("x-request-id"));
     assert.equal((await invalidProxyBody.json()).error.code, "invalid_request_body");
   }
   const usageAfterInvalidBodies = await fetch(`${base}/v1/usage`, { headers: { authorization: `Bearer ${proxyKey}` } });
@@ -500,7 +525,7 @@ try {
     const stored = await fetch(`${base}/v1/admin/upstream-grants/policies/rotation/${tokenRef}`, { method: "PUT", headers: adminHeaders, body: JSON.stringify({ provider: "local-openai", kind: "api_key", priority: 10, weight, credential }) });
     assert.equal(stored.status, 200, JSON.stringify(await stored.clone().json()));
   }
-  const rotationRequest = (sessionId) => fetch(`${base}/v1/chat/completions`, { method: "POST", headers: { authorization: `Bearer ${rotationKey}`, "content-type": "application/json", ...(sessionId ? { "session-id": sessionId } : {}) }, body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "rotate grant" }] }) });
+  const rotationRequest = (correlationHeaders = {}) => fetch(`${base}/v1/chat/completions`, { method: "POST", headers: { authorization: `Bearer ${rotationKey}`, "content-type": "application/json", ...correlationHeaders }, body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "rotate grant" }] }) });
   for (let index = 0; index < 4; index += 1) assert.equal((await rotationRequest()).status, 200);
   assert.deepEqual(rotationCalls, ["Bearer rotate-a", "Bearer rotate-b", "Bearer rotate-a", "Bearer rotate-b"], "round-robin selection is serialized by the authority");
   await waitUntil(async () => {
@@ -515,7 +540,7 @@ try {
   assert.equal(actionNamedGrant.status, 200, "action names remain valid three-segment grant references");
   const updateRotationPolicy = async (grantRouting) => {
     const response = await fetch(`${base}/v1/admin/policies/rotation`, { method: "PUT", headers: adminHeaders, body: JSON.stringify({ enabled: true, providers: ["local-openai"], tenantId: "default", tokenRole: "service", requestCostMicros: 1, retainRequestContent: false, grantRouting }) });
-    assert.equal(response.status, 200, JSON.stringify(await response.clone().json()));
+    assert.equal(response.status, 200, await response.clone().text());
   };
   await updateRotationPolicy({ ...routingDefaults, strategy: "least_used" });
   assert.equal((await rotationRequest()).status, 200);
@@ -523,8 +548,22 @@ try {
   assert.deepEqual(rotationCalls.slice(-2), ["Bearer rotate-a", "Bearer rotate-b"], "least-used selection balances authority counters");
   await updateRotationPolicy({ ...routingDefaults, strategy: "weighted_random", stickiness: "session" });
   const stickyStart = rotationCalls.length;
-  for (let index = 0; index < 3; index += 1) assert.equal((await rotationRequest("session-alpha")).status, 200);
-  assert.equal(new Set(rotationCalls.slice(stickyStart)).size, 1, "session stickiness is deterministic across requests");
+  for (let index = 0; index < 3; index += 1) assert.equal((await rotationRequest({ "x-clawrouter-session-id": "session-alpha" })).status, 200);
+  assert.equal(new Set(rotationCalls.slice(stickyStart)).size, 1, "canonical OpenClaw session stickiness is deterministic across requests");
+  const fallbackStickyStart = rotationCalls.length;
+  for (let index = 0; index < 3; index += 1) assert.equal((await rotationRequest({ "session-id": "codex-session-alpha" })).status, 200);
+  assert.equal(new Set(rotationCalls.slice(fallbackStickyStart)).size, 1, "documented Codex session fallback remains deterministic");
+  const precedenceStart = rotationCalls.length;
+  for (let index = 0; index < 3; index += 1) assert.equal((await rotationRequest({ "x-clawrouter-session-id": "canonical-wins", "session-id": `ignored-fallback-${index}` })).status, 200);
+  assert.equal(new Set(rotationCalls.slice(precedenceStart)).size, 1, "canonical session id takes precedence over changing native fallbacks");
+  for (const [requestId, sessionId] of [["unsafe-session", "bad session"], ["oversized-session", "x".repeat(257)]]) {
+    const callsBeforeInvalidSession = rotationCalls.length;
+    const invalidSession = await rotationRequest({ "x-request-id": requestId, "x-clawrouter-session-id": sessionId });
+    assert.equal(invalidSession.status, 400);
+    assert.equal(invalidSession.headers.get("x-request-id"), requestId);
+    assert.equal((await invalidSession.json()).error.code, "invalid_attribution_id");
+    assert.equal(rotationCalls.length, callsBeforeInvalidSession, "unsafe session metadata is rejected before the upstream call");
+  }
   await updateRotationPolicy({ ...routingDefaults, strategy: "priority", eligibleGrants: { "local-openai": ["rotate-b"] } });
   assert.equal((await rotationRequest()).status, 200);
   assert.equal(rotationCalls.at(-1), "Bearer rotate-b", "policy eligibility restricts the grant pool");
@@ -541,15 +580,21 @@ try {
       authorization: `Bearer ${rotationKey}`,
       "content-type": "application/json",
       "x-request-id": "fakeco-observability-contract",
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
       "x-clawrouter-session-id": "session-fakeco",
+      "session-id": "ignored-session-fallback",
       "x-clawrouter-agent-id": "openclaw/gateway",
+      "x-claude-code-agent-id": "ignored-native-agent",
       "x-clawrouter-parent-agent-id": "crabhelm/tenant",
+      "x-claude-code-parent-agent-id": "ignored-native-parent",
       "x-clawrouter-project-id": "fakeco",
       "x-clawrouter-client": "crabhelm",
     },
-    body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "private prompt sentinel" }] }),
+    body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "private prompt sentinel" }], tools: [{ type: "function", function: { name: "lookup", description: "private tool sentinel" } }] }),
   });
   assert.equal(attributed.status, 200);
+  assert.equal(attributed.headers.get("x-request-id"), "fakeco-observability-contract");
+  assert.ok(attributed.headers.get("access-control-expose-headers").split(",").map((value) => value.trim()).includes("x-request-id"));
   assert.equal(attributed.headers.get("x-clawrouter-content-retention"), "off");
   let attributedEvent;
   await waitUntil(async () => {
@@ -564,6 +609,8 @@ try {
       parent: attributedEvent.parent_agent_id,
       project: attributedEvent.project_id,
       client: attributedEvent.client,
+      trace: attributedEvent.trace_id,
+      span: attributedEvent.span_id,
       retained: attributedEvent.content_retained,
       contentRef: attributedEvent.content_ref,
     },
@@ -573,11 +620,51 @@ try {
       parent: "crabhelm/tenant",
       project: "fakeco",
       client: "crabhelm",
+      trace: "4bf92f3577b34da6a3ce929d0e0e4736",
+      span: "00f067aa0ba902b7",
       retained: false,
       contentRef: null,
     },
   );
-  assert.doesNotMatch(JSON.stringify(attributedEvent), /private prompt sentinel|messages|completion/i);
+  assert.doesNotMatch(JSON.stringify(attributedEvent), /private prompt sentinel|private tool sentinel|messages|completion|rotation123|clawrouter-live/i);
+  const invalidTrace = await fetch(`${base}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${rotationKey}`,
+      "content-type": "application/json",
+      traceparent: "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+      "session-id": "codex-fallback-session",
+    },
+    body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "invalid trace private sentinel" }] }),
+  });
+  assert.equal(invalidTrace.status, 200);
+  const invalidTraceRequestId = invalidTrace.headers.get("x-request-id");
+  assert.match(invalidTraceRequestId, /^req_[a-f0-9]{32}$/);
+  let invalidTraceEvent;
+  await waitUntil(async () => {
+    const response = await fetch(`${base}/v1/usage`, { headers: { authorization: `Bearer ${rotationKey}` } });
+    invalidTraceEvent = (await response.json()).usage.events.find((event) => event.request_id === invalidTraceRequestId);
+    return Boolean(invalidTraceEvent);
+  }, "invalid trace usage event was not visible");
+  assert.deepEqual(
+    {
+      request: invalidTraceEvent.request_id,
+      trace: invalidTraceEvent.trace_id,
+      span: invalidTraceEvent.span_id,
+      session: invalidTraceEvent.session_id,
+      retained: invalidTraceEvent.content_retained,
+      contentRef: invalidTraceEvent.content_ref,
+    },
+    {
+      request: invalidTraceRequestId,
+      trace: null,
+      span: null,
+      session: "codex-fallback-session",
+      retained: false,
+      contentRef: null,
+    },
+  );
+  assert.doesNotMatch(JSON.stringify(invalidTraceEvent), /invalid trace private sentinel|messages|completion|rotation123|clawrouter-live/i);
   for (const [tokenRef, credential] of [["no-fail-a", "no-fail-primary"], ["no-fail-b", "no-fail-backup"]]) {
     const stored = await fetch(`${base}/v1/admin/upstream-grants/policies/no_failover/${tokenRef}`, { method: "PUT", headers: adminHeaders, body: JSON.stringify({ provider: "local-openai", kind: "api_key", priority: 10, credential }) });
     assert.equal(stored.status, 200);
@@ -610,6 +697,7 @@ try {
   assert.equal(unavailablePool.status, 503);
   assert.equal((await unavailablePool.json()).error.code, "upstream_grant_pool_unavailable");
   assert.equal(upstreamCalls.length, callsBeforeUnavailablePool, "cooled scoped grants never fall through to an unscoped provider credential");
+  assert.doesNotMatch(output, /private prompt sentinel|private tool sentinel|invalid trace private sentinel|secret_1234|rotation123/i, "Worker logs remain metadata-only");
   console.log(`local Worker smoke passed on ${base}`);
   if (process.env.CLAWROUTER_E2E_HOLD_FILE) {
     writeFileSync(process.env.CLAWROUTER_E2E_HOLD_FILE, `${JSON.stringify({ base, adminToken, rotationKey, noFailoverKey })}\n`, { mode: 0o600 });
@@ -632,10 +720,10 @@ try {
 
 async function json(url) { const response = await fetch(url); assert.equal(response.status, 200, `${url} returned ${response.status}`); return response.json(); }
 async function waitUntil(predicate, message) {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     if (await predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(message);
 }

--- a/worker/accounting.ts
+++ b/worker/accounting.ts
@@ -1,4 +1,5 @@
 import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
+import { logCorrelationError } from "./correlation.ts";
 import { HttpError, randomId } from "./utils.ts";
 
 export interface BudgetReservation {
@@ -43,7 +44,7 @@ export async function finalizeAccounting(env: Env, auth: AuthorizedIdentity, res
     enqueueUsage(env, event),
   ]);
   for (const result of results) {
-    if (result.status === "rejected") console.error("accounting finalization failed", result.reason instanceof Error ? result.reason.message : String(result.reason));
+    if (result.status === "rejected") logCorrelationError("accounting finalization failed", event.request_id);
   }
 }
 

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -7,6 +7,7 @@ import {
   type AssignmentEvidence,
 } from "./assignments";
 import { contentKey, contentRetentionDefault } from "./content-retention.ts";
+import { logCorrelationError } from "./correlation.ts";
 import { currentGrantRuntime, grantPriority, grantRoutingPolicy, grantRuntimeStates, grantSelectionStats, grantUsable, grantWeight, syncGrantPoolIndex, validCredentialBundle, validGrantSegment } from "./grant-selection";
 import { assertFusionModels, loadFusionConfig, storeFusionConfig } from "./fusion-config";
 import { fusionReadiness } from "./fusion-readiness";
@@ -59,7 +60,7 @@ export async function adminApi(request: Request, env: Env, path: string): Promis
     return errorResponse("route_not_found", "admin route not found", 404);
   } catch (error) {
     if (error instanceof HttpError) return errorResponse(error.code, error.message, error.status);
-    console.error("admin request failed", error instanceof Error ? error.message : String(error));
+    logCorrelationError("admin request failed", request.headers.get("x-request-id"));
     return errorResponse("admin_error", "admin request failed", 500);
   }
 }

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -7,7 +7,7 @@ import {
   type AssignmentEvidence,
 } from "./assignments";
 import { contentKey, contentRetentionDefault } from "./content-retention.ts";
-import { logCorrelationError } from "./correlation.ts";
+import { correlationRequestId, logCorrelationError } from "./correlation.ts";
 import { currentGrantRuntime, grantPriority, grantRoutingPolicy, grantRuntimeStates, grantSelectionStats, grantUsable, grantWeight, syncGrantPoolIndex, validCredentialBundle, validGrantSegment } from "./grant-selection";
 import { assertFusionModels, loadFusionConfig, storeFusionConfig } from "./fusion-config";
 import { fusionReadiness } from "./fusion-readiness";
@@ -60,7 +60,7 @@ export async function adminApi(request: Request, env: Env, path: string): Promis
     return errorResponse("route_not_found", "admin route not found", 404);
   } catch (error) {
     if (error instanceof HttpError) return errorResponse(error.code, error.message, error.status);
-    logCorrelationError("admin request failed", request.headers.get("x-request-id"));
+    logCorrelationError("admin request failed", correlationRequestId(request));
     return errorResponse("admin_error", "admin request failed", 500);
   }
 }

--- a/worker/correlation.ts
+++ b/worker/correlation.ts
@@ -7,19 +7,19 @@ const traceparentMaxLength = 512;
 
 const attributionHeaders = [
   {
-    canonical: "x-clawrouter-session-id",
+    field: "sessionId",
     sources: ["x-clawrouter-session-id", "x-claude-code-session-id", "session-id"],
   },
   {
-    canonical: "x-clawrouter-agent-id",
+    field: "agentId",
     sources: ["x-clawrouter-agent-id", "x-claude-code-agent-id"],
   },
   {
-    canonical: "x-clawrouter-parent-agent-id",
+    field: "parentAgentId",
     sources: ["x-clawrouter-parent-agent-id", "x-claude-code-parent-agent-id"],
   },
-  { canonical: "x-clawrouter-project-id", sources: ["x-clawrouter-project-id"] },
-  { canonical: "x-clawrouter-client", sources: ["x-clawrouter-client"] },
+  { field: "projectId", sources: ["x-clawrouter-project-id"] },
+  { field: "client", sources: ["x-clawrouter-client"] },
 ] as const;
 
 export interface CorrelationMetadata {
@@ -39,51 +39,44 @@ export interface CorrelatedRequest {
   error: { code: string; message: string; status: 400 } | null;
 }
 
+// Preserve the ingress Request/body stream. Reconstructing it solely to add headers can
+// retain an unconsumed body tee across a long-lived Worker process.
+const ingressMetadata = new WeakMap<Request, CorrelationMetadata>();
+
 export function correlateIngressRequest(input: Request): CorrelatedRequest {
-  const headers = new Headers(input.headers);
-  const suppliedRequestId = headers.get("x-request-id");
+  const suppliedRequestId = input.headers.get("x-request-id");
   const normalizedRequestId = suppliedRequestId == null
     ? null
     : normalizeRequestId(suppliedRequestId);
   const requestId = suppliedRequestId == null || normalizedRequestId == null
     ? generatedRequestId()
     : normalizedRequestId;
-  headers.set("x-request-id", requestId);
-
   let error = suppliedRequestId != null && normalizedRequestId == null
     ? invalidHeader("X-Request-ID", REQUEST_ID_MAX_LENGTH, "invalid_request_id")
     : null;
-  if (!error) {
-    for (const specification of attributionHeaders) {
-      const result = resolveAttributionHeader(headers, specification);
-      if (result) {
-        error = result;
-        break;
-      }
-    }
-  }
+  const resolved = metadataFromHeaders(input.headers, requestId);
+  if (!error) error = resolved.error;
+  ingressMetadata.set(input, resolved.metadata);
 
   return {
-    request: new Request(input, { headers }),
+    request: input,
     requestId,
     error,
   };
 }
 
 export function correlationMetadata(request: Request): CorrelationMetadata {
+  const stored = ingressMetadata.get(request);
+  if (stored) return stored;
   const requestId = normalizeRequestId(request.headers.get("x-request-id") ?? "");
   if (!requestId) throw new Error("request correlation metadata is missing");
-  const trace = parseTraceparent(request.headers.get("traceparent"));
-  return {
-    requestId,
-    traceId: trace?.traceId ?? null,
-    spanId: trace?.spanId ?? null,
-    sessionId: canonicalAttribution(request.headers, "x-clawrouter-session-id"),
-    agentId: canonicalAttribution(request.headers, "x-clawrouter-agent-id"),
-    parentAgentId: canonicalAttribution(request.headers, "x-clawrouter-parent-agent-id"),
-    projectId: canonicalAttribution(request.headers, "x-clawrouter-project-id"),
-    client: canonicalAttribution(request.headers, "x-clawrouter-client"),
-  };
+  const resolved = metadataFromHeaders(request.headers, requestId);
+  if (resolved.error) throw new Error("request attribution metadata is invalid");
+  return resolved.metadata;
+}
+
+export function correlationRequestId(request: Request): string | null {
+  return ingressMetadata.get(request)?.requestId ?? normalizeRequestId(request.headers.get("x-request-id") ?? "");
 }
 
 export function normalizeRequestId(value: string): string | null {
@@ -130,21 +123,38 @@ export function logCorrelationError(scope: string, requestId: string | null | un
 function resolveAttributionHeader(
   headers: Headers,
   specification: (typeof attributionHeaders)[number],
-): { code: string; message: string; status: 400 } | null {
+): { value: string | null; error: { code: string; message: string; status: 400 } | null } {
   for (const source of specification.sources) {
     const raw = headers.get(source);
     if (raw == null) continue;
     const normalized = normalizeAttributionId(raw);
-    if (!normalized) return invalidHeader(source, ATTRIBUTION_ID_MAX_LENGTH, "invalid_attribution_id");
-    headers.set(specification.canonical, normalized);
-    return null;
+    if (!normalized) return { value: null, error: invalidHeader(source, ATTRIBUTION_ID_MAX_LENGTH, "invalid_attribution_id") };
+    return { value: normalized, error: null };
   }
-  headers.delete(specification.canonical);
-  return null;
+  return { value: null, error: null };
 }
 
-function canonicalAttribution(headers: Headers, name: string): string | null {
-  return normalizeAttributionId(headers.get(name) ?? "");
+function metadataFromHeaders(
+  headers: Headers,
+  requestId: string,
+): { metadata: CorrelationMetadata; error: { code: string; message: string; status: 400 } | null } {
+  const trace = parseTraceparent(headers.get("traceparent"));
+  const metadata: CorrelationMetadata = {
+    requestId,
+    traceId: trace?.traceId ?? null,
+    spanId: trace?.spanId ?? null,
+    sessionId: null,
+    agentId: null,
+    parentAgentId: null,
+    projectId: null,
+    client: null,
+  };
+  for (const specification of attributionHeaders) {
+    const resolved = resolveAttributionHeader(headers, specification);
+    if (resolved.error) return { metadata, error: resolved.error };
+    metadata[specification.field] = resolved.value;
+  }
+  return { metadata, error: null };
 }
 
 function invalidHeader(name: string, maxLength: number, code: string) {

--- a/worker/correlation.ts
+++ b/worker/correlation.ts
@@ -1,0 +1,160 @@
+export const REQUEST_ID_MAX_LENGTH = 128;
+export const ATTRIBUTION_ID_MAX_LENGTH = 256;
+
+const requestIdPattern = /^[A-Za-z0-9._~:/+@=-]+$/;
+const attributionIdPattern = /^[A-Za-z0-9._~:/+@=-]+$/;
+const traceparentMaxLength = 512;
+
+const attributionHeaders = [
+  {
+    canonical: "x-clawrouter-session-id",
+    sources: ["x-clawrouter-session-id", "x-claude-code-session-id", "session-id"],
+  },
+  {
+    canonical: "x-clawrouter-agent-id",
+    sources: ["x-clawrouter-agent-id", "x-claude-code-agent-id"],
+  },
+  {
+    canonical: "x-clawrouter-parent-agent-id",
+    sources: ["x-clawrouter-parent-agent-id", "x-claude-code-parent-agent-id"],
+  },
+  { canonical: "x-clawrouter-project-id", sources: ["x-clawrouter-project-id"] },
+  { canonical: "x-clawrouter-client", sources: ["x-clawrouter-client"] },
+] as const;
+
+export interface CorrelationMetadata {
+  requestId: string;
+  traceId: string | null;
+  spanId: string | null;
+  sessionId: string | null;
+  agentId: string | null;
+  parentAgentId: string | null;
+  projectId: string | null;
+  client: string | null;
+}
+
+export interface CorrelatedRequest {
+  request: Request;
+  requestId: string;
+  error: { code: string; message: string; status: 400 } | null;
+}
+
+export function correlateIngressRequest(input: Request): CorrelatedRequest {
+  const headers = new Headers(input.headers);
+  const suppliedRequestId = headers.get("x-request-id");
+  const normalizedRequestId = suppliedRequestId == null
+    ? null
+    : normalizeRequestId(suppliedRequestId);
+  const requestId = suppliedRequestId == null || normalizedRequestId == null
+    ? generatedRequestId()
+    : normalizedRequestId;
+  headers.set("x-request-id", requestId);
+
+  let error = suppliedRequestId != null && normalizedRequestId == null
+    ? invalidHeader("X-Request-ID", REQUEST_ID_MAX_LENGTH, "invalid_request_id")
+    : null;
+  if (!error) {
+    for (const specification of attributionHeaders) {
+      const result = resolveAttributionHeader(headers, specification);
+      if (result) {
+        error = result;
+        break;
+      }
+    }
+  }
+
+  return {
+    request: new Request(input, { headers }),
+    requestId,
+    error,
+  };
+}
+
+export function correlationMetadata(request: Request): CorrelationMetadata {
+  const requestId = normalizeRequestId(request.headers.get("x-request-id") ?? "");
+  if (!requestId) throw new Error("request correlation metadata is missing");
+  const trace = parseTraceparent(request.headers.get("traceparent"));
+  return {
+    requestId,
+    traceId: trace?.traceId ?? null,
+    spanId: trace?.spanId ?? null,
+    sessionId: canonicalAttribution(request.headers, "x-clawrouter-session-id"),
+    agentId: canonicalAttribution(request.headers, "x-clawrouter-agent-id"),
+    parentAgentId: canonicalAttribution(request.headers, "x-clawrouter-parent-agent-id"),
+    projectId: canonicalAttribution(request.headers, "x-clawrouter-project-id"),
+    client: canonicalAttribution(request.headers, "x-clawrouter-client"),
+  };
+}
+
+export function normalizeRequestId(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= REQUEST_ID_MAX_LENGTH && requestIdPattern.test(normalized)
+    ? normalized
+    : null;
+}
+
+export function normalizeAttributionId(value: string): string | null {
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= ATTRIBUTION_ID_MAX_LENGTH && attributionIdPattern.test(normalized)
+    ? normalized
+    : null;
+}
+
+export function parseTraceparent(value: string | null): { traceId: string; spanId: string } | null {
+  const normalized = value?.trim() ?? "";
+  if (normalized.length < 55 || normalized.length > traceparentMaxLength) return null;
+  if (normalized[2] !== "-" || normalized[35] !== "-" || normalized[52] !== "-") return null;
+  const version = normalized.slice(0, 2);
+  const traceId = normalized.slice(3, 35);
+  const spanId = normalized.slice(36, 52);
+  const flags = normalized.slice(53, 55);
+  if (!/^[0-9a-f]{2}$/.test(version) || version === "ff") return null;
+  if (!/^[0-9a-f]{32}$/.test(traceId) || /^0{32}$/.test(traceId)) return null;
+  if (!/^[0-9a-f]{16}$/.test(spanId) || /^0{16}$/.test(spanId)) return null;
+  if (!/^[0-9a-f]{2}$/.test(flags)) return null;
+  if (version === "00" && normalized.length !== 55) return null;
+  if (version !== "00" && normalized.length > 55 && normalized[55] !== "-") return null;
+  return { traceId, spanId };
+}
+
+export function withRequestId(response: Response, requestId: string): Response {
+  const copy = new Response(response.body, response);
+  copy.headers.set("x-request-id", requestId);
+  return copy;
+}
+
+export function logCorrelationError(scope: string, requestId: string | null | undefined): void {
+  console.error(scope, { request_id: normalizeRequestId(requestId ?? "") ?? "unavailable" });
+}
+
+function resolveAttributionHeader(
+  headers: Headers,
+  specification: (typeof attributionHeaders)[number],
+): { code: string; message: string; status: 400 } | null {
+  for (const source of specification.sources) {
+    const raw = headers.get(source);
+    if (raw == null) continue;
+    const normalized = normalizeAttributionId(raw);
+    if (!normalized) return invalidHeader(source, ATTRIBUTION_ID_MAX_LENGTH, "invalid_attribution_id");
+    headers.set(specification.canonical, normalized);
+    return null;
+  }
+  headers.delete(specification.canonical);
+  return null;
+}
+
+function canonicalAttribution(headers: Headers, name: string): string | null {
+  return normalizeAttributionId(headers.get(name) ?? "");
+}
+
+function invalidHeader(name: string, maxLength: number, code: string) {
+  return {
+    code,
+    message: `${name} must be a ${maxLength}-character-or-shorter ASCII identifier without whitespace or control characters`,
+    status: 400 as const,
+  };
+}
+
+function generatedRequestId(): string {
+  return `req_${crypto.randomUUID().replaceAll("-", "")}`;
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -6,6 +6,7 @@ import {
 import { budgetStatus, BudgetLedgerObject, queue, UsageLedgerObject, usageSnapshot, usageSnapshots } from "./ledgers";
 import { dashboardSecurityHeaders } from "./dashboard-security";
 import { contentRetentionDefault } from "./content-retention.ts";
+import { correlateIngressRequest, withRequestId } from "./correlation.ts";
 import { oauthCallback } from "./oauth";
 import { routeCatalog, snapshot } from "./providers";
 import { authenticateProxyKey, inspectKey, proxyManifest, proxyNative, proxyOpenAi } from "./proxy";
@@ -20,10 +21,18 @@ export { BudgetLedgerObject, UsageLedgerObject };
 
 const handler: ExportedHandler<Env, QueueMessage> = {
   async fetch(request, env, context) {
+    const path = canonicalPath(new URL(request.url).pathname);
+    const correlated = correlateIngressRequest(request);
+    let response: Response;
     try {
-      const response = await route(request, env, context);
-      return corsEnabled(canonicalPath(new URL(request.url).pathname)) ? withCors(response) : response;
-    } catch (error) { return caughtResponse(error); }
+      response = correlated.error
+        ? errorResponse(correlated.error.code, correlated.error.message, correlated.error.status)
+        : await route(correlated.request, env, context);
+    } catch (error) {
+      response = caughtResponse(error, correlated.requestId);
+    }
+    response = withRequestId(response, correlated.requestId);
+    return corsEnabled(path) ? withCors(response) : response;
   },
   queue,
 };

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -2,6 +2,7 @@ import { accessIdentity } from "./access";
 import { finalizeAccounting, reserveBudget, type BudgetReservation, type EstimatedCost } from "./accounting";
 import { resolveCredentials, resolvePolicies, resolveUsers } from "./authority";
 import { retainRequestContent } from "./content-retention";
+import { correlationMetadata } from "./correlation.ts";
 import {
   FUSION_MODEL_ID, buildAggregatorBody, buildFusionReservationProposals, collectFusionProposals,
   fusionMessagesValid,
@@ -16,7 +17,7 @@ import {
 import { actualModelCost, estimateModelCost } from "./pricing";
 import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, CompiledQuotaConfig, Env, UsageEvent } from "./types";
 import {
-  clampAudit, errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
+  errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
 } from "./utils";
 
 type AuthMode = "proxy_key" | "access";
@@ -135,7 +136,7 @@ async function proxyFusion(
   const config = await loadFusionConfig(env);
   if (!config.enabled) return errorResponse("fusion_disabled", `${FUSION_MODEL_ID} is not enabled`, 404);
   if (!fusionMessagesValid(body.messages)) return errorResponse("fusion_messages_invalid", "fusion messages must be an array of objects with string roles", 400);
-  const requestId = request.headers.get("x-request-id") ?? randomId("req");
+  const requestId = correlationMetadata(request).requestId;
   const compoundRequestId = randomId("fusion");
   const compoundRequestSize = config.adviserModels.length + 1;
   const fusionHeaders = new Headers(request.headers);
@@ -320,12 +321,12 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
   const auth = reservedBudget?.auth ?? await selectedAuth(request, env, mode, selection, preauthenticated);
   if (auth instanceof Response) {
     if (compound && auditAuth) {
-      const requestId = request.headers.get("x-request-id") ?? randomId("req");
+      const requestId = correlationMetadata(request).requestId;
       auditFailure(context, env, auditAuth, selection, request, requestId, Date.now(), estimateCost(selection.model, selection.body, auditAuth.policy.requestCostMicros, selection.capability), auth.status, auth.status === 403 ? "denied" : auth.status < 500 ? "client_error" : "provider_error", compound);
     }
     return auth;
   }
-  const requestId = request.headers.get("x-request-id") ?? randomId("req");
+  const requestId = correlationMetadata(request).requestId;
   const started = Date.now();
   const estimatedCost = estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability);
   const cost = reservedBudget?.cost ?? estimatedCost;
@@ -397,7 +398,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
 async function reserveSelected(request: Request, env: Env, context: ExecutionContext, mode: AuthMode, selection: ProxySelection, preauthenticated: AuthorizedIdentity | null, compound?: CompoundRequestContext): Promise<ReservedProxyBudget | Response> {
   const auth = await selectedAuth(request, env, mode, selection, preauthenticated);
   if (auth instanceof Response) return auth;
-  const requestId = request.headers.get("x-request-id") ?? randomId("req");
+  const requestId = correlationMetadata(request).requestId;
   const started = Date.now();
   const cost = estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability);
   try {
@@ -456,8 +457,8 @@ async function grantStickyHash(request: Request, auth: AuthorizedIdentity): Prom
   if (routing.stickiness === "none") return null;
   const identity = auth.principalId ?? auth.credentialId ?? auth.policyId;
   if (routing.stickiness === "identity") return sha256Hex(`identity:${identity}`);
-  const rawSession = ["session-id", "x-session-id", "thread-id", "conversation-id"].map((name) => request.headers.get(name)?.trim()).find((value) => value && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value));
-  return sha256Hex(`session:${rawSession ?? identity}`);
+  const sessionId = correlationMetadata(request).sessionId;
+  return sha256Hex(`session:${sessionId ?? identity}`);
 }
 
 function selectedFailure(error: unknown): HttpError {
@@ -473,7 +474,7 @@ async function auditSelectionFailure(request: Request, env: Env, context: Execut
   const selected = await selectedAuth(request, env, mode, selection, preauthenticated);
   const auth = selected instanceof Response ? auditAuth : selected;
   if (!auth) return;
-  const requestId = request.headers.get("x-request-id") ?? randomId("req");
+  const requestId = correlationMetadata(request).requestId;
   const status = statusCode === 403 ? "denied" : statusCode < 500 ? "client_error" : "provider_error";
   auditFailure(context, env, auth, selection, request, requestId, Date.now(), estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability), statusCode, status, compound);
 }
@@ -516,13 +517,14 @@ function actualCost(model: CompiledModel | null, tokens: Tokens, fixed: number |
 }
 
 function usageEvent(auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, statusCode: number, tokens: Tokens | null, cost: Cost, reservation: BudgetReservation, contentRef: string | null, status: UsageEvent["status"], actual = 0, compound?: CompoundRequestContext): UsageEvent {
+  const correlation = correlationMetadata(request);
   return {
     id: randomId("usage"), type: "clawrouter.usage.v1", occurred_at_ms: Date.now(), tenant_id: auth.policy.tenantId ?? "default",
     policy_id: auth.policyId, credential_id: auth.credentialId, principal_id: auth.principalId, auth_type: auth.authType,
-    session_id: clampAudit(request.headers.get("x-clawrouter-session-id") ?? request.headers.get("session-id")),
-    agent_id: clampAudit(request.headers.get("x-clawrouter-agent-id")), parent_agent_id: clampAudit(request.headers.get("x-clawrouter-parent-agent-id")),
-    project_id: clampAudit(request.headers.get("x-clawrouter-project-id")), client: clampAudit(request.headers.get("x-clawrouter-client")),
+    session_id: correlation.sessionId, agent_id: correlation.agentId, parent_agent_id: correlation.parentAgentId,
+    project_id: correlation.projectId, client: correlation.client,
     key_id: auth.credentialId ?? auth.policyId, request_id: requestId,
+    trace_id: correlation.traceId, span_id: correlation.spanId,
     compound_request_id: compound?.id ?? null, compound_request_stage: compound?.stage ?? null, compound_request_index: compound?.index ?? null,
     compound_request_size: compound?.size ?? null, compound_request_started_at_ms: compound?.startedAtMs ?? null,
     provider: selection.provider.id, capability: selection.capability,

--- a/worker/test/accounting.test.mjs
+++ b/worker/test/accounting.test.mjs
@@ -11,7 +11,7 @@ const auth = {
   contentRetentionDisabled: false,
 };
 const reservation = { reservationId: "reservation", reservedMicros: 100 };
-const event = { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy" };
+const event = { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy", request_id: "request-safe" };
 
 test("thrown ledger settlement queues a retry", async () => {
   const sent = [];
@@ -28,14 +28,16 @@ test("settlement retry failure does not suppress the usage event", async () => {
   });
   const errors = [];
   const original = console.error;
-  console.error = (...values) => errors.push(values.join(" "));
+  console.error = (...values) => errors.push(JSON.stringify(values));
   try {
     await finalizeAccounting(env, auth, reservation, 42, event);
   } finally {
     console.error = original;
   }
   assert.deepEqual(sent, [event]);
-  assert.match(errors.join("\n"), /queue settlement unavailable/);
+  assert.match(errors.join("\n"), /accounting finalization failed/);
+  assert.match(errors.join("\n"), /request-safe/);
+  assert.doesNotMatch(errors.join("\n"), /queue settlement unavailable/);
 });
 
 function mockEnv(send) {

--- a/worker/test/correlation.test.mjs
+++ b/worker/test/correlation.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  correlateIngressRequest,
+  correlationMetadata,
+  normalizeRequestId,
+  parseTraceparent,
+  withRequestId,
+} from "../correlation.ts";
+import { caughtResponse, corsPreflight, errorResponse, withCors } from "../utils.ts";
+
+test("ingress echoes one safe request id across success, owned errors, and CORS", async () => {
+  const correlated = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: { "x-request-id": "caller_123" },
+  }));
+  const supplied = withCors(withRequestId(Response.json({ ok: true }), correlated.requestId));
+  assert.equal(supplied.status, 200);
+  assert.equal(supplied.headers.get("x-request-id"), "caller_123");
+  assert.match(supplied.headers.get("access-control-expose-headers"), /(?:^|,)\s*x-request-id(?:,|$)/);
+
+  const missingA = correlateIngressRequest(new Request("https://router.example/v1/health"));
+  const missingB = correlateIngressRequest(new Request("https://router.example/v1/health"));
+  assert.match(missingA.requestId, /^req_[a-f0-9]{32}$/);
+  assert.match(missingB.requestId, /^req_[a-f0-9]{32}$/);
+  assert.notEqual(missingA.requestId, missingB.requestId);
+
+  const ownedError = withRequestId(errorResponse("route_not_found", "route not found", 404), "owned_error");
+  assert.equal(ownedError.status, 404);
+  assert.equal(ownedError.headers.get("x-request-id"), "owned_error");
+
+  const preflight = withRequestId(corsPreflight(), missingA.requestId);
+  assert.equal(preflight.status, 204);
+  assert.match(preflight.headers.get("access-control-allow-headers"), /(?:^|,)\s*x-request-id(?:,|$)/);
+  assert.match(preflight.headers.get("access-control-allow-headers"), /(?:^|,)\s*traceparent(?:,|$)/);
+  assert.match(preflight.headers.get("access-control-expose-headers"), /(?:^|,)\s*x-request-id(?:,|$)/);
+});
+
+test("invalid and oversized request ids are rejected without reflection", async () => {
+  for (const rejected of ["bad id", "bad\tid", "x".repeat(129), "ümlaut", ""]) {
+    const correlated = correlateIngressRequest(new Request("https://router.example/v1/health", {
+      headers: { "x-request-id": rejected },
+    }));
+    assert.equal(correlated.error?.status, 400);
+    assert.equal(correlated.error?.code, "invalid_request_id");
+    assert.match(correlated.requestId, /^req_[a-f0-9]{32}$/);
+    assert.notEqual(correlated.requestId, rejected);
+  }
+  assert.equal(normalizeRequestId("  caller.trimmed  "), "caller.trimmed");
+});
+
+test("canonical attribution wins and documented session fallbacks normalize once", () => {
+  const explicit = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: {
+      "x-clawrouter-session-id": "openclaw-session",
+      "x-claude-code-session-id": "claude-session",
+      "session-id": "codex-session",
+      "x-clawrouter-agent-id": "configured-agent",
+      "x-claude-code-agent-id": "native-agent",
+      "x-clawrouter-project-id": "project-one",
+      "x-clawrouter-client": "openclaw",
+    },
+  }));
+  assert.equal(explicit.error, null);
+  assert.deepEqual(correlationMetadata(explicit.request), {
+    requestId: explicit.requestId,
+    traceId: null,
+    spanId: null,
+    sessionId: "openclaw-session",
+    agentId: "configured-agent",
+    parentAgentId: null,
+    projectId: "project-one",
+    client: "openclaw",
+  });
+
+  const claudeFallback = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: { "x-claude-code-session-id": "claude-session" },
+  }));
+  assert.equal(correlationMetadata(claudeFallback.request).sessionId, "claude-session");
+
+  const codexFallback = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: { "session-id": "codex-session" },
+  }));
+  assert.equal(correlationMetadata(codexFallback.request).sessionId, "codex-session");
+});
+
+test("unsafe selected attribution is rejected while lower-priority input cannot override explicit values", () => {
+  const invalid = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: {
+      "x-request-id": "attribution_error",
+      "x-clawrouter-session-id": "bad session",
+      "session-id": "safe-fallback",
+    },
+  }));
+  assert.equal(invalid.error?.code, "invalid_attribution_id");
+  assert.match(invalid.error?.message, /x-clawrouter-session-id/i);
+
+  const explicit = correlateIngressRequest(new Request("https://router.example/v1/health", {
+    headers: {
+      "x-clawrouter-session-id": "explicit-session",
+      "session-id": "ignored unsafe fallback",
+    },
+  }));
+  assert.equal(explicit.error, null);
+  assert.equal(correlationMetadata(explicit.request).sessionId, "explicit-session");
+});
+
+test("W3C traceparent parsing accepts bounded lineage and ignores invalid contexts", () => {
+  const valid = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+  assert.deepEqual(parseTraceparent(valid), {
+    traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+    spanId: "00f067aa0ba902b7",
+  });
+  assert.deepEqual(
+    parseTraceparent("01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-future"),
+    { traceId: "4bf92f3577b34da6a3ce929d0e0e4736", spanId: "00f067aa0ba902b7" },
+  );
+  for (const invalid of [
+    "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+    "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+    "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",
+    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0g",
+    "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra",
+  ]) assert.equal(parseTraceparent(invalid), null);
+});
+
+test("unhandled owned errors log only bounded request correlation metadata", async () => {
+  const logs = [];
+  const original = console.error;
+  console.error = (...values) => logs.push(values);
+  try {
+    const response = withRequestId(
+      caughtResponse(new Error("private-body-and-secret-sentinel"), "safe_log_id"),
+      "safe_log_id",
+    );
+    assert.equal(response.status, 500);
+    assert.equal(response.headers.get("x-request-id"), "safe_log_id");
+  } finally {
+    console.error = original;
+  }
+  assert.deepEqual(logs, [["unhandled request error", { request_id: "safe_log_id" }]]);
+  assert.doesNotMatch(JSON.stringify(logs), /private-body-and-secret-sentinel/);
+});

--- a/worker/test/correlation.test.mjs
+++ b/worker/test/correlation.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   correlateIngressRequest,
   correlationMetadata,
+  correlationRequestId,
   normalizeRequestId,
   parseTraceparent,
   withRequestId,
@@ -11,9 +12,14 @@ import {
 import { caughtResponse, corsPreflight, errorResponse, withCors } from "../utils.ts";
 
 test("ingress echoes one safe request id across success, owned errors, and CORS", async () => {
-  const correlated = correlateIngressRequest(new Request("https://router.example/v1/health", {
+  const request = new Request("https://router.example/v1/health", {
+    method: "POST",
     headers: { "x-request-id": "caller_123" },
-  }));
+    body: "fixture body",
+  });
+  const correlated = correlateIngressRequest(request);
+  assert.equal(correlated.request, request, "ingress correlation must not clone or tee the request body stream");
+  assert.equal(await correlated.request.text(), "fixture body");
   const supplied = withCors(withRequestId(Response.json({ ok: true }), correlated.requestId));
   assert.equal(supplied.status, 200);
   assert.equal(supplied.headers.get("x-request-id"), "caller_123");
@@ -24,6 +30,7 @@ test("ingress echoes one safe request id across success, owned errors, and CORS"
   assert.match(missingA.requestId, /^req_[a-f0-9]{32}$/);
   assert.match(missingB.requestId, /^req_[a-f0-9]{32}$/);
   assert.notEqual(missingA.requestId, missingB.requestId);
+  assert.equal(correlationRequestId(missingA.request), missingA.requestId);
 
   const ownedError = withRequestId(errorResponse("route_not_found", "route not found", 404), "owned_error");
   assert.equal(ownedError.status, 404);

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -264,6 +264,8 @@ export interface UsageEvent {
   client: string | null;
   key_id: string;
   request_id: string;
+  trace_id: string | null;
+  span_id: string | null;
   compound_request_id: string | null;
   compound_request_stage: "fusion_adviser" | "fusion_synthesizer" | null;
   compound_request_index: number | null;

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -1,18 +1,21 @@
+import { logCorrelationError } from "./correlation.ts";
+
 const corsHeaders = {
   "access-control-allow-origin": "*",
   "access-control-allow-methods": "GET,POST,PUT,OPTIONS",
   "access-control-allow-headers": [
     "authorization", "content-type", "x-api-key", "anthropic-beta", "anthropic-version",
-    "x-request-id", "session-id", "thread-id", "session_id", "x-clawrouter-session-id",
+    "x-request-id", "traceparent", "session-id", "thread-id", "session_id", "x-clawrouter-session-id",
     "x-clawrouter-agent-id", "x-clawrouter-parent-agent-id", "x-clawrouter-project-id",
-    "x-clawrouter-client", "anthropic-dangerous-direct-browser-access",
+    "x-clawrouter-client", "x-claude-code-session-id", "x-claude-code-agent-id",
+    "x-claude-code-parent-agent-id", "anthropic-dangerous-direct-browser-access",
     "x-stainless-retry-count", "x-stainless-timeout", "x-stainless-lang",
     "x-stainless-package-version", "x-stainless-os", "x-stainless-arch",
     "x-stainless-runtime", "x-stainless-runtime-version", "x-stainless-helper-method",
     "x-stainless-helper",
   ].join(","),
   "access-control-expose-headers": [
-    "x-clawrouter-content-retention", "x-clawrouter-upstream-provider", "x-clawrouter-fusion",
+    "x-request-id", "x-clawrouter-content-retention", "x-clawrouter-upstream-provider", "x-clawrouter-fusion",
     "x-clawrouter-fusion-aggregator", "x-clawrouter-fusion-adviser-count", "x-clawrouter-fusion-failed-count",
     "x-clawrouter-fusion-latency-ms", "x-clawrouter-fusion-advisers",
   ].join(","),
@@ -127,7 +130,6 @@ export function commaSet(value: string | undefined): Set<string> {
 
 export function nowIso(): string { return new Date().toISOString(); }
 export function randomId(prefix: string): string { return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`; }
-export function clampAudit(value: string | null, max = 256): string | null { return value ? value.slice(0, max) : null; }
 
 const maxJsonBodyBytes = 8 * 1024 * 1024;
 
@@ -161,8 +163,8 @@ export class HttpError extends Error {
   constructor(status: number, code: string, message: string) { super(message); this.status = status; this.code = code; }
 }
 
-export function caughtResponse(error: unknown): Response {
+export function caughtResponse(error: unknown, requestId: string): Response {
   if (error instanceof HttpError) return errorResponse(error.code, error.message, error.status);
-  console.error("unhandled request error", error instanceof Error ? error.message : String(error));
+  logCorrelationError("unhandled request error", requestId);
   return errorResponse("internal_error", "internal server error", 500);
 }


### PR DESCRIPTION
## Summary

- Canonicalize `X-Request-ID` once at Worker ingress, reuse it throughout request handling, echo it on every Worker-owned response, and expose it through CORS.
- Parse valid W3C `traceparent` lineage into bounded usage/status metadata while keeping prompts, completions, tool bodies, and credentials out of retained data and logs.
- Make grant selection consume the canonical OpenClaw `X-ClawRouter-Session-ID`, with only the documented Claude/session compatibility fallbacks and explicit attribution-header precedence.
- Add focused unit, integration, source-blind behavior, documentation, and changelog coverage.

## Exact contract

- A caller-supplied request ID wins after outer-whitespace trimming when it is 1-128 safe ASCII characters (`A-Z`, `a-z`, `0-9`, `._~:/+@=-`). A missing ID becomes `req_` plus 32 lowercase hexadecimal characters. Invalid, control-containing, or oversized input fails with `400 invalid_request_id`; the rejected value is never reflected.
- The canonical request ID is present on OpenAI-compatible success responses and every Worker-owned error response. CORS permits and exposes `x-request-id` and permits `traceparent`.
- Valid lowercase W3C `traceparent` values contribute nonzero `trace_id` and `span_id`; malformed, uppercase, zero, unsupported, or oversized values are ignored. These fields and the canonical request ID are metadata only, including when detailed retention is disabled.
- Error logs contain only a bounded safe request ID and a constant scope. Request/response/tool bodies, exception messages, and secrets are excluded.
- Session stickiness precedence is `X-ClawRouter-Session-ID`, then `X-Claude-Code-Session-ID`, then documented `Session-ID`. Explicit ClawRouter agent and parent headers precede their documented Claude-native fallbacks; project and client attribution remain explicit-only. Unsafe selected attribution fails before provider or grant selection.
- Request, trace, span, session, agent, parent, project, and client identifiers are not Prometheus labels. No metrics surface was changed.

## Proof on exact head

Tested head: `f6c7a8ac350f1b5329d34432b8c01d91f711636c`

- Node 24 `pnpm check` — Worker 78/78, admin 26/26, scripts 72/72.
- Node 24 `pnpm build` — green, including Worker 78/78.
- Exact Linux/Node 24 `pnpm worker:e2e` — local Worker smoke green.
- Source-blind behavior validation — 5/5 applicable behaviors passed: explicit/generated/error IDs, CORS, valid/invalid trace lineage, retention-off sentinel exclusion, attribution precedence/fallbacks, stable session-to-grant selection, and refusal before selection for unsafe sessions.
- Canonical `autoreview --mode local` — clean; no accepted actionable findings.
- `git diff --check` — clean.

The first GitHub run exposed a Linux Worker-runtime body-stream retention failure caused by reconstructing every ingress `Request` to add headers. The follow-up commit preserves request identity/body streams and stores validated correlation metadata out-of-band; the regression is covered by request-identity/body-readability tests and the exact Linux/Node 24 E2E proof above.

## Compatibility and risk

- This intentionally tightens caller metadata: internal whitespace, Unicode/control characters, and oversized identifiers now fail instead of flowing into logs, usage records, or stickiness keys.
- Undocumented `X-Session-ID`, `Thread-ID`, and `Conversation-ID` stickiness fallbacks are removed. The documented `Session-ID` and Claude compatibility header remain.
- Historical usage records can omit the additive trace fields; new records emit a string or `null`.
- No hosted Cloudflare, OpenClaw, or Crabhelm integration was exercised. Prometheus non-labeling is covered by unchanged metric surfaces plus code/test review because this repository has no Prometheus endpoint.

## Deployment status

No Cloudflare/AWS deployment, SaaS or GitHub Environment mutation, secret creation, release, version bump, or tag.
