### PR TITLE
fix(proxy): resolve native path models for pricing; fail closed on unpriced budgeted catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Resolve native path models for pricing and omit unpriced catalog models for budgeted proxy keys without fixed request pricing.
 - Add OpenAI GPT-5.6 as the default flagship model with current context limits and list pricing.
 - Add canonical request, W3C trace, and session correlation across OpenAI-compatible responses, CORS, metadata-only usage/status events, bounded error logs, and session-stable grant selection.
 - Wire FakeCo Access service-token identifiers into the staging deploy so Crabhelm automation receives the intended non-identity policy.

--- a/worker/discovery.ts
+++ b/worker/discovery.ts
@@ -37,8 +37,9 @@ export async function avatarResponse(request: Request, env: Env): Promise<Respon
 }
 
 export async function modelsResponse(request: Request, env: Env): Promise<Response> {
-  const rows = await clientEntitlements(request, env);
-  if (rows instanceof Response) return rows;
+  const entitlements = await clientEntitlements(request, env);
+  if (entitlements instanceof Response) return entitlements;
+  const rows = entitlements.rows;
   const allowed = new Map(rows.filter((row) => row.allowed && row.readiness.executable).map((row) => [row.provider, row.readiness.executableEndpoints]));
   if (request.headers.has("anthropic-version")) {
     const data = snapshot.providers.flatMap((provider) => provider.models.filter((model) => model.capabilities.includes("llm.messages") && executableCapabilities(provider, model.capabilities, allowed.get(provider.id) ?? []).length).map((model) => ({
@@ -63,8 +64,9 @@ export async function modelsResponse(request: Request, env: Env): Promise<Respon
 }
 
 export async function catalogResponse(request: Request, env: Env): Promise<Response> {
-  const rows = await clientEntitlements(request, env);
-  if (rows instanceof Response) return rows;
+  const entitlements = await clientEntitlements(request, env);
+  if (entitlements instanceof Response) return entitlements;
+  const rows = entitlements.rows;
   const providers = rows.filter((row) => row.allowed && row.provider !== "clawrouter").flatMap((row) => {
     const provider = snapshot.providers.find((candidate) => candidate.id === row.provider);
     if (!provider) return [];
@@ -74,10 +76,7 @@ export async function catalogResponse(request: Request, env: Env): Promise<Respo
       openaiCompatible: row.readiness.executable && provider.class === "openai_compatible", nativeBaseUrl: `/v1/native/${provider.id}`,
       policies: row.policies, readiness: row.readiness, connectionTypes: connectionTypes(provider),
       routes: provider.endpoints.filter((endpoint) => endpoint.native_proxy && endpoints.includes(endpoint.id)).map((endpoint) => ({ endpoint: endpoint.id, methods: endpoint.methods, path: endpoint.path, requestFormat: endpoint.request_format, responseFormat: endpoint.response_format, streaming: endpoint.streaming })),
-      models: provider.models.flatMap((model) => {
-        const capabilities = executableCapabilities(provider, model.capabilities, endpoints);
-        return capabilities.length ? [{ id: model.id, upstream: model.upstream, capabilities, pricing_ref: model.pricing_ref, pricing: model.pricing }] : [];
-      }),
+      models: catalogModels(provider, endpoints, entitlements.proxyPolicy),
     }];
   });
   const fusion = rows.find((row) => row.provider === "clawrouter" && row.allowed);
@@ -182,15 +181,30 @@ function routeExecutable(route: NonNullable<ReturnType<typeof modelRoute>>, rows
   return !!endpoint && row?.allowed === true && row.readiness.executableEndpoints.includes(endpoint.id);
 }
 
-async function clientEntitlements(request: Request, env: Env): Promise<EntitlementRow[] | Response> {
+interface ClientEntitlements {
+  rows: EntitlementRow[];
+  proxyPolicy: AccessPolicyEntry["policy"] | null;
+}
+
+async function clientEntitlements(request: Request, env: Env): Promise<ClientEntitlements | Response> {
   const hasKey = ["authorization", "x-api-key", "x-goog-api-key", "api-key"].some((name) => request.headers.get(name)?.includes("clawrouter-") || request.headers.get(name)?.includes("ocpk_"));
   if (hasKey) {
     const auth = await authenticateProxyKey(request.headers, env);
     if (auth instanceof Response) return auth;
-    return entitlementRowsForEntries([{ policyId: auth.policyId, policy: auth.policy }], env);
+    return { rows: await entitlementRowsForEntries([{ policyId: auth.policyId, policy: auth.policy }], env), proxyPolicy: auth.policy };
   }
   const session = await verifiedAccessSession(request, env);
-  return session ? entitlementRows(session, env) : errorResponse("client_auth_required", "a valid ClawRouter proxy key or Cloudflare Access session is required", 401);
+  return session ? { rows: await entitlementRows(session, env), proxyPolicy: null } : errorResponse("client_auth_required", "a valid ClawRouter proxy key or Cloudflare Access session is required", 401);
+}
+
+export function catalogModels(provider: CompiledProvider, endpoints: string[], proxyPolicy: AccessPolicyEntry["policy"] | null) {
+  const requiresPricing = proxyPolicy?.monthlyBudgetMicros != null && proxyPolicy.requestCostMicros == null;
+  return provider.models.flatMap((model) => {
+    // Budgeted proxy keys fail closed at discovery instead of per-request pricing_required.
+    if (requiresPricing && model.pricing == null) return [];
+    const capabilities = executableCapabilities(provider, model.capabilities, endpoints);
+    return capabilities.length ? [{ id: model.id, upstream: model.upstream, capabilities, pricing_ref: model.pricing_ref, pricing: model.pricing }] : [];
+  });
 }
 
 async function retentionView(session: AccessSession, env: Env) {

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -224,6 +224,10 @@ export function prepareManifestRequest(provider: CompiledProvider, endpoint: Com
   };
 }
 
+export function prepareNativeRequest(provider: CompiledProvider, endpoint: CompiledEndpoint, body: Record<string, unknown>, path: string, env: Env): { model: CompiledModel | null; body: Record<string, unknown>; pathParams: Record<string, string> } {
+  return prepareManifestRequest(provider, endpoint, body, nativeParams(endpoint, path), env);
+}
+
 function directManifestEnvelope(request: Request, endpoint: CompiledEndpoint): { method: string; pathParams: Record<string, string>; query: Record<string, unknown>; body: Record<string, unknown> } {
   const query = new URL(request.url).searchParams;
   const pathParams: Record<string, string> = {};
@@ -269,15 +273,9 @@ export async function proxyNative(request: Request, env: Env, context: Execution
   const method = request.method.toUpperCase();
   if (!endpoint.methods.includes(method)) return errorResponse("method_not_allowed", `endpoint does not allow ${method}`, 405);
   const body = request.method === "GET" || request.method === "HEAD" ? {} : requestObject(await readJson<unknown>(request));
-  const modelId = typeof body.model === "string" ? body.model : null;
-  const globalModel = modelId ? modelRoute(modelId) : null;
-  if (globalModel && globalModel.provider.id !== provider.id) return errorResponse("model_provider_mismatch", `model ${modelId} does not belong to provider ${provider.id}`, 400);
-  const resolvedModel = modelId ? providerModelRoute(provider, modelId) : null;
-  const model = resolvedModel?.model ?? null;
+  const prepared = prepareNativeRequest(provider, endpoint, body, match[2], env);
   const capability = provider.capabilities.find((item) => item.endpoint === endpoint.id)?.id ?? endpoint.id;
-  const upstreamModel = model ? resolvedUpstreamModel(provider, model, env) : null;
-  const transformed = model ? transformRequestBody(provider, endpoint.path, upstreamModel!, { ...body, model: upstreamModel }, env) : body;
-  return proxySelected(request, env, context, "proxy_key", { provider, endpoint, model, capability, body: transformed, pathParams: nativeParams(endpoint, match[2]), method }, searchParamsRecord(new URL(request.url).searchParams), preauthenticated);
+  return proxySelected(request, env, context, "proxy_key", { provider, endpoint, model: prepared.model, capability, body: prepared.body, pathParams: prepared.pathParams, method }, searchParamsRecord(new URL(request.url).searchParams), preauthenticated);
 }
 
 export async function authenticateProxyKey(headers: Headers, env: Env): Promise<AuthorizedIdentity | Response> {
@@ -501,7 +499,7 @@ async function finalizeResponse(response: Response, env: Env, auth: AuthorizedId
 type Cost = EstimatedCost;
 type Tokens = UsageTokens;
 
-function estimateCost(model: CompiledModel | null, body: Record<string, unknown>, fixed: number | null | undefined, capability: string): Cost {
+export function estimateCost(model: CompiledModel | null, body: Record<string, unknown>, fixed: number | null | undefined, capability: string): Cost {
   if (capability === "llm.count_tokens") return { reserveMicros: 0, basis: "none", inputTokens: 0, outputTokens: 0 };
   if (fixed != null) return { reserveMicros: fixed, basis: "policy_fixed", inputTokens: null, outputTokens: null };
   const pricing = model?.pricing;

--- a/worker/test/discovery.test.mjs
+++ b/worker/test/discovery.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+import { providerById } from "../providers.ts";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (
+      specifier.startsWith(".") &&
+      context.parentURL &&
+      !extname(new URL(specifier, context.parentURL).pathname)
+    ) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { catalogModels } = await import("../discovery.ts");
+
+const fireworks = providerById("fireworks");
+assert.ok(fireworks);
+const endpoints = fireworks.endpoints.map((endpoint) => endpoint.id);
+
+test("budgeted proxy-key catalogs omit unpriced models without fixed request pricing", () => {
+  const models = catalogModels(fireworks, endpoints, {
+    enabled: true,
+    generation: "test",
+    providers: ["fireworks"],
+    monthlyBudgetMicros: 1_000_000,
+    requestCostMicros: null,
+  });
+
+  assert.ok(models.some((model) => model.id === "fireworks/glm-5.2"));
+  assert.ok(!models.some((model) => model.id === "fireworks/gpt-oss-120b"));
+});
+
+test("unpriced catalog models remain for unmetered, fixed-price, and Access scopes", () => {
+  const policies = [
+    { enabled: true, generation: "unmetered", providers: ["fireworks"], monthlyBudgetMicros: null, requestCostMicros: null },
+    { enabled: true, generation: "fixed", providers: ["fireworks"], monthlyBudgetMicros: 1_000_000, requestCostMicros: 25 },
+    null,
+  ];
+
+  for (const policy of policies) {
+    const models = catalogModels(fireworks, endpoints, policy);
+    assert.ok(models.some((model) => model.id === "fireworks/gpt-oss-120b"));
+  }
+});

--- a/worker/test/native-proxy.test.mjs
+++ b/worker/test/native-proxy.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+import { providerById } from "../providers.ts";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (
+      specifier.startsWith(".") &&
+      context.parentURL &&
+      !extname(new URL(specifier, context.parentURL).pathname)
+    ) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+const { estimateCost, prepareNativeRequest } = await import("../proxy.ts");
+
+const google = providerById("google-gemini");
+assert.ok(google);
+const streamGenerate = google.endpoints.find((endpoint) => endpoint.id === "stream_generate_content");
+assert.ok(streamGenerate);
+
+test("Google native path models use manifest pricing under a budgeted policy", () => {
+  const prepared = prepareNativeRequest(
+    google,
+    streamGenerate,
+    { contents: [{ role: "user", parts: [{ text: "hello" }] }] },
+    "/v1beta/models/gemini-3.5-flash:streamGenerateContent",
+    {},
+  );
+  const policy = { monthlyBudgetMicros: 1_000_000, requestCostMicros: null };
+  const cost = estimateCost(prepared.model, prepared.body, policy.requestCostMicros, "llm.stream");
+
+  assert.equal(prepared.model?.id, "google/gemini-3.5-flash");
+  assert.equal(prepared.body.model, undefined);
+  assert.deepEqual(prepared.pathParams, { model: "gemini-3.5-flash" });
+  assert.equal(cost.basis, "manifest_pricing");
+  assert.ok(cost.reserveMicros > 1);
+});
+
+test("Anthropic native body models remain rewritten in the body", () => {
+  const anthropic = providerById("anthropic");
+  assert.ok(anthropic);
+  const messages = anthropic.endpoints.find((endpoint) => endpoint.id === "messages");
+  assert.ok(messages);
+
+  const prepared = prepareNativeRequest(
+    anthropic,
+    messages,
+    { model: "anthropic/claude-sonnet-4-6", max_tokens: 16, messages: [{ role: "user", content: "hello" }] },
+    "/v1/messages",
+    {},
+  );
+
+  assert.equal(prepared.model?.id, "anthropic/claude-sonnet-4-6");
+  assert.equal(prepared.body.model, "claude-sonnet-4-6");
+  assert.deepEqual(prepared.pathParams, {});
+});
+
+test("native path models reject provider mismatches", () => {
+  assert.throws(
+    () => prepareNativeRequest(
+      google,
+      streamGenerate,
+      {},
+      "/v1beta/models/anthropic%2Fclaude-sonnet-4-6:streamGenerateContent",
+      {},
+    ),
+    (error) => error?.code === "model_provider_mismatch",
+  );
+});
+
+test("native path models reject body and path mismatches", () => {
+  assert.throws(
+    () => prepareNativeRequest(
+      google,
+      streamGenerate,
+      { model: "google/gemini-3.5-flash" },
+      "/v1beta/models/gemini-3.5-pro:streamGenerateContent",
+      {},
+    ),
+    (error) => error?.code === "model_path_mismatch",
+  );
+});


### PR DESCRIPTION
## Summary

Live testing the OpenClaw integration against production with a budgeted maintainer credential (`maintainer_access`, `monthlyBudgetMicros` set, no `requestCostMicros`) exposed two defects:

1. **Native path models never resolved for pricing.** `proxyNative` read the model only from `body.model`. Google Gemini native calls carry the model in the URL path (`/v1beta/models/<model>:streamGenerateContent`), so `selection.model` stayed null, `estimateCost` fell back to `flat_fallback`, and budgeted policies rejected every Google native call with 400 `pricing_required` even though the catalog model has versioned pricing (live-reproduced). On unmetered policies the same gap silently skipped manifest accounting (reserve = 1 micro).
2. **Budgeted proxy-key catalogs advertised guaranteed-400 models.** `/v1/catalog` included unpriced models (`azure-openai/deployment`, `fireworks/gpt-oss-120b`, `huggingface/gpt-oss-120b-fastest`, `openrouter/auto` in prod) for budgeted keys without fixed request pricing; clients like the bundled OpenClaw plugin advertised them and every call failed opaquely.

`proxyNative` now reuses `prepareManifestRequest` via `prepareNativeRequest` (path-param model resolution, provider/path mismatch validation, body-model rewrite semantics preserved for Anthropic-style body models), and the credential-scoped catalog omits unpriced models when the key's policy is budgeted with no `requestCostMicros`, so those keys fail closed at discovery. Access-session catalogs and admin/readiness surfaces are unchanged.

## Verification

- `worker/test/native-proxy.test.mjs`: Google native path model resolves with `manifest_pricing` basis under a budgeted policy; path param extraction; body stays model-free for path-templated endpoints; Anthropic body-model rewrite regression; mismatch validation.
- `worker/test/discovery.test.mjs`: unpriced models omitted only for budgeted no-fixed-price proxy scope; retained for unmetered, fixed-price, and Access-session scopes.
- Full worker suite: 87 passed, 0 failed. `pnpm provider:compile`: providers=21, models=32. Autoreview clean.
- Live repro before fix: `POST /v1/native/google-gemini/v1beta/models/gemini-3.5-flash:generateContent` with a budgeted key returned `pricing_required`; same call succeeds once the policy has fixed request pricing (interim prod mitigation: `maintainer_access` now sets `requestCostMicros=1000`).

## Deployment status

Not deployed. After merge, the next deploy picks it up; the interim `requestCostMicros` on `maintainer_access` can stay (it also unblocks unpriced tool routes like tavily/firecrawl) — with this fix Google native calls will use manifest pricing again since fixed pricing only applies as fallback... note: `estimateCost` prefers `requestCostMicros` when set, so if per-token Google accounting is preferred over flat pricing, clear `requestCostMicros` after adding pricing for the remaining unpriced models.

## Remaining risk

- Model-less native endpoints now default to `provider.models[0]` (same semantics as the manifest proxy); previously they kept `model=null` with flat fallback. Affects only single-model native endpoints without body/path model ids.
- Upstream 4xx before stream start is still wrapped as HTTP 200 + SSE `event: error` on OpenAI-compatible streaming routes (observed with Perplexity); tracked separately.
