### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,305 +1,88 @@
-# ClawRouter
+# ClawRouter 🦞 — One key, many upstreams.
 
-ClawRouter is a high-throughput API gateway and provider router for OpenClaw services.
+[![CI](https://img.shields.io/github/actions/workflow/status/openclaw/clawrouter/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/openclaw/clawrouter/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/openclaw/clawrouter?style=flat-square)](https://github.com/openclaw/clawrouter/releases/latest)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D24-339933?style=flat-square&logo=nodedotjs)](https://nodejs.org/)
+[![License](https://img.shields.io/github/license/openclaw/clawrouter?style=flat-square)](LICENSE)
 
-It brokers proxy keys, service identities, versioned upstream grants, budgets, and metered usage across model providers, search APIs, tool APIs, and future service providers.
+ClawRouter is a provider-neutral API gateway for OpenClaw deployments. It routes policy-scoped credentials across model and tool providers while enforcing access, revocation, budgets, request retention, and metered usage.
 
-Current implementation target:
+## Install
 
-- TypeScript data plane on Cloudflare Workers
-- Durable Object budget ledgers
-- serialized Durable Object access-control authority
-- tenant/policy-sharded Durable Object usage ledgers
-- TypeScript admin/control UI
-- declarative service provider manifests
-- OpenClaw-native `clawrouter-` key routing
-- Cloudflare KV-backed one-time migration seeds, version 1
-  API-key/OAuth/subscription grants, assignment rules, and provider health
+ClawRouter is distributed from source. Local development requires Node.js 24 or newer and the pnpm version declared in `package.json`.
 
-## OpenClaw client
+```sh
+git clone https://github.com/openclaw/clawrouter.git
+cd clawrouter
+corepack enable
+pnpm install --frozen-lockfile
+```
 
-OpenClaw includes a bundled `@openclaw/clawrouter` plugin. One policy-scoped
-credential discovers allowed models, routes supported OpenAI-compatible and
-native provider protocols, and reports managed budget usage without installing
-or authenticating every upstream provider plugin on the OpenClaw host.
+For a complete service without a Cloudflare account, use the [Docker self-hosting profile](docs/self-hosting.md). It requires Docker with Compose and OpenSSL.
 
-See [Use ClawRouter with OpenClaw](docs/openclaw.md) for credential setup,
-dynamic model discovery, multi-provider smoke tests, and quota verification.
+## Quick start
 
-The isolated Cloudflare-native environment for AWS FakeCo clients is defined in
-[FakeCo staging](docs/fakeco.md). It has a locked Worker/hostname/resource
-profile, environment-scoped deploy credentials, a retention-off default, and a
-testable OpenAI-compatible OpenClaw/Crabhelm contract.
+Run the local end-to-end Worker smoke:
 
-## Self-hosting
+```sh
+pnpm worker:e2e
+```
 
-Run the complete Worker without a Cloudflare account using Docker, workerd, and
-filesystem persistence. See [Self-hosting ClawRouter](docs/self-hosting.md).
+The smoke starts a local Worker and fixture upstream, exercises discovery, authentication, routing, budgets, failover, retention, usage, and admin paths, then removes its temporary state.
 
-## Provider Registry
+## Routing
 
-Provider support is data-driven. Most integrations are added by creating one file:
+Clients authenticate with one policy-scoped `clawrouter-` credential. The selected policy controls which providers and models are visible, how upstream grants are chosen, what budget applies, and whether request content is retained.
+
+| Surface | Path |
+| --- | --- |
+| OpenAI-compatible chat, responses, and embeddings | `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings` |
+| Anthropic messages | `/v1/messages`, `/v1/messages/count_tokens` |
+| Manifest-defined APIs | `/v1/proxy/<provider>/<endpoint>` |
+| Provider-native APIs | `/v1/native/<provider>/<provider-native-path>` |
+| Credential-scoped discovery | `/v1/models`, `/v1/catalog` |
+| Usage and key status | `/v1/usage`, `/v1/key/inspect` |
+
+Models use provider-qualified IDs such as `openai/gpt-4.1-mini`. `GET /v1/catalog` reports only the providers, models, and transports the caller can execute. See the [API reference](docs/api-reference.md) for the complete route inventory and authentication boundaries.
+
+## Provider catalog
+
+Provider support starts with one manifest:
 
 ```text
 providers/<service>.provider.yaml
 ```
 
-That file declares the service id, auth scheme, OAuth platform mapping when needed,
-base URLs, route templates, adapter family, model/capability mapping, and billing
-meters. The TypeScript compiler turns those files into a provider snapshot consumed by
-the edge runtime and admin UI.
+The compiler validates auth schemes, routes, request and response formats, capabilities, models, pricing, and billing meters, then emits the snapshot shared by the Worker and admin console. Add a focused TypeScript adapter only when a manifest cannot express the provider safely. See [Service providers](providers/README.md) for the schema and mapping rules.
 
-Built-in starter coverage:
+Amazon Bedrock uses native SigV4-signed `InvokeModel` routes rather than OpenAI normalization; its IAM and request contract are documented separately in [Amazon Bedrock](docs/aws-bedrock.md). The optional `clawrouter/fusion` model combines several adviser calls with one synthesizer through the normal policy and accounting path; see [Fusion routing](docs/fusion-router.md).
 
-- model APIs: OpenAI, Anthropic, Google Gemini, Azure OpenAI, AWS Bedrock,
-  MiniMax, Mistral, Cohere, xAI, Groq, Perplexity, DeepSeek, Together, Fireworks,
-  Hugging Face, Replicate, and operator-hosted OpenAI-compatible runtimes such as
-  Ollama and LM Studio
-- gateway APIs: OpenRouter, Cloudflare AI Gateway
-- tool/API platforms: Tavily, Firecrawl (keyless starter access; API key
-  optional for higher limits)
+## Policy and accounting
 
-Amazon Bedrock support signs native `InvokeModel` and
-`InvokeModelWithResponseStream` calls from the Cloudflare Worker. It uses
-model-specific JSON rather than OpenAI or Converse normalization. See
-[Amazon Bedrock](docs/aws-bedrock.md) for IAM, credentials, Region, policy,
-headers, invocation, smoke-test, and limitation details.
+Revocation-critical policy and credential state lives in serialized Durable Object authority. Budget reservations happen before upstream work, successful responses settle to actual metered cost, and failed settlement or audit delivery retries independently without hiding the provider response.
 
-Validate the catalog with:
+Usage ledgers retain bounded request metadata, not prompts or completions. Policies can enable request-content retention in a separate R2 archive. The [architecture](docs/architecture.md), [content-retention contract](docs/content-retention.md), and [agent spend-control guide](docs/agent-spend-control.md) describe those boundaries.
 
-```sh
-pnpm provider:compile
-```
+## Deployment
 
-Before a real Cloudflare deploy, run:
+| Target | Guide |
+| --- | --- |
+| Docker and local workerd persistence | [Self-hosting](docs/self-hosting.md) |
+| Cloudflare Workers, Durable Objects, KV, queues, R2, and Access | [Deploy on Cloudflare](docs/deploy-cloudflare.md) |
+| OpenClaw client configuration and quota checks | [Use with OpenClaw](docs/openclaw.md) |
+| Isolated non-production Cloudflare profile | [FakeCo staging](docs/fakeco.md) |
+
+The Docker profile exposes port 8787 on host loopback and persists Durable Objects, KV, and R2 under a named volume. The Cloudflare profile adds distributed queues, managed storage, and an Access-protected browser console.
+
+## Development
 
 ```sh
-pnpm cf:doctor
+pnpm build
+pnpm check
 ```
 
-It checks Wrangler auth, required GitHub Actions secret names, local deploy env,
-provider binding coverage, and the all-provider smoke plan without printing
-secret values. Real deploys require at least one live golden-provider smoke;
-the result is persisted in `POLICY_KV` so readiness distinguishes verified,
-failed, stale, unverified, and disabled providers.
+`pnpm build` compiles the provider snapshot and admin UI, then typechecks the Worker. `pnpm check` runs Worker, admin, and script tests.
 
-The browser console is meant to sit behind Cloudflare Access. Provision that
-edge gate with:
+## License
 
-```sh
-CLOUDFLARE_ACCOUNT_ID=... \
-CLOUDFLARE_API_TOKEN=... \
-CLAWROUTER_ACCESS_GITHUB_ORGS=openclaw \
-CLAWROUTER_ACCESS_ADMIN_EMAILS=you@example.com \
-pnpm cf:access
-```
-
-Then redeploy with the printed `CLAWROUTER_ACCESS_TEAM_DOMAIN` and
-`CLAWROUTER_ACCESS_AUD` values. `/` redirects to the Access-protected
-`/dashboard` path, `/dashboard` redirects to the role-aware `/dashboard/home`, and canonical console views live under `/dashboard/*`, while
-public `/v1` catalog and proxy routes stay normal. The Access app must also
-protect `/v1/session*`, `/v1/playground/*`, `/v1/admin/*`, and
-`/v1/oauth/callback` so the browser console can bootstrap identity,
-entitlements, session quota usage, playground calls, admin mutations, and OAuth callbacks from a
-verified Access session. A ClawRouter `access_session_required` JSON body on
-`/dashboard/*`, `/v1/session`, `/v1/session/usage`, `/v1/playground/*`, or `/v1/oauth/callback` means the Access app is not
-in front of that console path yet, and `pnpm cf:smoke` treats that as a failed
-deployment smoke.
-
-The `Deploy Cloudflare` workflow can do the Access step too: dispatch it with
-`provision_access=true` after adding a `CLOUDFLARE_API_TOKEN` that can manage
-Zero Trust Access apps and policies. The production default admits verified
-members of the `openclaw` GitHub organization through the configured GitHub
-identity provider. GitHub organization and team assignment rules use that
-same-origin, verified Access identity to bind or revoke the user's managed
-policy; no browser-supplied organization claim is trusted. Real deploys also require KV write
-permission because Wrangler validates the Worker `POLICY_KV` binding while
-publishing. Keep `access_domain` set to the console hostname; `worker_url` is
-only the post-deploy smoke-test target.
-
-## Edge Proxy
-
-The Worker currently exposes:
-
-- `GET /v1/health`
-- `GET /v1/providers`
-- `GET /v1/routes`
-- `GET /v1/session`
-- `GET /v1/entitlements`
-- `GET /v1/me`
-- `GET /v1/usage`
-- `GET /v1/models`
-- `GET /v1/catalog`
-- `GET /v1/oauth/callback`
-- `GET /v1/key/inspect`
-- `POST /v1/chat/completions`
-- `POST /v1/responses`
-- `POST /v1/embeddings`
-- `POST /v1/messages`
-- `POST /v1/messages/count_tokens`
-- `POST /v1/proxy/<provider>/<endpoint>`
-- `<METHOD> /v1/native/<provider>/<provider-native-path>`
-- `GET /v1/admin/overview`
-- `GET /v1/admin/bootstrap`
-- `GET /v1/admin/tenants`
-- `GET /v1/admin/usage`
-- `GET /v1/admin/policies`
-- `GET /v1/admin/credentials`
-- `GET /v1/admin/connections`
-- `GET /v1/admin/access-users`
-- `GET /v1/admin/policy-bindings`
-- `GET /v1/admin/provider-status`
-- `GET /v1/admin/provider-health`
-- `GET /v1/admin/upstream-grants`
-- `GET /v1/admin/assignment-rules`
-- `GET /v1/admin/fusion`
-- `PUT /v1/admin/access-users/<email>`
-- `PUT /v1/admin/access-user-grants/<email>`
-- `PUT /v1/admin/policy-bindings`
-- `PUT /v1/admin/policies/<policy-id>`
-- `PUT /v1/admin/credentials/<credential-id>`
-- `PUT /v1/admin/connections/<provider-id>`
-- `PUT /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>`
-- `PUT /v1/admin/assignment-rules/<rule-id>`
-- `PUT /v1/admin/fusion`
-- `POST /v1/admin/policies/<policy-id>/revoke`
-- `POST /v1/admin/credentials/<credential-id>/revoke`
-- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/revoke`
-- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/refresh`
-- `POST /v1/admin/upstream-grants/<policies|tenants>/<scope-id>/<token-ref>/authorize`
-- `POST /v1/admin/assignment-rules/reconcile`
-
-Legacy `GET|PUT /v1/admin/keys...`, `POST /v1/admin/keys/<kid>/revoke`, and
-`GET /v1/admin/users` remain compatibility aliases during migration. New
-control-plane clients should use policies, credentials, and tenants directly.
-The legacy revoke alias treats `<kid>` as a credential id and never disables a
-shared policy.
-
-OpenAI-compatible proxy requests route by the request body `model` field, for
-example `openai/gpt-4.1-mini`. Before an upstream provider secret is used, the
-Worker verifies the issued credential and its policy from serialized
-`ACCESS_CONTROL` Durable Object authority. `credentials/<credential-id>` and
-`policies/<policy-id>` in `POLICY_KV` are one-time migration seeds:
-
-```json
-{"enabled":true,"secretSha256":"<sha256 of key secret>","policyId":"team_docs","policyGeneration":"policy_..."}
-```
-
-```json
-{
-  "enabled": true,
-  "generation": "policy_...",
-  "providers": ["openai"],
-  "allProviders": false,
-  "tenantId": "team_docs",
-  "tokenRole": "service",
-  "monthlyBudgetMicros": 100000000
-}
-```
-
-Policy and credential generations must match. Strongly consistent authority
-writes make revocation and scope reductions immediate; generation mismatches
-still fail closed during migration or incomplete rotations. Canonical policy
-edits preserve their generation. The legacy key mutation alias rejects changing
-policy scope and secret together.
-
-`clawrouter/fusion` is an optional virtual chat model. Selecting it fans a
-bounded text-only prompt out to as many as four configured adviser models,
-then asks one configured synthesizer model for the final response. Every
-subrequest uses normal ClawRouter policy, budget, retention, readiness, and
-usage-accounting paths. Configure it under **Access → Fusion**; see
-[Fusion routing](docs/fusion-router.md) for architecture, local-runtime setup,
-security boundaries, and cost behavior.
-
-`GET /v1/catalog` is the credential-scoped client integration contract. It
-returns only allowed providers and executable models. Each provider row reports
-whether the unified OpenAI-compatible `/v1` route is available, its native proxy
-base URL, and the request/response formats for its executable native routes.
-Clients can use those fields to choose the real provider transport without
-guessing from provider ids.
-
-Disable a credential to revoke one issued key, disable a policy to revoke every
-user and credential bound to it, or disable a provider connection to stop that
-provider globally. Legacy `keys/<kid>` records remain readable during
-migration only when they are genuine pre-migration records. Generation-bearing
-compatibility records stay disabled and are never authorization fallback. See
-`docs/deploy-cloudflare.md` for Cloudflare provisioning, deployment, key
-registration, and smoke commands.
-
-The legacy-named `pnpm cf:oauth:put` and `pnpm cf:oauth:revoke` helpers write
-canonical version 1 upstream-grant records for `api_key`, `oauth`, and
-`subscription` connections. They accept access tokens, refresh tokens, and
-single- or multi-field credentials only through stdin, environment variables,
-or files, never argv.
-Revocation retains grant metadata in a disabled tombstone while removing
-secrets. See `docs/deploy-cloudflare.md` for the complete operator flow.
-
-The admin API and console can register multiple token references for the same
-scope and provider. ClawRouter maintains a bounded pool index outside the
-secret-bearing grant records, prefers the lowest numeric `priority`, and uses
-the canonical grant key as the deterministic tie-breaker. Existing grants
-whose token reference is the provider id remain compatible without an index.
-
-Admin endpoints accept a verified Cloudflare Access admin session or
-`Authorization: Bearer <admin-token>` against `CLAWROUTER_ADMIN_TOKEN_SHA256`.
-Provider-approved browser OAuth starts only from a verified Access admin
-session, uses a one-time PKCE state, and stores the resulting grant without
-returning provider tokens to the browser.
-The browser console hashes generated proxy key secrets in-browser before
-issuing a credential, manages policies separately from credentials and provider
-connections, assigns explicit user/group policy bindings, shows provider
-readiness and request audit, and includes a Cloudflare Access-backed playground
-for model and manifest-proxy service routes. Admin rights come from the Access
-admin allowlist, not editable user rows, and do not imply provider access.
-
-Generic REST/tool proxy requests are manifest-driven:
-
-```sh
-curl "$CLAWROUTER_BASE_URL/v1/proxy/tavily/search" \
-  -H "authorization: Bearer $CLAWROUTER_KEY" \
-  -H "content-type: application/json" \
-  --data '{"body":{"query":"openclaw"},"query":{"topic":"news"}}'
-```
-
-The Worker resolves `provider` and `endpoint` from the compiled provider
-snapshot, applies manifest path/query/header/auth mapping, forwards the request,
-and emits a usage event to `USAGE_QUEUE`. The same Worker consumes that queue
-into tenant/policy-sharded, bounded `USAGE_LEDGER` reporting Durable Objects and
-replays unsettled budget updates. Audit events retain identity, policy,
-credential, provider, route capability, model, timing, outcome, tokens when
-safely available, cost, the canonical request ID, and validated W3C trace/span
-IDs for 30 days. Every owned response echoes the canonical `X-Request-ID`, and
-CORS exposes it to browser clients. Prompt and completion bodies are never
-stored in the usage ledger. LLM request bodies are stored separately for
-30 days when the access policy enables request-content retention (the default)
-and the credential owner is not exempt; see [Content retention](docs/content-retention.md).
-`/v1/usage` returns the caller policy's
-budget plus usage summary; `/v1/admin/usage` returns budget rows plus the
-all-tenant usage summary and recent request audit.
-
-Budgeted requests reserve an upper-bound token cost before the upstream call
-when the selected model has versioned pricing in its provider manifest. An
-explicit policy `requestCostMicros` remains a fixed-cost override; unpriced
-routes retain the one-micro fallback only outside monthly budgets. Budgeted
-calls without versioned pricing fail closed. Successful responses settle
-their actual token cost, including cached input when reported. SSE responses are metered
-inline without buffering the client stream. Missing or interrupted usage stays
-charged at the conservative reservation; non-2xx and transport failures refund
-the reservation. Failed settlement calls are persisted to `USAGE_QUEUE` for
-durable retry while the reservation remains charged fail-closed. Settlement and
-audit delivery are independent: failure of either cannot suppress the provider
-response or the other accounting operation. Messages that exhaust automatic retries move to the
-separate usage DLQ for operator inspection and replay before Cloudflare's
-four-day unconsumed-DLQ retention expires. Internal reservation ids are
-generated independently from caller-supplied request ids.
-
-Codex and Claude Code integration, pricing fields, reservation semantics, and
-agent attribution headers are documented in
-[`docs/agent-spend-control.md`](docs/agent-spend-control.md).
-OAuth, SigV4, and deployment-templated providers execute through the same
-policy-enforced proxy when their manifest-declared grant and remaining runtime
-configuration are present. Provider secrets can come from scoped upstream
-grants instead of Worker-global bindings.
-
-Control-plane boundaries, migration rules, refresh behavior, and failure
-semantics are summarized in [Architecture](docs/architecture.md).
+MIT. See [LICENSE](LICENSE).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,131 @@
+# API reference
+
+ClawRouter serves discovery, proxy, session, and administration APIs from one Worker. This page lists the HTTP surface; deployment and resource configuration live in [Deploy ClawRouter on Cloudflare](deploy-cloudflare.md), and state ownership and failure behavior live in [Architecture](architecture.md).
+
+## Authentication
+
+Proxy credentials use `Authorization: Bearer <clawrouter-key>`. Authentication resolves the issued credential and its policy from the serialized `ACCESS_CONTROL` Durable Object authority before any provider secret is used.
+
+Browser session, playground, and OAuth routes require a verified Cloudflare Access session. Admin routes accept that verified session for configured admins or `Authorization: Bearer <admin-token>` against `CLAWROUTER_ADMIN_TOKEN_SHA256`. Admin status does not grant provider access, and provider access does not grant admin status.
+
+The Docker self-hosting profile has no Cloudflare Access identity. Its admin API uses the bearer token, and clients use normal proxy credentials.
+
+## Discovery and client routes
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/health` | Service health and observability mode |
+| `GET` | `/v1/providers` | Compiled provider snapshot |
+| `GET` | `/v1/routes` | Compiled OpenAI-compatible, manifest, and native route catalog |
+| `GET` | `/v1/models` | OpenAI-style model list scoped to the proxy credential |
+| `GET` | `/v1/catalog` | Executable providers, models, formats, and transports scoped to the proxy credential |
+| `GET` | `/v1/me` | Proxy-credential identity and policy summary |
+| `GET` | `/v1/usage` | Caller policy or principal budget and usage summary |
+| `GET` | `/v1/key/inspect` | Proxy-credential verification and readiness status |
+
+`GET /v1/catalog` is the client integration contract. Each provider row reports whether the unified OpenAI-compatible route is executable, its native proxy base URL, and the request and response formats for executable native routes.
+
+## Proxy routes
+
+| Method | Path | Contract |
+| --- | --- | --- |
+| `POST` | `/v1/chat/completions` | OpenAI-compatible chat routing |
+| `POST` | `/v1/responses` | OpenAI Responses routing |
+| `POST` | `/v1/embeddings` | OpenAI-compatible embeddings routing |
+| `POST` | `/v1/messages` | Anthropic Messages routing |
+| `POST` | `/v1/messages/count_tokens` | Anthropic token counting |
+| manifest-defined | `/v1/proxy/<provider>/<endpoint>` | Manifest request, query, header, path, and auth mapping |
+| manifest-defined | `/v1/native/<provider>/<provider-native-path>` | Provider-native request and response formats |
+
+OpenAI-compatible requests select a provider-qualified model in the request body, for example `openai/gpt-4.1-mini`. Native and manifest routes resolve the provider and endpoint from the compiled snapshot instead of accepting arbitrary upstream URLs.
+
+A manifest proxy request for Tavily looks like this:
+
+```sh
+curl "$CLAWROUTER_BASE_URL/v1/proxy/tavily/search" \
+  -H "authorization: Bearer $CLAWROUTER_KEY" \
+  -H "content-type: application/json" \
+  --data '{"body":{"query":"openclaw"},"query":{"topic":"news"}}'
+```
+
+`clawrouter/fusion` is an optional virtual model on `/v1/chat/completions`. It fans a bounded text-only prompt out to configured adviser models and asks one configured synthesizer for the final response. Every subrequest uses normal policy, budget, readiness, retention, and usage-accounting paths. See [Fusion routing](fusion-router.md).
+
+## Access session routes
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/session` | Verified Access identity, entitlements, and readiness |
+| `GET` | `/v1/session/avatar` | Proxied user avatar |
+| `GET` | `/v1/session/usage` | Session quota and usage summary |
+| `GET` | `/v1/entitlements` | Compatibility entitlement response |
+| `GET` | `/v1/session/credentials` | Credentials owned by the signed-in user |
+| `PUT` | `/v1/session/credentials/<credential-id>` | Create or rotate a caller-owned credential |
+| `POST` | `/v1/session/credentials/<credential-id>/revoke` | Revoke a caller-owned credential |
+| `POST` | `/v1/playground/<route>` | Run a console playground request through an allowed route |
+| `GET` | `/v1/oauth/callback` | Complete a provider-approved browser OAuth flow |
+
+The Worker redirects `/` to `/dashboard`, and `/dashboard` to `/dashboard/home`. A production Cloudflare Access application protects `/dashboard/*`, `/v1/session*`, `/v1/playground/*`, `/v1/admin/*`, and `/v1/oauth/callback` before the request reaches the Worker.
+
+## Admin reads
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/admin/bootstrap` | Coherent authority, configuration, and readiness snapshot |
+| `GET` | `/v1/admin/overview` | Policy, credential, tenant, provider, and budget totals |
+| `GET` | `/v1/admin/tenants` | Tenant summaries |
+| `GET` | `/v1/admin/usage` | Budget rows, aggregate usage, and recent request audit |
+| `GET` | `/v1/admin/content?tenant=<id>&ref=<ref>` | Retained request content from the separate archive |
+| `GET` | `/v1/admin/policies` | Access policies |
+| `GET` | `/v1/admin/credentials` | Issued proxy credentials without raw secrets |
+| `GET` | `/v1/admin/connections` | Global provider connections and kill switches |
+| `GET` | `/v1/admin/access-users` | Materialized Access users |
+| `GET` | `/v1/admin/policy-bindings` | User and group policy bindings |
+| `GET` | `/v1/admin/provider-status` | Policy-aware provider readiness |
+| `GET` | `/v1/admin/provider-health` | Persisted provider smoke status |
+| `GET` | `/v1/admin/upstream-grants` | Sanitized policy- and tenant-scoped upstream grants |
+| `GET` | `/v1/admin/assignment-rules` | Access identity assignment rules |
+| `GET` | `/v1/admin/fusion` | Fusion configuration |
+
+## Admin mutations
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `PUT` | `/v1/admin/access-users/<email>` | Update a materialized user's tenant, status, groups, or retention exemption |
+| `PUT` | `/v1/admin/access-user-grants/<email>` | Update a user and atomically replace direct policy grants |
+| `PUT` | `/v1/admin/policy-bindings` | Create or update a user or group binding |
+| `PUT` | `/v1/admin/policies/<policy-id>` | Create or update a policy |
+| `POST` | `/v1/admin/policies/<policy-id>/revoke` | Disable a policy and every credential bound to it |
+| `PUT` | `/v1/admin/credentials/<credential-id>` | Create or update an issued credential |
+| `POST` | `/v1/admin/credentials/<credential-id>/revoke` | Revoke one issued credential |
+| `PUT` | `/v1/admin/connections/<provider-id>` | Update a global provider connection |
+| `PUT` | `/v1/admin/upstream-grants/<policies\|tenants>/<scope-id>/<token-ref>` | Create or update a scoped upstream grant |
+| `POST` | `/v1/admin/upstream-grants/<policies\|tenants>/<scope-id>/<token-ref>/revoke` | Revoke a scoped upstream grant and remove its secrets |
+| `POST` | `/v1/admin/upstream-grants/<policies\|tenants>/<scope-id>/<token-ref>/refresh` | Refresh an OAuth grant |
+| `POST` | `/v1/admin/upstream-grants/<policies\|tenants>/<scope-id>/<token-ref>/quota-refresh` | Refresh provider-reported grant quota state |
+| `POST` | `/v1/admin/upstream-grants/<policies\|tenants>/<scope-id>/<token-ref>/authorize` | Begin a browser OAuth authorization |
+| `PUT` | `/v1/admin/assignment-rules/<rule-id>` | Create or update an identity assignment rule |
+| `POST` | `/v1/admin/assignment-rules/reconcile` | Reconcile materialized users against assignment rules |
+| `PUT` | `/v1/admin/fusion` | Update Fusion routing configuration |
+| `POST` | `/v1/admin/fusion/preview` | Evaluate Fusion readiness and estimated reservations for a policy |
+
+The legacy `GET|PUT /v1/admin/keys...`, `POST /v1/admin/keys/<kid>/revoke`, and `GET /v1/admin/users` routes remain compatibility aliases. New control-plane clients use policies, credentials, and tenants directly. Legacy top-level console and `/api/*` aliases redirect or normalize to their `/dashboard/*` and `/v1/*` equivalents.
+
+## Routing and authorization behavior
+
+Before forwarding a request, the Worker authenticates the credential, resolves its policy, checks the provider connection and scoped grant readiness, and reserves a conservative budget. Policies can select grants by priority, round robin, least used, reported remaining quota, or weighted random choice, with optional identity or session stickiness.
+
+Provider grants can be scoped to a policy or tenant. When several token references are eligible, ClawRouter applies the policy strategy within the active priority tier. An upstream 401, 403, or 429 records sanitized grant state and can trigger one same-provider alternate when policy allows failover.
+
+Disable one credential to revoke one key, disable a policy to revoke every credential bound to it, or disable a provider connection to stop that provider globally. Policy and credential generations must match, so incomplete rotations and stale migration records fail closed.
+
+## Budgets, usage, and retention
+
+Budgeted requests reserve an upper-bound token cost before the upstream call when the selected model has versioned pricing. A policy `requestCostMicros` value is a fixed-cost override; budgeted routes without versioned pricing or an override fail closed.
+
+Successful responses settle to reported usage, including cached input where available. Non-2xx and transport failures refund the reservation. Missing or interrupted usage remains charged at the conservative reservation. Streaming responses are metered without buffering the client stream.
+
+Usage events are delivered through `USAGE_QUEUE` to tenant- and policy-sharded `USAGE_LEDGER` Durable Objects. Settlement and audit delivery retry independently, and exhausted messages move to the configured usage dead-letter queue. Ledgers keep bounded identity, route, timing, outcome, token, cost, request ID, and trace metadata; they do not store prompts or completions.
+
+Policies can retain LLM request bodies in the separate `CONTENT_ARCHIVE` R2 binding. Retention failure is fail-closed before upstream traffic. See [Request content retention](content-retention.md) for the policy and disclosure contract.
+
+Every Worker-owned response returns the canonical `X-Request-ID`, and CORS exposes it to clients. Valid W3C trace and span IDs are preserved in usage metadata. Agent attribution headers, pricing fields, and reservation semantics are documented in [Agent spend control](agent-spend-control.md).


### PR DESCRIPTION
## Summary

Rewrites the README as a concise front door: dynamic badges, a plain project description, source installation, one-command local proof, progressive routing/provider/policy sections, deployment links, development, and license.

The exhaustive route inventory, authentication boundaries, compatibility aliases, and routing/accounting semantics move to `docs/api-reference.md`. Existing deep guides remain canonical for Cloudflare deployment, self-hosting, OpenClaw setup, architecture, retention, Fusion, Bedrock, and agent spend control.

## Removed or consolidated

- Removes the aspirational “current implementation target” framing and the open-ended “future service providers” wording.
- Consolidates duplicated Cloudflare Access, provider, migration, and accounting prose into the existing focused docs linked from the README.
- Drops no verified capability. The new API reference also adds implemented session, retained-content, Fusion preview, and grant quota-refresh routes that the old README omitted.

## Verification

- `pnpm install --frozen-lockfile` — passed with Node 24.18.0 and pnpm 11.5.1.
- `pnpm provider:compile` — passed for all 21 manifests.
- `pnpm worker:e2e` — passed; local Worker and fixture-upstream smoke completed.
- `pnpm build` — passed, including the admin production build and 117 Worker tests.
- `pnpm check` — passed: 117 Worker, 26 admin, and 74 script tests.
- README/API-reference relative-link resolution — passed.
- All external README targets and four badge URLs — HTTP 200; badge SVGs contain no invalid/not-found card.
- Distribution checks — no npm package or Homebrew formula/cask; GitHub release `v0.1.0` exists.
- Autoreview — clean, no accepted/actionable findings.

The moved Tavily `curl` example requires a configured deployment, proxy credential, and live upstream, so it was not sent; its `-H` and `--data` flags were validated against `curl --help all`. Docker is not installed on this host, so the existing self-host commands were not rerun locally; the repository CI builds and smokes that image.
