### PR TITLE
feat(deploy): Docker self-host profile without a Cloudflare account

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.env*
+**/.env*
+.dev.vars*
+**/.dev.vars*
+.wrangler
+.wrangler*.toml
+**/node_modules
+admin/dist
+playwright-report
+test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  self-host:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and smoke self-host image
+        run: |
+          read -r admin_token < <(openssl rand -hex 32)
+          admin_hash="$(printf '%s' "$admin_token" | sha256sum | awk '{print $1}')"
+          docker build -f deploy/self-host/Dockerfile -t clawrouter-self-host:ci .
+          container_id="$(docker run -d -p 8787:8787 \
+            -e CLAWROUTER_ADMIN_TOKEN_SHA256="$admin_hash" \
+            clawrouter-self-host:ci)"
+          trap 'docker logs "$container_id"; docker rm -fv "$container_id" >/dev/null' EXIT
+          CLAWROUTER_BASE_URL=http://127.0.0.1:8787 \
+            CLAWROUTER_ADMIN_TOKEN="$admin_token" \
+            node scripts/smoke-self-host.mjs
+
   admin:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a supported Docker self-hosting profile with local workerd persistence, admin API bootstrap, end-to-end smoke coverage, and no Cloudflare account requirement.
 - Add self-service proxy-key creation, rotation, listing, and revocation for signed-in maintainers, constrained to caller-owned credentials and effective policies.
 - Preserve upstream HTTP errors as JSON 4xx/5xx responses before OpenAI-compatible streaming begins while retaining SSE error events after stream commitment.
 - Add opt-in per-maintainer budget quotas with principal-scoped ledgers, usage status, and admin breakdowns while preserving policy-wide defaults.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The isolated Cloudflare-native environment for AWS FakeCo clients is defined in
 profile, environment-scoped deploy credentials, a retention-off default, and a
 testable OpenAI-compatible OpenClaw/Crabhelm contract.
 
+## Self-hosting
+
+Run the complete Worker without a Cloudflare account using Docker, workerd, and
+filesystem persistence. See [Self-hosting ClawRouter](docs/self-hosting.md).
+
 ## Provider Registry
 
 Provider support is data-driven. Most integrations are added by creating one file:

--- a/deploy/self-host/.env.example
+++ b/deploy/self-host/.env.example
@@ -1,0 +1,10 @@
+# Required. SHA-256 digest only; keep the raw admin token in your secret manager.
+CLAWROUTER_ADMIN_TOKEN_SHA256=
+
+# Provider bindings are discovered from the compiled provider snapshot.
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# GOOGLE_API_KEY=
+
+# Extra custom Worker variable names to pass through, comma-separated.
+# CLAWROUTER_SELF_HOST_VARS=

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-slim AS build
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@11.5.1 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY admin/package.json admin/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm provider:compile -- --output worker/generated/provider-snapshot.json \
+  && pnpm --dir admin build
+
+FROM node:24-slim AS runtime
+
+ENV NODE_ENV=production \
+  WRANGLER_SEND_METRICS=false
+
+WORKDIR /app
+
+RUN mkdir -p /data \
+  && chown node:node /app /data
+
+COPY --from=build --chown=node:node /app /app
+
+USER node
+
+EXPOSE 8787
+VOLUME ["/data"]
+
+ENTRYPOINT ["node", "deploy/self-host/entrypoint.mjs"]

--- a/deploy/self-host/README.md
+++ b/deploy/self-host/README.md
@@ -1,0 +1,4 @@
+# ClawRouter self-hosting
+
+Docker Compose quickstart, administration, persistence, and limitations:
+[Self-hosting ClawRouter](../../docs/self-hosting.md).

--- a/deploy/self-host/docker-compose.yml
+++ b/deploy/self-host/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  clawrouter:
+    image: clawrouter-self-host:latest
+    build:
+      context: ../..
+      dockerfile: deploy/self-host/Dockerfile
+    ports:
+      - "127.0.0.1:8787:8787"
+    volumes:
+      - clawrouter-data:/data
+    env_file:
+      - .env
+    restart: unless-stopped
+
+volumes:
+  clawrouter-data:

--- a/deploy/self-host/entrypoint.mjs
+++ b/deploy/self-host/entrypoint.mjs
@@ -1,0 +1,103 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const configPath = join(root, ".wrangler.self-host.toml");
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+
+export function renderSelfHostConfig(source) {
+  const output = [];
+  let skippingSection = false;
+  for (const line of source.split(/\r?\n/)) {
+    if (/^\s*(?:\[build\]|\[\[routes\]\])\s*(?:#.*)?$/.test(line)) {
+      skippingSection = true;
+      continue;
+    }
+    if (skippingSection && /^\s*\[/.test(line)) {
+      skippingSection = false;
+    }
+    if (!skippingSection) output.push(line);
+  }
+  return `${output.join("\n").trim()}\n\n[[kv_namespaces]]\nbinding = "POLICY_KV"\nid = "self-host-local"\n`;
+}
+
+export function selfHostVariableNames(providerSnapshot, env) {
+  const names = new Set(
+    providerSnapshot.providers.flatMap((provider) => provider.config_keys ?? []),
+  );
+  for (const name of (env.CLAWROUTER_SELF_HOST_VARS ?? "").split(",")) {
+    const trimmed = name.trim();
+    if (!trimmed) continue;
+    if (!/^[A-Z][A-Z0-9_]*$/.test(trimmed)) {
+      throw new Error(`invalid variable name in CLAWROUTER_SELF_HOST_VARS: ${trimmed}`);
+    }
+    if (trimmed === "CLAWROUTER_ADMIN_TOKEN") {
+      throw new Error(
+        "CLAWROUTER_ADMIN_TOKEN cannot be passed to the Worker; configure only its SHA-256 digest",
+      );
+    }
+    names.add(trimmed);
+  }
+  names.delete("CLAWROUTER_ADMIN_TOKEN_SHA256");
+  return [...names]
+    .filter((name) => env[name] !== undefined && env[name] !== "")
+    .sort();
+}
+
+function main() {
+  const adminTokenSha256 = process.env.CLAWROUTER_ADMIN_TOKEN_SHA256?.trim();
+  if (!adminTokenSha256) {
+    fail("CLAWROUTER_ADMIN_TOKEN_SHA256 is required; set it to the SHA-256 digest of the admin bearer token");
+  }
+  if (!/^[a-f0-9]{64}$/i.test(adminTokenSha256)) {
+    fail("CLAWROUTER_ADMIN_TOKEN_SHA256 must be a 64-character hexadecimal SHA-256 digest");
+  }
+
+  const sourceConfig = readFileSync(join(root, "wrangler.toml"), "utf8");
+  writeFileSync(configPath, renderSelfHostConfig(sourceConfig), { mode: 0o600 });
+
+  const snapshot = JSON.parse(
+    readFileSync(join(root, "worker/generated/provider-snapshot.json"), "utf8"),
+  );
+  const variableNames = selfHostVariableNames(snapshot, process.env);
+  const args = [
+    "dev",
+    "--local",
+    "--ip",
+    "0.0.0.0",
+    "--port",
+    "8787",
+    "--persist-to",
+    "/data",
+    "--config",
+    configPath,
+    "--var",
+    `CLAWROUTER_ADMIN_TOKEN_SHA256:${adminTokenSha256}`,
+  ];
+  // Wrangler redacts secret-shaped bindings; --var makes Docker env explicit to local workerd.
+  for (const name of variableNames) {
+    args.push("--var", `${name}:${process.env[name]}`);
+  }
+
+  const child = spawn(join(root, "node_modules/.bin/wrangler"), args, {
+    cwd: root,
+    env: { ...process.env, WRANGLER_SEND_METRICS: "false" },
+    stdio: "inherit",
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+  child.on("error", (error) => fail(`could not start Wrangler: ${error.message}`));
+  child.on("exit", (code) => {
+    process.exitCode = code ?? 1;
+  });
+}
+
+function fail(message) {
+  console.error(`clawrouter self-host: ${message}`);
+  process.exit(1);
+}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,107 @@
+# Self-hosting ClawRouter with Docker
+
+This profile runs the stock ClawRouter Worker on Cloudflare's open-source
+workerd runtime. It uses Wrangler's local implementations of Durable Objects,
+KV, queues, and R2. Durable Objects, KV, and R2 use filesystem persistence;
+the local queue broker is memory-only. No Cloudflare account or Cloudflare
+network connection is involved.
+
+## Quickstart
+
+Requirements: Docker with Compose, Node.js 24, and OpenSSL.
+
+Generate an admin bearer token, retain the raw value in your secret manager,
+and write only its SHA-256 digest to the container environment:
+
+```sh
+read -r CLAWROUTER_ADMIN_TOKEN < <(openssl rand -hex 32)
+export CLAWROUTER_ADMIN_TOKEN
+export CLAWROUTER_ADMIN_TOKEN_SHA256="$(printf '%s' "$CLAWROUTER_ADMIN_TOKEN" | openssl dgst -sha256 | awk '{print $2}')"
+install -m 600 /dev/null deploy/self-host/.env
+printf 'CLAWROUTER_ADMIN_TOKEN_SHA256=%s\n' "$CLAWROUTER_ADMIN_TOKEN_SHA256" > deploy/self-host/.env
+docker compose -f deploy/self-host/docker-compose.yml up --build -d
+```
+
+Compose publishes port 8787 on host loopback only. Keep bearer tokens on a
+trusted host. For remote access, put an authenticated HTTPS reverse proxy in
+front of `127.0.0.1:8787`; do not publish the plaintext port directly.
+
+Provider bindings declared by the compiled provider snapshot are passed to the
+Worker when they are present in `deploy/self-host/.env`. For example:
+
+```dotenv
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+```
+
+For a custom manifest or another intentional Worker variable, add its name to
+the comma-separated `CLAWROUTER_SELF_HOST_VARS` value. Never add the raw
+`CLAWROUTER_ADMIN_TOKEN`; the Worker receives only its digest.
+
+## Create a proxy key
+
+The normal key helper uses the running Worker's admin bearer-token API. It does
+not use Wrangler, Cloudflare credentials, or direct local KV mutation unless
+`--local` is explicitly supplied.
+
+```sh
+export CLAWROUTER_BASE_URL=http://localhost:8787
+read -r CLAWROUTER_PROXY_SECRET < <(openssl rand -hex 24)
+export CLAWROUTER_PROXY_SECRET
+printf '%s' "$CLAWROUTER_PROXY_SECRET" | node scripts/key-put.mjs \
+  --kid self_host \
+  --secret-stdin \
+  --providers firecrawl \
+  --request-cost-micros 1
+export CLAWROUTER_KEY="clawrouter-live-self_host-$CLAWROUTER_PROXY_SECRET"
+```
+
+`firecrawl` is usable without a provider key at its upstream free rate limit.
+Choose another provider after adding its required configuration to the env
+file, then recreate the container so it receives the new environment:
+
+```sh
+docker compose -f deploy/self-host/docker-compose.yml up -d --force-recreate
+```
+
+## Smoke test
+
+```sh
+curl --fail http://localhost:8787/v1/health
+curl --fail http://localhost:8787/v1/catalog \
+  -H "authorization: Bearer $CLAWROUTER_KEY"
+
+CLAWROUTER_BASE_URL=http://localhost:8787 \
+CLAWROUTER_ADMIN_TOKEN="$CLAWROUTER_ADMIN_TOKEN" \
+node scripts/smoke-self-host.mjs
+```
+
+The smoke script creates a temporary policy and credential through the admin
+API, verifies its scoped catalog, and revokes it.
+
+## Persistence, backup, and upgrades
+
+Durable Object, KV, and R2 state lives under `/data`, backed by the named
+Compose volume `clawrouter-data`. Stop the container before taking a
+filesystem-consistent backup of that volume. Losing it loses policies, proxy
+credentials, grants, budgets, settled usage records, and retained content.
+Pending, delayed, or retrying local queue messages are memory-only and are lost
+on a crash or restart; drain request traffic before planned maintenance.
+
+To upgrade a source checkout, back up `/data`, pull the new source, review the
+release notes, then pull fresh base layers, rebuild, and restart:
+
+```sh
+docker compose -f deploy/self-host/docker-compose.yml build --pull
+docker compose -f deploy/self-host/docker-compose.yml up -d
+```
+
+## Version 1 limitations
+
+Cloudflare Access is absent. Console sign-in, browser OAuth, and GitHub
+maintainer auto-provisioning are unavailable. Manage the service through the
+admin bearer-token API and repository scripts; clients use normal proxy keys.
+The dashboard and Access-session endpoints remain fail-closed without an Access
+identity. This profile is one local workerd process and does not provide
+Cloudflare's distributed availability, durable queue delivery, or managed
+backups.

--- a/scripts/smoke-self-host.mjs
+++ b/scripts/smoke-self-host.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { createHash, randomBytes } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+import { adminRequest } from "./admin-api.mjs";
+
+const baseUrl = requiredEnv("CLAWROUTER_BASE_URL").replace(/\/$/, "");
+requiredEnv("CLAWROUTER_ADMIN_TOKEN");
+
+const suffix = randomBytes(6).toString("hex");
+const credentialId = `self_host_smoke_${suffix}`;
+const proxySecret = randomBytes(24).toString("base64url");
+const proxyKey = `clawrouter-live-${credentialId}-${proxySecret}`;
+let created = false;
+
+try {
+  const health = await waitForHealth();
+  assert.equal(health.ok, true, "health response must report ok");
+
+  await adminRequest(`/v1/admin/keys/${credentialId}`, {
+    method: "PUT",
+    body: {
+      enabled: true,
+      providers: ["firecrawl"],
+      allProviders: false,
+      tenantId: "self-host-smoke",
+      secretSha256: createHash("sha256").update(proxySecret).digest("hex"),
+      requestCostMicros: 1,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+  created = true;
+
+  const catalogResponse = await fetch(`${baseUrl}/v1/catalog`, {
+    headers: { authorization: `Bearer ${proxyKey}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  const catalog = await catalogResponse.json();
+  assert.equal(catalogResponse.status, 200, JSON.stringify(catalog));
+  assert.ok(
+    catalog.providers?.some((provider) => provider.id === "firecrawl"),
+    "credential-scoped catalog must include firecrawl",
+  );
+
+  await revoke();
+  created = false;
+  console.log("self-host smoke ok: health, admin mutation, scoped catalog, revocation");
+} finally {
+  if (created) await revoke();
+}
+
+async function waitForHealth() {
+  const deadline = Date.now() + 30_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/v1/health`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+      const body = await response.json();
+      if (response.ok) return body;
+      lastError = new Error(`health returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(500);
+  }
+  throw new Error(`self-host health did not become ready: ${lastError?.message ?? "timeout"}`);
+}
+
+async function revoke() {
+  await adminRequest(`/v1/admin/keys/${credentialId}/revoke`, {
+    method: "POST",
+    signal: AbortSignal.timeout(10_000),
+  });
+  await adminRequest(`/v1/admin/policies/${credentialId}/revoke`, {
+    method: "POST",
+    signal: AbortSignal.timeout(10_000),
+  });
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}

--- a/test/self-host-entrypoint.test.mjs
+++ b/test/self-host-entrypoint.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  renderSelfHostConfig,
+  selfHostVariableNames,
+} from "../deploy/self-host/entrypoint.mjs";
+
+test("self-host config removes custom routes and adds local policy KV", () => {
+  const rendered = renderSelfHostConfig(`name = "clawrouter"
+
+[build]
+command = "pnpm build"
+
+[[routes]]
+pattern = "example.com"
+custom_domain = true
+
+[vars]
+EXAMPLE = "kept"
+`);
+
+  assert.doesNotMatch(rendered, /\[\[routes\]\]/);
+  assert.doesNotMatch(rendered, /\[build\]/);
+  assert.doesNotMatch(rendered, /pnpm build/);
+  assert.match(rendered, /\[vars\]\nEXAMPLE = "kept"/);
+  assert.match(
+    rendered,
+    /\[\[kv_namespaces\]\]\nbinding = "POLICY_KV"\nid = "self-host-local"/,
+  );
+});
+
+test("self-host vars include configured provider and explicit custom bindings", () => {
+  const snapshot = {
+    providers: [
+      { config_keys: ["OPENAI_API_KEY", "OPENAI_BASE_URL"] },
+      { config_keys: ["ANTHROPIC_API_KEY"] },
+    ],
+  };
+  const names = selfHostVariableNames(snapshot, {
+    OPENAI_API_KEY: "test",
+    ANTHROPIC_API_KEY: "",
+    CUSTOM_BINDING: "custom",
+    CLAWROUTER_SELF_HOST_VARS: "CUSTOM_BINDING",
+  });
+
+  assert.deepEqual(names, ["CUSTOM_BINDING", "OPENAI_API_KEY"]);
+  assert.throws(
+    () =>
+      selfHostVariableNames(snapshot, {
+        CLAWROUTER_ADMIN_TOKEN: "test",
+        CLAWROUTER_SELF_HOST_VARS: "CLAWROUTER_ADMIN_TOKEN",
+      }),
+    /cannot be passed to the Worker/,
+  );
+});


### PR DESCRIPTION
## Summary

Supported self-hosting path without a Cloudflare account (closes #97). The stock Worker already runs on the open-source workerd runtime via `wrangler dev --local` with filesystem persistence — this packages that as a first-class deployment profile, with zero worker runtime changes:

- `deploy/self-host/Dockerfile` — multi-stage Node 24 build (pnpm-pinned, provider snapshot + admin UI compiled in), non-root runtime, offline-capable (no package downloads at start; verified with `--network none`), `/data` volume for Durable Object/KV persistence.
- `deploy/self-host/entrypoint.mjs` — renders a self-host wrangler config (strips the Cloudflare route/build sections, adds a local KV binding), requires `CLAWROUTER_ADMIN_TOKEN_SHA256` (validated digest; refuses the raw token), and forwards only provider-snapshot config keys plus an explicitly allowlisted `CLAWROUTER_SELF_HOST_VARS` list.
- `deploy/self-host/docker-compose.yml` + `.env.example` — loopback port mapping, env file, volume.
- `docs/self-hosting.md` — quickstart (admin token digest, compose up, seeding policies/keys via the admin API with `scripts/key-put.mjs` — no Cloudflare credentials involved), backup/upgrade, and explicit v1 limitations (no Cloudflare Access → no console sign-in or GitHub maintainer auto-provisioning; management via admin bearer token; data plane uses normal proxy keys).
- `scripts/smoke-self-host.mjs` — health → admin policy+credential seed → scoped catalog with the issued key → revocation → cleanup; wired into CI as a Docker build+run job with no Cloudflare secrets.

## Verification

- `pnpm check` clean on the rebased branch (worker 117, admin 26, scripts 74 — includes new entrypoint config/variable-forwarding tests).
- Live local proof: image built, container reached ready offline, smoke passed end-to-end (`self-host smoke ok: health, admin mutation, scoped catalog, revocation`); `.env*`/`.dev.vars*` verified absent from the image.
- Autoreview (codex gpt-5.6-sol): clean; accepted findings fixed during the cycle (secret-file exclusions, loopback binding, offline startup, compose lifecycle, 0600 env file, full smoke cleanup).

## Deployment status

No production impact — additive packaging/docs/CI only; the Cloudflare deployment path is untouched.

## Remaining risk

- Self-host v1 has no console sessions (Cloudflare Access absent); documented as a limitation with the admin-API workflow. A token-based console login could follow if demand materializes.
- workerd local persistence lives under `/data`; queue delivery uses wrangler dev's local queue simulation — documented durability wording reflects that.
