### PR TITLE
feat: per-provider monthly budget limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add tenant-global monthly provider budgets with preflight enforcement, dual-ledger settlement, retry-safe accounting, and console spend controls.
+
 ## 0.1.0 - 2026-07-16
 
 First tagged release: a provider-neutral API gateway and router for OpenClaw services — TypeScript Worker data plane, Durable Object budget and usage ledgers, policy-driven access control with Cloudflare Access/GitHub identity, a management console, and a Docker self-hosting profile.

--- a/admin/src/app-shell.tsx
+++ b/admin/src/app-shell.tsx
@@ -7,7 +7,7 @@ export function AppShell() {
   const { policies, credentials: credentialState, connections: connectionState, bindings: bindingState, upstream, assignments, fusion, users: userState, tab } = access;
   const { items: keys, selected: selectedPolicy, form: policyForm, setForm: setPolicyForm, error: policyError, save: savePolicy, revoke, edit: editPolicy, startNew: startNewPolicy, applyPreset, toggleProvider: togglePolicyProvider, setProviderGroup: setPolicyProviderGroup } = policies;
   const { items: credentials, selected: selectedCredential, form: credentialForm, setForm: setCredentialForm, issuedKey, issue: issueCredential, revoke: revokeCredential, setSelectedId: setSelectedCredentialId, setIssuedKey } = credentialState;
-  const { items: connections, setEnabled: setProviderConnection } = connectionState;
+  const { items: connections, setEnabled: setProviderConnection, setBudget: setProviderBudget } = connectionState;
   const { items: bindings, selected: selectedBinding, form: bindingForm, setForm: setBindingForm, save: saveBinding, edit: editBinding, startNew: startNewBinding } = bindingState;
   const { items: upstreamGrants, selected: selectedUpstreamGrant, form: upstreamGrantForm, setForm: setUpstreamGrantForm, save: saveUpstreamGrant, revoke: revokeUpstreamGrant, refresh: refreshUpstreamGrant, refreshQuota: refreshUpstreamGrantQuota, authorize: authorizeUpstreamGrant, edit: editUpstreamGrant, startNew: startNewUpstreamGrant } = upstream;
   const { items: assignmentRules, selected: selectedAssignmentRule, form: assignmentRuleForm, setForm: setAssignmentRuleForm, save: saveAssignmentRule, reconcile: reconcileAssignments, edit: editAssignmentRule, startNew: startNewAssignmentRule } = assignments;
@@ -122,6 +122,7 @@ export function AppShell() {
             canAdminister={session.role === "admin"}
             onSelect={(service) => setSelectedServiceId(service.id)}
             onSetConnection={setProviderConnection}
+            onSetProviderBudget={setProviderBudget}
             onPlay={(service) => {
               const model = models.find((item) => item.provider === service.provider);
               const proxyRoute = serviceRoutes.find((route) => route.provider === service.provider);

--- a/admin/src/hooks/access/use-connection-admin.ts
+++ b/admin/src/hooks/access/use-connection-admin.ts
@@ -20,7 +20,7 @@ export function useConnectionAdmin({ allowDemo, gatewayOrigin, demoMode, setStat
     try {
       setStatus(`${enabled ? "enabling" : "disabling"} ${providerId}`);
       const current = connections.find((connection) => connection.providerId === providerId);
-      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null };
+      const next: ProviderConnection = { providerId, enabled, label: current?.label ?? null, monthlyBudgetMicros: current?.monthlyBudgetMicros ?? null };
       if (demoMode) {
         setConnections((items) => [next, ...items.filter((item) => item.providerId !== providerId)]);
         setProviderReadiness((items) => {
@@ -37,5 +37,22 @@ export function useConnectionAdmin({ allowDemo, gatewayOrigin, demoMode, setStat
     }
   }
 
-  return { connections: { items: connections, setItems: setConnections, setEnabled }, hydrate: setConnections };
+  async function setBudget(providerId: string, monthlyBudgetMicros: number | null) {
+    try {
+      setStatus(`updating ${providerId} budget`);
+      const current = connections.find((connection) => connection.providerId === providerId);
+      const next: ProviderConnection = { providerId, enabled: current?.enabled ?? true, label: current?.label ?? null, monthlyBudgetMicros };
+      if (demoMode) {
+        setConnections((items) => [{ ...next, spentMicros: 0, remainingMicros: monthlyBudgetMicros }, ...items.filter((item) => item.providerId !== providerId)]);
+      } else {
+        await request<ProviderConnection>(gatewayOrigin, `/v1/admin/connections/${encodeURIComponent(providerId)}`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(next) });
+        await refresh();
+      }
+      setStatus(`updated ${providerId} budget`);
+    } catch (caught) {
+      setStatus(errorMessage(caught));
+    }
+  }
+
+  return { connections: { items: connections, setItems: setConnections, setEnabled, setBudget }, hydrate: setConnections };
 }

--- a/admin/src/hooks/use-session.ts
+++ b/admin/src/hooks/use-session.ts
@@ -22,6 +22,7 @@ export function useSession() {
     const nextUrl = `${nextPath}${window.location.search}${window.location.hash}`;
     if (replace) window.history.replaceState(null, "", nextUrl);
     else window.history.pushState(null, "", nextUrl);
+    window.scrollTo(0, 0);
   }
 
   function enforceRoleView() {

--- a/admin/src/screens/access.tsx
+++ b/admin/src/screens/access.tsx
@@ -61,7 +61,14 @@ export function PoliciesScreen({ tab, setTab, keys, selected, credentials, selec
 }) {
   const resourceTabsRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    resourceTabsRef.current?.querySelector('[role="tab"][aria-selected="true"]')?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    // Reveal the active tab by scrolling only the tablist horizontally;
+    // scrollIntoView also scrolls ancestors and yanked the page down on mount.
+    const tabs = resourceTabsRef.current;
+    const active = tabs?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
+    if (!tabs || !active) return;
+    const left = active.offsetLeft, right = left + active.offsetWidth;
+    if (left < tabs.scrollLeft) tabs.scrollLeft = left;
+    else if (right > tabs.scrollLeft + tabs.clientWidth) tabs.scrollLeft = right - tabs.clientWidth;
   }, [tab]);
   return (
     <div className="accessWorkspace">

--- a/admin/src/screens/dashboard-catalog.tsx
+++ b/admin/src/screens/dashboard-catalog.tsx
@@ -187,7 +187,7 @@ export function DashboardStat({ label, value, note }: { label: string; value: st
   return <div><span>{label}</span><strong>{value}</strong><small>{note}</small></div>;
 }
 
-export function CatalogScreen({ services, allServices, selected, policies, connections, query, setQuery, kind, setKind, kinds, canAdminister, onSelect, onSetConnection, onPlay, onAdd }: {
+export function CatalogScreen({ services, allServices, selected, policies, connections, query, setQuery, kind, setKind, kinds, canAdminister, onSelect, onSetConnection, onSetProviderBudget, onPlay, onAdd }: {
   services: ServiceItem[];
   allServices: ServiceItem[];
   selected?: ServiceItem;
@@ -201,6 +201,7 @@ export function CatalogScreen({ services, allServices, selected, policies, conne
   canAdminister: boolean;
   onSelect: (service: ServiceItem) => void;
   onSetConnection: (providerId: string, enabled: boolean) => void;
+  onSetProviderBudget: (providerId: string, monthlyBudgetMicros: number | null) => void;
   onPlay: (service: ServiceItem) => void;
   onAdd: (service: ServiceItem) => void;
 }) {
@@ -273,6 +274,7 @@ export function CatalogScreen({ services, allServices, selected, policies, conne
               <dt>missing</dt><dd>{selected.readiness?.missingConfig.length ? selected.readiness.missingConfig.join(", ") : "none"}</dd>
               <dt>oauth grants</dt><dd>{selected.readiness?.oauthGrantRequired ? selected.readiness.oauthGrantCount : "n/a"}</dd>
             </dl>
+            {canAdminister ? <ProviderBudgetEditor connection={connection ?? { providerId: selected.provider, enabled: connectionEnabled !== false }} onSave={onSetProviderBudget} /> : null}
             {selected.readiness?.reasons.length ? <InlineNote>{selected.readiness.reasons.join("; ")}</InlineNote> : null}
             <div className="sectionTitle">Policies including this service</div>
             <div className="miniList">
@@ -293,6 +295,24 @@ export function CatalogScreen({ services, allServices, selected, policies, conne
   );
 }
 
+function ProviderBudgetEditor({ connection, onSave }: { connection: ProviderConnection; onSave: (providerId: string, monthlyBudgetMicros: number | null) => void }) {
+  const [value, setValue] = useState(currencyInput(connection.monthlyBudgetMicros));
+  const [error, setError] = useState("");
+  useEffect(() => { setValue(currencyInput(connection.monthlyBudgetMicros)); setError(""); }, [connection.providerId, connection.monthlyBudgetMicros]);
+  return (
+    <form className="providerBudgetEditor" onSubmit={(event) => {
+      event.preventDefault();
+      try { onSave(connection.providerId, optionalCurrencyMicros(value) ?? null); setError(""); }
+      catch (caught) { setError(caught instanceof Error ? caught.message : "invalid monthly budget"); }
+    }}>
+      <label><span>monthly provider budget ($)</span><input inputMode="decimal" value={value} onChange={(event) => setValue(event.target.value)} placeholder="unlimited" /></label>
+      <button type="submit" className="buttonSecondary">Save budget</button>
+      {connection.monthlyBudgetMicros != null ? <small>Month to date {formatMicros(connection.spentMicros)} · {formatMicros(connection.remainingMicros)} remaining</small> : <small>Unlimited across all policies and principals</small>}
+      {error ? <small className="providerBudgetError">{error}</small> : null}
+    </form>
+  );
+}
+
 export function GrantChips({ names }: { names: string[] }) {
   if (!names.length) return <span className="emptyGrant">no policy</span>;
   const first = names[0];
@@ -305,7 +325,7 @@ export function GrantChips({ names }: { names: string[] }) {
 }
 import React, { useEffect, useState } from "react";
 import { Activity, ArrowUpRight, BarChart3, Boxes, Bug, CheckCircle2, ChevronRight, CircleSlash2, FlaskConical, KeyRound, Play, Plus, Search, ServerCog, ShieldCheck, SlidersHorizontal, Users } from "lucide-react";
-import { grantNamesForService, playgroundBlockedForService, policyCoversProvider, policyUsageFallback, readinessLabel, serviceOutcome } from "../domain";
+import { currencyInput, grantNamesForService, optionalCurrencyMicros, playgroundBlockedForService, policyCoversProvider, policyUsageFallback, readinessLabel, serviceOutcome } from "../domain";
 import { BrandMark, EntityName, InlineNote, InspectorHeader, OutcomeStatus, PanelTitle, ReadinessStatus, Status, kindIcon, kindLabel } from "../components";
 import { ProviderUsageChart, TrafficAreaChart } from "../analytics-charts";
 import { budgetPercent, effectiveProviderCount, formatBudget, formatCount, formatDuration, formatMicros, formatRelativeTime, matchesServiceQuery, providerBrandIcon, readyCount, usagePolicyId } from "../ui-helpers";

--- a/admin/src/screens/dashboard-catalog.tsx
+++ b/admin/src/screens/dashboard-catalog.tsx
@@ -295,6 +295,10 @@ export function CatalogScreen({ services, allServices, selected, policies, conne
   );
 }
 
+function formatSpendMicros(value: number | null | undefined) {
+  return value === 0 ? "$0.00" : formatMicros(value);
+}
+
 function ProviderBudgetEditor({ connection, onSave }: { connection: ProviderConnection; onSave: (providerId: string, monthlyBudgetMicros: number | null) => void }) {
   const [value, setValue] = useState(currencyInput(connection.monthlyBudgetMicros));
   const [error, setError] = useState("");
@@ -307,7 +311,7 @@ function ProviderBudgetEditor({ connection, onSave }: { connection: ProviderConn
     }}>
       <label><span>monthly provider budget ($)</span><input inputMode="decimal" value={value} onChange={(event) => setValue(event.target.value)} placeholder="unlimited" /></label>
       <button type="submit" className="buttonSecondary">Save budget</button>
-      {connection.monthlyBudgetMicros != null ? <small>Month to date {formatMicros(connection.spentMicros)} · {formatMicros(connection.remainingMicros)} remaining</small> : <small>Unlimited across all policies and principals</small>}
+      {connection.monthlyBudgetMicros != null ? <small>Month to date {formatSpendMicros(connection.spentMicros)} · {formatSpendMicros(connection.remainingMicros)} remaining</small> : <small>Unlimited across all policies and principals</small>}
       {error ? <small className="providerBudgetError">{error}</small> : null}
     </form>
   );

--- a/admin/src/styles/workspace.css
+++ b/admin/src/styles/workspace.css
@@ -234,6 +234,25 @@
   font-size: 11px;
 }
 
+.providerBudgetEditor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+}
+
+.providerBudgetEditor small {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.providerBudgetEditor .providerBudgetError { color: var(--bad); }
+
 .miniList {
   display: grid;
   gap: 5px;

--- a/docs/agent-spend-control.md
+++ b/docs/agent-spend-control.md
@@ -65,6 +65,16 @@ pricing:
     outputMicrosPerMillion: 22500000
 ```
 
+## Per-provider budgets
+
+Provider connections can set a monthly budget that applies tenant-wide to all
+traffic routed to that provider, independent of policy and principal budgets.
+The UTC calendar-month ledger uses the same conservative reservation and actual
+cost settlement flow as policy budgets. Both limits must admit a request; an
+exhausted provider limit returns HTTP 402 with `provider_budget_exhausted`.
+Leaving the provider budget blank keeps the provider unmetered and adds no
+provider-ledger call to the request path.
+
 Rates are integer micro-US-dollars per million tokens. Update `pricingRef` and
 `effectiveAt` together when a provider changes price. Subscription traffic uses
 the equivalent public API list price for governance; it is not an invoice for

--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -449,10 +449,10 @@ try {
   }
   const canonicalConnection = await fetch(connectionUrl, { method: "PUT", headers: userHeaders, body: JSON.stringify({ providerId: "missing", enabled: false, label: " Ops ", ignored: true }) });
   assert.equal(canonicalConnection.status, 200);
-  assert.deepEqual(await canonicalConnection.json(), { providerId: "openai", enabled: false, label: "Ops" });
+  assert.deepEqual(await canonicalConnection.json(), { providerId: "openai", enabled: false, label: "Ops", monthlyBudgetMicros: null });
   const connectionsAfterMutation = await fetch(`${base}/v1/admin/connections`, { headers: userHeaders });
   assert.equal(connectionsAfterMutation.status, 200);
-  assert.deepEqual((await connectionsAfterMutation.json()).connections.find((connection) => connection.providerId === "openai"), { providerId: "openai", enabled: false, label: "Ops" });
+  assert.deepEqual((await connectionsAfterMutation.json()).connections.find((connection) => connection.providerId === "openai"), { providerId: "openai", enabled: false, label: "Ops", monthlyBudgetMicros: null });
   const invalidCredentialUrl = `${base}/v1/admin/credentials/invalid_shape`;
   const credentialDigest = sha256("credential-shape");
   for (const [credentialMutationId, body] of [
@@ -697,6 +697,21 @@ try {
   assert.equal(unavailablePool.status, 503);
   assert.equal((await unavailablePool.json()).error.code, "upstream_grant_pool_unavailable");
   assert.equal(upstreamCalls.length, callsBeforeUnavailablePool, "cooled scoped grants never fall through to an unscoped provider credential");
+  const budgetedConnectionUrl = `${base}/v1/admin/connections/local-openai`;
+  const budgetedConnection = await fetch(budgetedConnectionUrl, { method: "PUT", headers: adminHeaders, body: JSON.stringify({ monthlyBudgetMicros: 1 }) });
+  assert.equal(budgetedConnection.status, 200);
+  assert.deepEqual(await budgetedConnection.json(), { providerId: "local-openai", enabled: true, label: null, monthlyBudgetMicros: 1 });
+  assert.equal((await rotationRequest()).status, 200, "a request within the provider budget succeeds");
+  const providerBudgetExhausted = await rotationRequest();
+  assert.equal(providerBudgetExhausted.status, 402);
+  assert.equal((await providerBudgetExhausted.json()).error.code, "provider_budget_exhausted");
+  const connectionsAfterProviderSpend = await fetch(`${base}/v1/admin/connections`, { headers: adminHeaders });
+  assert.equal(connectionsAfterProviderSpend.status, 200);
+  assert.deepEqual((await connectionsAfterProviderSpend.json()).connections.find((connection) => connection.providerId === "local-openai"), { providerId: "local-openai", enabled: true, label: null, monthlyBudgetMicros: 1, spentMicros: 1, remainingMicros: 0 });
+  const unmeteredConnection = await fetch(budgetedConnectionUrl, { method: "PUT", headers: adminHeaders, body: JSON.stringify({ monthlyBudgetMicros: null }) });
+  assert.equal(unmeteredConnection.status, 200);
+  assert.deepEqual(await unmeteredConnection.json(), { providerId: "local-openai", enabled: true, label: null, monthlyBudgetMicros: null });
+  assert.equal((await rotationRequest()).status, 200, "clearing the provider budget restores requests");
   assert.doesNotMatch(output, /private prompt sentinel|private tool sentinel|invalid trace private sentinel|secret_1234|rotation123/i, "Worker logs remain metadata-only");
   console.log(`local Worker smoke passed on ${base}`);
   if (process.env.CLAWROUTER_E2E_HOLD_FILE) {

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -50,7 +50,14 @@ export interface ProxyCredential {
   principalId?: string | null;
 }
 
-export interface ProviderConnection { providerId: string; enabled: boolean; label?: string | null }
+export interface ProviderConnection {
+  providerId: string;
+  enabled: boolean;
+  label?: string | null;
+  monthlyBudgetMicros?: number | null;
+  spentMicros?: number | null;
+  remainingMicros?: number | null;
+}
 
 export interface FusionConfig {
   version: 1;

--- a/worker/accounting.ts
+++ b/worker/accounting.ts
@@ -1,11 +1,20 @@
-import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
-import { budgetLedgerAddress, budgetPrincipal } from "./budget-scope.ts";
+import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, ProviderConnection, QueueMessage, UsageEvent } from "./types";
+import { budgetLedgerAddress, budgetPrincipal, providerBudgetLedgerAddress } from "./budget-scope.ts";
 import { logCorrelationError } from "./correlation.ts";
 import { HttpError, randomId } from "./utils.ts";
 
 export interface BudgetReservation {
-  reservationId: string | null;
+  reservations: LedgerBudgetReservation[];
   reservedMicros: number;
+}
+
+interface LedgerBudgetReservation {
+  reservationId: string;
+  objectName: string;
+  tenant: string;
+  policyId: string;
+  principalId: string | null;
+  ledger: "policy" | "provider";
 }
 
 export interface EstimatedCost {
@@ -15,17 +24,48 @@ export interface EstimatedCost {
   outputTokens: number | null;
 }
 
-export async function reserveBudget(env: Env, auth: AuthorizedIdentity, capability: string, cost: EstimatedCost): Promise<BudgetReservation> {
-  const limit = auth.policy.monthlyBudgetMicros;
-  if (limit == null) return { reservationId: null, reservedMicros: 0 };
-  if (limit === 0) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
+export async function reserveBudget(env: Env, auth: AuthorizedIdentity, capability: string, cost: EstimatedCost, connection?: ProviderConnection): Promise<BudgetReservation> {
+  if (capability === "llm.count_tokens") return emptyReservation();
+  const policyLimit = auth.policy.monthlyBudgetMicros;
+  const providerLimit = connection?.monthlyBudgetMicros;
+  if (policyLimit == null && providerLimit == null) return emptyReservation();
+  if (policyLimit === 0) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
+  if (providerLimit === 0) throw new HttpError(402, "provider_budget_exhausted", `provider ${connection?.providerId ?? "unknown"} monthly budget is exhausted`);
   if (cost.basis === "flat_fallback") throw new HttpError(400, "pricing_required", "budgeted requests require versioned manifest pricing or a fixed policy request price");
+  const reservations: LedgerBudgetReservation[] = [];
+  if (policyLimit != null) {
+    const principal = budgetPrincipal(auth);
+    const address = budgetLedgerAddress(auth.policyId, auth.policy, principal);
+    reservations.push(await reserveLedger(env, address, policyLimit, cost, capability, "policy", principal, "budget_exhausted", "proxy key budget is exhausted"));
+  }
+  if (providerLimit != null && connection) {
+    const address = providerBudgetLedgerAddress(connection.providerId);
+    try {
+      reservations.push(await reserveLedger(env, address, providerLimit, cost, capability, "provider", null, "provider_budget_exhausted", `provider ${connection.providerId} monthly budget is exhausted`));
+    } catch (error) {
+      await settleReservations(env, auth, reservations, 0).catch(() => undefined);
+      throw error;
+    }
+  }
+  return { reservations, reservedMicros: cost.reserveMicros };
+}
+
+async function reserveLedger(
+  env: Env,
+  address: ReturnType<typeof budgetLedgerAddress>,
+  limitMicros: number,
+  cost: EstimatedCost,
+  capability: string,
+  ledger: LedgerBudgetReservation["ledger"],
+  principalId: string | null,
+  exhaustedCode: string,
+  exhaustedMessage: string,
+): Promise<LedgerBudgetReservation> {
   const reservationId = randomId("budget");
-  const address = budgetLedgerAddress(auth.policyId, auth.policy, budgetPrincipal(auth));
   const request: BudgetReserveRequest = {
     policyId: address.policyId,
     windowKey: address.windowKey,
-    limitMicros: limit,
+    limitMicros,
     costMicros: cost.reserveMicros,
     reservationId,
     capability,
@@ -34,8 +74,8 @@ export async function reserveBudget(env: Env, auth: AuthorizedIdentity, capabili
   const response = await stub.fetch("https://clawrouter.internal/reserve", { method: "POST", body: JSON.stringify(request) });
   if (!response.ok) throw new Error(`budget reserve returned ${response.status}`);
   const result = await response.json<{ allowed: boolean; chargedMicros: number }>();
-  if (!result.allowed) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
-  return { reservationId, reservedMicros: result.chargedMicros };
+  if (!result.allowed) throw new HttpError(402, exhaustedCode, exhaustedMessage);
+  return { reservationId, objectName: address.objectName, tenant: address.tenant, policyId: address.policyId, principalId, ledger };
 }
 
 export async function finalizeAccounting(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number, event: UsageEvent): Promise<void> {
@@ -49,13 +89,22 @@ export async function finalizeAccounting(env: Env, auth: AuthorizedIdentity, res
 }
 
 export async function settleBudget(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number): Promise<void> {
-  if (!reservation.reservationId) return;
-  const principal = budgetPrincipal(auth);
-  const address = budgetLedgerAddress(auth.policyId, auth.policy, principal);
+  await settleReservations(env, auth, reservation.reservations, actualCostMicros);
+}
+
+async function settleReservations(env: Env, auth: AuthorizedIdentity, reservations: LedgerBudgetReservation[], actualCostMicros: number): Promise<void> {
+  const results = await Promise.allSettled(reservations.map((reservation) => settleReservation(env, auth, reservation, actualCostMicros)));
+  const failed = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (failed) throw failed.reason;
+}
+
+async function settleReservation(env: Env, auth: AuthorizedIdentity, reservation: LedgerBudgetReservation, actualCostMicros: number): Promise<void> {
   const body: BudgetSettleRequest = { reservationId: reservation.reservationId, actualCostMicros };
-  const job: QueueMessage = { kind: "budget_settlement", tenant_id: address.tenant, policy_id: auth.policyId, principal_id: principal, request: body };
+  const job: QueueMessage = reservation.ledger === "provider"
+    ? { kind: "budget_settlement", tenant_id: reservation.tenant, policy_id: reservation.policyId, principal_id: null, ledger: { objectName: reservation.objectName }, request: body }
+    : { kind: "budget_settlement", tenant_id: reservation.tenant, policy_id: auth.policyId, principal_id: reservation.principalId, request: body };
   try {
-    const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(address.objectName));
+    const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(reservation.objectName));
     const response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(body) });
     if (response.ok) return;
   } catch {
@@ -63,6 +112,8 @@ export async function settleBudget(env: Env, auth: AuthorizedIdentity, reservati
   }
   await env.USAGE_QUEUE.send(job);
 }
+
+export function emptyReservation(): BudgetReservation { return { reservations: [], reservedMicros: 0 }; }
 
 export async function enqueueUsage(env: Env, event: UsageEvent): Promise<void> {
   await env.USAGE_QUEUE.send(event satisfies QueueMessage);

--- a/worker/admin.ts
+++ b/worker/admin.ts
@@ -1,6 +1,6 @@
 import { authorizeAdmin } from "./access";
 import {
-  authorityCall, listBindings, listConnections, listCredentials, listPolicies, listUsers,
+  authorityCall, listBindings, listConnections, listCredentials, listPolicies, listUsers, resolveConnection,
 } from "./authority";
 import {
   listAssignmentRules, normalizeAssignmentEvidence, reconcileUserAssignments,
@@ -13,7 +13,7 @@ import { currentGrantRuntime, grantPriority, grantRoutingPolicy, grantRuntimeSta
 import { assertFusionModels, loadFusionConfig, storeFusionConfig } from "./fusion-config";
 import { fusionReadiness } from "./fusion-readiness";
 import { normalizeFusionConfig } from "./fusion";
-import { budgetStatus as policyBudgetStatus, usageSnapshots } from "./ledgers";
+import { budgetStatus as policyBudgetStatus, providerBudgetStatus, usageSnapshots } from "./ledgers";
 import { startOAuth } from "./oauth";
 import { endpointForPath, listGrantRecords, listHealth, modelRoute, providerReadiness, providerReadinessForPolicies, providerReadinessFromState, refreshStoredGrant, refreshStoredGrantQuota, snapshot } from "./providers";
 import type { AdminBootstrapResponse } from "../shared/contracts";
@@ -178,12 +178,21 @@ async function credentialResponses(env: Env) {
 
 async function connections(env: Env): Promise<ProviderConnection[]> {
   const stored = await listConnections(env, snapshot.providers.map((provider) => provider.id));
-  return connectionsFrom(stored);
+  return connectionResponses(env, connectionsFrom(stored));
 }
 
 function connectionsFrom(stored: ProviderConnection[]): ProviderConnection[] {
   const byId = new Map(stored.map((connection) => [connection.providerId, connection]));
   return snapshot.providers.map((provider) => byId.get(provider.id) ?? { providerId: provider.id, enabled: true, label: null });
+}
+
+async function connectionResponses(env: Env, connections: ProviderConnection[]): Promise<ProviderConnection[]> {
+  return Promise.all(connections.map(async (connection) => {
+    const limit = connection.monthlyBudgetMicros;
+    if (limit == null) return connection;
+    const status = await providerBudgetStatus(env, connection.providerId, limit);
+    return { ...connection, spentMicros: status.spentMicros, remainingMicros: status.remainingMicros };
+  }));
 }
 
 async function adminBootstrap(env: Env): Promise<AdminBootstrapResponse> {
@@ -199,10 +208,11 @@ async function adminBootstrap(env: Env): Promise<AdminBootstrapResponse> {
     loadFusionConfig(env),
   ]);
   const connectionRows = connectionsFrom(storedConnections);
+  const connectionResponseRows = await connectionResponses(env, connectionRows);
   return {
     policies: policies.map(policyResponse),
     credentials: credentialResponsesFrom(policies, credentials),
-    connections: connectionRows,
+    connections: connectionResponseRows,
     users: users.map(userResponse),
     bindings,
     providers: providerReadinessFromState(env, grants, connectionRows, health),
@@ -276,7 +286,7 @@ async function credentialMutation(request: Request, env: Env, rest: string): Pro
 
 async function putConnection(request: Request, env: Env, encodedId: string): Promise<Response> {
   const id = decodeURIComponent(encodedId), provider = snapshot.providers.find((item) => item.id === id); if (!provider) throw new HttpError(404, "unknown_provider", "provider does not exist");
-  const connection = normalizeConnection(await readJson<unknown>(request), id);
+  const connection = normalizeConnection(await readJson<unknown>(request), id, await resolveConnection(env, id));
   await authorityCall(env, "/connections/put", connection); return privateJson(connection);
 }
 
@@ -512,13 +522,15 @@ function normalizeBinding(value: unknown): PolicyBinding {
   return { policyId, principalType, principalId, enabled, priority: priority as number };
 }
 
-function normalizeConnection(value: unknown, providerId: string): ProviderConnection {
+export function normalizeConnection(value: unknown, providerId: string, existing?: ProviderConnection | null): ProviderConnection {
   const body = mutationObject(value, "invalid_provider_connection", "provider connection");
   const enabled = body.enabled === undefined ? true : body.enabled;
   if (typeof enabled !== "boolean") throw new HttpError(400, "invalid_provider_connection", "enabled must be a boolean");
   if (body.label !== undefined && body.label !== null && typeof body.label !== "string") throw new HttpError(400, "invalid_provider_connection", "label must be a string or null");
   const label = typeof body.label === "string" ? body.label.trim() || null : null;
-  return { providerId, enabled, label };
+  const monthlyBudgetMicros = body.monthlyBudgetMicros === undefined ? existing?.monthlyBudgetMicros ?? null : body.monthlyBudgetMicros;
+  if (monthlyBudgetMicros !== null && (!Number.isSafeInteger(monthlyBudgetMicros) || (monthlyBudgetMicros as number) < 0)) throw new HttpError(400, "invalid_provider_connection", "monthlyBudgetMicros must be a non-negative safe integer or null");
+  return { providerId, enabled, label, monthlyBudgetMicros: monthlyBudgetMicros as number | null };
 }
 
 function normalizeUserMutation(value: unknown, existing: AccessControlUser["record"], includePolicyIds = false): { record: AccessControlUser["record"]; policyIds: string[] } {

--- a/worker/budget-scope.ts
+++ b/worker/budget-scope.ts
@@ -21,3 +21,13 @@ export function budgetLedgerAddress(policyId: string, policy: Pick<AccessPolicy,
     windowKey: `${tenant}/${policyId}${path}/${new Date().toISOString().slice(0, 7)}`,
   };
 }
+
+export function providerBudgetLedgerAddress(providerId: string) {
+  const month = new Date().toISOString().slice(0, 7);
+  return {
+    tenant: "default",
+    objectName: `provider:${providerId}`,
+    policyId: `provider/${providerId}`,
+    windowKey: `provider/${providerId}/${month}`,
+  };
+}

--- a/worker/ledgers.ts
+++ b/worker/ledgers.ts
@@ -1,5 +1,5 @@
 import type { BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
-import { budgetLedgerAddress } from "./budget-scope.ts";
+import { budgetLedgerAddress, providerBudgetLedgerAddress } from "./budget-scope.ts";
 import { emptyUsageSnapshot, mergeUsageSnapshots, usageCutoffs, usageDayMs, usageShardName, type UsageSnapshot } from "./usage-sharding.ts";
 import { errorResponse, json } from "./utils.ts";
 
@@ -161,7 +161,7 @@ export async function queue(batch: MessageBatch<QueueMessage>, env: Env): Promis
       if ("type" in message.body) response = await usageStub(env, message.body.tenant_id, message.body.policy_id).fetch("https://clawrouter.internal/ingest", { method: "POST", body: JSON.stringify(message.body) });
       else {
         const job = message.body;
-        const objectName = `${job.tenant_id}:${job.policy_id}${job.principal_id ? `:${job.principal_id}` : ""}`;
+        const objectName = job.ledger?.objectName ?? `${job.tenant_id}:${job.policy_id}${job.principal_id ? `:${job.principal_id}` : ""}`;
         const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(objectName));
         response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(job.request) });
       }
@@ -213,6 +213,22 @@ export async function budgetStatus(env: Env, policyId: string, policy: { tenantI
     return { configured: true, ledger: "durable_object", windowKey: address.windowKey, limitMicros: limit, spentMicros: status.spentMicros, remainingMicros: status.remainingMicros };
   } catch {
     return { configured: true, ledger: "unavailable", windowKey: address.windowKey, limitMicros: limit, spentMicros: null, remainingMicros: null };
+  }
+}
+
+export async function providerBudgetStatus(env: Env, providerId: string, limitMicros: number) {
+  const address = providerBudgetLedgerAddress(providerId);
+  try {
+    const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(address.objectName));
+    const url = new URL("https://clawrouter.internal/status");
+    url.searchParams.set("policy_id", address.policyId);
+    url.searchParams.set("window_key", address.windowKey);
+    url.searchParams.set("limit_micros", String(limitMicros));
+    const response = await stub.fetch(url);
+    if (!response.ok) throw new Error(`provider budget status returned ${response.status}`);
+    return response.json<{ spentMicros: number; remainingMicros: number }>();
+  } catch {
+    return { spentMicros: null, remainingMicros: null };
   }
 }
 

--- a/worker/providers.ts
+++ b/worker/providers.ts
@@ -185,10 +185,11 @@ function readinessFor(provider: CompiledProvider, env: Env, grants: GrantRecord[
   };
 }
 
-export async function assertProviderAccess(provider: CompiledProvider, auth: AuthorizedIdentity, env: Env): Promise<void> {
+export async function assertProviderAccess(provider: CompiledProvider, auth: AuthorizedIdentity, env: Env, resolvedConnection?: ProviderConnection): Promise<ProviderConnection> {
   if (auth.policy.providers.length && !auth.policy.providers.includes(provider.id)) throw new HttpError(403, "provider_not_allowed", `policy does not allow provider ${provider.id}`);
-  const connection = await connectionFor(env, provider.id);
+  const connection = resolvedConnection ?? await connectionFor(env, provider.id);
   if (!connection.enabled) throw new HttpError(503, "provider_disabled", `provider ${provider.id} is disabled`);
+  return connection;
 }
 
 export async function upstreamAuth(provider: CompiledProvider, endpoint: CompiledEndpoint, auth: AuthorizedIdentity, env: Env, excludedGrantKeys: ReadonlySet<string> = new Set(), stickyHash: string | null = null, recordSelection = true): Promise<UpstreamAuth> {

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -1,5 +1,5 @@
 import { accessIdentity } from "./access";
-import { finalizeAccounting, reserveBudget, type BudgetReservation, type EstimatedCost } from "./accounting";
+import { emptyReservation, finalizeAccounting, reserveBudget, type BudgetReservation, type EstimatedCost } from "./accounting";
 import { resolveCredentials, resolvePolicies, resolveUsers } from "./authority";
 import { retainRequestContent } from "./content-retention";
 import { correlationMetadata } from "./correlation.ts";
@@ -16,7 +16,7 @@ import {
 } from "./providers";
 import { actualModelCost, estimateModelCost } from "./pricing";
 import { extractUsageTokens, type UsageTokens } from "./token-usage";
-import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, CompiledQuotaConfig, Env, UsageEvent } from "./types";
+import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, CompiledQuotaConfig, Env, ProviderConnection, UsageEvent } from "./types";
 import {
   errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
 } from "./utils";
@@ -45,6 +45,7 @@ interface PreparedUpstream {
   requestBody: string | undefined;
   grantKey: string | null;
   grantRevision: string | null;
+  connection: ProviderConnection;
 }
 
 interface ReservedProxyBudget {
@@ -54,6 +55,7 @@ interface ReservedProxyBudget {
   providerId: string;
   modelId: string | null;
   capability: string;
+  connection: ProviderConnection;
 }
 
 interface CompoundRequestContext {
@@ -334,7 +336,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     return errorResponse("fusion_reservation_invalid", "fusion synthesizer reservation does not cover the final request", 500);
   }
   let prepared: PreparedUpstream;
-  try { prepared = await prepareSelected(request, env, selection, queryInput, auth); }
+  try { prepared = await prepareSelected(request, env, selection, queryInput, auth, new Set(), true, reservedBudget?.connection); }
   catch (error) {
     const failure = selectedFailure(error);
     const status = failure.status === 403 ? "denied" : failure.status < 500 ? "client_error" : "provider_error";
@@ -344,7 +346,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
   }
   let reservation = reservedBudget?.reservation;
   if (!reservation) {
-    try { reservation = await reserveBudget(env, auth, selection.capability, cost); }
+    try { reservation = await reserveBudget(env, auth, selection.capability, cost, prepared.connection); }
     catch (error) {
       const failure = error instanceof HttpError ? error : new HttpError(503, "budget_store_unavailable", "budget ledger is unavailable");
       auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, failure.status === 402 ? "denied" : failure.status < 500 ? "client_error" : "provider_error", compound);
@@ -367,7 +369,7 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     captureGrantRuntime(context, env, prepared.grantKey, prepared.grantRevision, selection.provider.quota, response);
     if (shouldFailoverGrant(response.status, selection.method, selection.capability, prepared.grantKey, grantRoutingPolicy(auth.policy.grantRouting).failover)) {
       try {
-        const retry = await prepareSelected(request, env, selection, queryInput, auth, new Set([prepared.grantKey!]));
+        const retry = await prepareSelected(request, env, selection, queryInput, auth, new Set([prepared.grantKey!]), true, prepared.connection);
         const retryResponse = await fetch(retry.url, { method: selection.method, headers: retry.headers, body: retry.requestBody, signal: AbortSignal.any([request.signal, controller.signal]) });
         captureGrantRuntime(context, env, retry.grantKey, retry.grantRevision, selection.provider.quota, retryResponse);
         void response.body?.cancel().catch(() => undefined);
@@ -558,8 +560,9 @@ async function reserveSelected(request: Request, env: Env, context: ExecutionCon
   const requestId = correlationMetadata(request).requestId;
   const started = Date.now();
   const cost = estimateCost(selection.model, selection.body, auth.policy.requestCostMicros, selection.capability);
+  let prepared: PreparedUpstream;
   try {
-    await prepareSelected(request, env, selection, {}, auth, new Set(), false);
+    prepared = await prepareSelected(request, env, selection, {}, auth, new Set(), false);
   } catch (error) {
     const failure = selectedFailure(error);
     const status = failure.status === 403 ? "denied" : failure.status < 500 ? "client_error" : "provider_error";
@@ -567,8 +570,8 @@ async function reserveSelected(request: Request, env: Env, context: ExecutionCon
     return errorResponse(failure.code, failure.message, failure.status);
   }
   try {
-    const reservation = await reserveBudget(env, auth, selection.capability, cost);
-    return { auth, reservation, cost, providerId: selection.provider.id, modelId: selection.model?.id ?? null, capability: selection.capability };
+    const reservation = await reserveBudget(env, auth, selection.capability, cost, prepared.connection);
+    return { auth, reservation, cost, providerId: selection.provider.id, modelId: selection.model?.id ?? null, capability: selection.capability, connection: prepared.connection };
   } catch (error) {
     const failure = error instanceof HttpError ? error : new HttpError(503, "budget_store_unavailable", "budget ledger is unavailable");
     auditFailure(context, env, auth, selection, request, requestId, started, cost, failure.status, failure.status === 402 ? "denied" : failure.status < 500 ? "client_error" : "provider_error", compound);
@@ -580,8 +583,9 @@ async function selectedAuth(request: Request, env: Env, mode: AuthMode, selectio
   return preauthenticated ?? (mode === "access" ? accessIdentity(request, env, selection.provider.id) : authenticateProxyKey(request.headers, env));
 }
 
-async function prepareSelected(request: Request, env: Env, selection: ProxySelection, queryInput: Record<string, unknown>, auth: AuthorizedIdentity, excludedGrantKeys: ReadonlySet<string> = new Set(), recordSelection = true): Promise<PreparedUpstream> {
-  try { await assertProviderAccess(selection.provider, auth, env); }
+async function prepareSelected(request: Request, env: Env, selection: ProxySelection, queryInput: Record<string, unknown>, auth: AuthorizedIdentity, excludedGrantKeys: ReadonlySet<string> = new Set(), recordSelection = true, resolvedConnection?: ProviderConnection): Promise<PreparedUpstream> {
+  let connection: ProviderConnection;
+  try { connection = await assertProviderAccess(selection.provider, auth, env, resolvedConnection); }
   catch (error) { throw error instanceof HttpError ? error : new HttpError(503, "provider_unavailable", "provider authorization failed"); }
   let upstream;
   const stickyHash = await grantStickyHash(request, auth);
@@ -597,7 +601,7 @@ async function prepareSelected(request: Request, env: Env, selection: ProxySelec
     for (const [name, value] of Object.entries(queryInput)) if (value != null) url.searchParams.set(name, String(value));
     const requestBody = ["GET", "HEAD"].includes(selection.method) ? undefined : JSON.stringify(selection.body);
     await signSigV4(selection.provider, url, selection.method, requestBody, headers, env, upstream.grant);
-    return { headers, url, requestBody, grantKey: upstream.grantKey, grantRevision: upstream.grantRevision };
+    return { headers, url, requestBody, grantKey: upstream.grantKey, grantRevision: upstream.grantRevision, connection };
   } catch (error) {
     throw error instanceof HttpError ? error : new HttpError(503, "provider_request_invalid", "provider request configuration is invalid");
   }
@@ -623,7 +627,7 @@ function selectedFailure(error: unknown): HttpError {
 }
 
 function auditFailure(context: ExecutionContext, env: Env, auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, cost: Cost, statusCode: number, status: UsageEvent["status"], compound?: CompoundRequestContext): void {
-  const reservation = { reservationId: null, reservedMicros: 0 };
+  const reservation = emptyReservation();
   context.waitUntil(finalizeAccounting(env, auth, reservation, 0, usageEvent(auth, selection, request, requestId, started, statusCode, null, cost, reservation, null, status, 0, compound)));
 }
 

--- a/worker/test/accounting.test.mjs
+++ b/worker/test/accounting.test.mjs
@@ -10,7 +10,10 @@ const auth = {
   policy: { enabled: true, generation: "v1", providers: [], tenantId: "tenant", retainRequestContent: true },
   contentRetentionDisabled: false,
 };
-const reservation = { reservationId: "reservation", reservedMicros: 100 };
+const reservation = {
+  reservations: [{ reservationId: "reservation", objectName: "tenant:policy", tenant: "tenant", policyId: "tenant/policy", principalId: null, ledger: "policy" }],
+  reservedMicros: 100,
+};
 const event = { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy", request_id: "request-safe" };
 
 test("thrown ledger settlement queues a retry", async () => {

--- a/worker/test/admin-budget-policy.test.mjs
+++ b/worker/test/admin-budget-policy.test.mjs
@@ -8,7 +8,7 @@ registerHooks({ resolve(specifier, context, nextResolve) {
   return nextResolve(specifier, context);
 } });
 
-const { adminBudgetStatus, budgetPrincipalsByPolicy, normalizePolicy } = await import("../admin.ts");
+const { adminBudgetStatus, budgetPrincipalsByPolicy, normalizeConnection, normalizePolicy } = await import("../admin.ts");
 
 test("policy normalization validates budgetScope and preserves generation", () => {
   const existing = policy({ generation: "policy_existing" });
@@ -16,6 +16,15 @@ test("policy normalization validates budgetScope and preserves generation", () =
   assert.equal(updated.budgetScope, "principal");
   assert.equal(updated.generation, "policy_existing");
   assert.throws(() => normalizePolicy({ providers: ["openai"], budgetScope: "tenant" }, existing, true), (error) => error?.code === "invalid_policy" && error?.status === 400);
+});
+
+test("provider connection normalization validates monthlyBudgetMicros", () => {
+  assert.deepEqual(normalizeConnection({ enabled: true, monthlyBudgetMicros: 50_000_000 }, "openai"), { providerId: "openai", enabled: true, label: null, monthlyBudgetMicros: 50_000_000 });
+  assert.equal(normalizeConnection({ enabled: false, monthlyBudgetMicros: null }, "openai").monthlyBudgetMicros, null);
+  assert.equal(normalizeConnection({ enabled: false }, "openai", { providerId: "openai", enabled: true, monthlyBudgetMicros: 50_000_000 }).monthlyBudgetMicros, 50_000_000);
+  for (const monthlyBudgetMicros of [-1, 1.5, "50000000"]) {
+    assert.throws(() => normalizeConnection({ monthlyBudgetMicros }, "openai"), (error) => error?.code === "invalid_provider_connection" && error?.status === 400);
+  }
 });
 
 test("admin budget rows use the finite principals derived from loaded authority data", async () => {

--- a/worker/test/ledger-queue.test.mjs
+++ b/worker/test/ledger-queue.test.mjs
@@ -26,6 +26,16 @@ test("principal-scoped settlement retries target the reserved principal ledger",
   assert.equal(message.ackCount, 1);
 });
 
+test("provider settlement retries use their explicit ledger while legacy messages keep policy addressing", async () => {
+  const calls = [];
+  const provider = queueMessage({ kind: "budget_settlement", tenant_id: "default", policy_id: "provider/openai", ledger: { objectName: "provider:openai" }, request: { reservationId: "provider-r1", actualCostMicros: 4 } });
+  const legacy = queueMessage({ kind: "budget_settlement", tenant_id: "tenant", policy_id: "policy", request: { reservationId: "policy-r1", actualCostMicros: 4 } });
+  await queue({ messages: [provider, legacy] }, mockEnv(calls, new Response("accepted")));
+  assert.deepEqual(calls.map((call) => call.name), ["provider:openai", "tenant:policy"]);
+  assert.equal(provider.ackCount, 1);
+  assert.equal(legacy.ackCount, 1);
+});
+
 function usageEvent() { return { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy" }; }
 function queueMessage(body) {
   return { body, ackCount: 0, retryCount: 0, ack() { this.ackCount += 1; }, retry() { this.retryCount += 1; } };

--- a/worker/test/provider-budget.test.mjs
+++ b/worker/test/provider-budget.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { reserveBudget, settleBudget } from "../accounting.ts";
+
+const cost = { reserveMicros: 60, basis: "policy_fixed", inputTokens: null, outputTokens: null };
+const auth = {
+  credentialId: "credential",
+  principalId: "operator@example.com",
+  authType: "proxy_key",
+  policyId: "policy",
+  policy: { tenantId: "tenant", monthlyBudgetMicros: 100 },
+  contentRetentionDisabled: false,
+};
+
+test("provider denial returns provider_budget_exhausted and releases the policy reservation", async () => {
+  const env = budgetEnv({ denyProvider: true });
+  await assert.rejects(
+    () => reserveBudget(env, auth, "llm.chat", cost, { providerId: "openai", enabled: true, monthlyBudgetMicros: 50 }),
+    (error) => error?.status === 402 && error?.code === "provider_budget_exhausted" && /openai/.test(error.message),
+  );
+  assert.deepEqual(env.calls.map(({ name, path, body }) => ({ name, path, actualCostMicros: body.actualCostMicros })), [
+    { name: "tenant:policy", path: "/reserve", actualCostMicros: undefined },
+    { name: "provider:openai", path: "/reserve", actualCostMicros: undefined },
+    { name: "tenant:policy", path: "/settle", actualCostMicros: 0 },
+  ]);
+});
+
+test("successful accounting settles policy and provider ledgers to actual cost", async () => {
+  const env = budgetEnv();
+  const reservation = await reserveBudget(env, auth, "llm.chat", cost, { providerId: "openai", enabled: true, monthlyBudgetMicros: 100 });
+  await settleBudget(env, auth, reservation, 25);
+  const settlements = env.calls.filter((call) => call.path === "/settle");
+  assert.deepEqual(settlements.map(({ name, body }) => [name, body.actualCostMicros]).sort(), [["provider:openai", 25], ["tenant:policy", 25]]);
+  assert.equal(reservation.reservedMicros, 60);
+  assert.equal(reservation.reservations.length, 2);
+});
+
+test("unmetered providers add no provider-ledger calls", async () => {
+  const env = budgetEnv();
+  await reserveBudget(env, auth, "llm.chat", cost, { providerId: "openai", enabled: true, monthlyBudgetMicros: null });
+  assert.deepEqual(env.calls.map((call) => call.name), ["tenant:policy"]);
+});
+
+test("provider budgets fail closed on fallback pricing and skip zero-cost capabilities", async () => {
+  const env = budgetEnv();
+  const connection = { providerId: "openai", enabled: true, monthlyBudgetMicros: 100 };
+  await assert.rejects(() => reserveBudget(env, { ...auth, policy: { tenantId: "tenant" } }, "llm.chat", { ...cost, basis: "flat_fallback" }, connection), (error) => error?.status === 400 && error?.code === "pricing_required");
+  await reserveBudget(env, auth, "llm.count_tokens", { ...cost, reserveMicros: 0, basis: "none" }, connection);
+  assert.equal(env.calls.length, 0);
+});
+
+function budgetEnv({ denyProvider = false } = {}) {
+  const calls = [];
+  const namespace = {
+    idFromName: (name) => name,
+    get: (name) => ({ fetch: async (url, init) => {
+      const path = new URL(url).pathname;
+      const body = JSON.parse(init.body);
+      calls.push({ name, path, body });
+      if (path === "/reserve") return Response.json({ allowed: !(denyProvider && name.startsWith("provider:")), chargedMicros: body.costMicros });
+      return Response.json({ settled: true });
+    } }),
+  };
+  return { BUDGET_LEDGER: namespace, USAGE_QUEUE: { send: async () => {} }, calls };
+}

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -121,6 +121,9 @@ export interface ProviderConnection {
   providerId: string;
   enabled: boolean;
   label?: string | null;
+  monthlyBudgetMicros?: number | null;
+  spentMicros?: number | null;
+  remainingMicros?: number | null;
 }
 
 export interface ProviderHealth {
@@ -294,7 +297,7 @@ export interface UsageEvent {
   status: "success" | "provider_error" | "client_error" | "denied" | "timeout";
 }
 
-export type QueueMessage = UsageEvent | { kind: "budget_settlement"; tenant_id: string; policy_id: string; principal_id?: string | null; request: BudgetSettleRequest };
+export type QueueMessage = UsageEvent | { kind: "budget_settlement"; tenant_id: string; policy_id: string; principal_id?: string | null; ledger?: { objectName: string }; request: BudgetSettleRequest };
 
 export interface BudgetReserveRequest {
   policyId: string;


### PR DESCRIPTION
## Summary

- Enforces per-provider monthly budgets via a second budget-ledger dimension, including reservation and settlement.
- Returns `402 provider_budget_exhausted` when a provider budget is exhausted.
- Adds an admin editor with month-to-date spend in the Catalog inspector.
- Includes admin UX fixes for tablist-only tab reveal, scroll reset on view change, and `$0.00` spend formatting.

## Verification

- `pnpm check` all suites green: 123+26+74 tests.
- The Playwright darwin snapshot diff on `fusion-readiness` is pre-existing on this machine and reproduces without these changes; CI Linux snapshots are authoritative.
- Codex and Claude autoreview clean.

## Deployment

Will be deployed to clawrouter.openclaw.ai via the Deploy Cloudflare workflow after merge.

## Remaining risk

Provider budgets default to `null`/unmetered; only metered providers pay one extra Durable Object round-trip.
