### PR TITLE
fix: abort hung dashboard and OAuth token fetches

### DIFF
--- a/admin/src/dashboard-fetch.ts
+++ b/admin/src/dashboard-fetch.ts
@@ -1,0 +1,37 @@
+import { fetchTimeoutSignal } from "../../shared/fetch-timeout";
+import type { PlaygroundHttpResponse } from "./ui-types";
+
+export async function request<T>(baseUrl: string, path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal) });
+  if (!response.ok) throw new Error((await response.text()) || `${path} failed with ${response.status}`);
+  if (!(response.headers.get("content-type") ?? "").includes("application/json")) throw new Error(`${path} returned a non-JSON response from ${baseUrl}`);
+  return response.json() as Promise<T>;
+}
+
+export async function playgroundRequest(baseUrl: string, path: string, init: RequestInit = {}): Promise<PlaygroundHttpResponse> {
+  const headers = new Headers(init.headers);
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal) });
+  const contentType = response.headers.get("content-type") ?? "";
+  const retention = response.headers.get("x-clawrouter-content-retention") ?? "unknown";
+  const body = await response.arrayBuffer();
+  const text = isTextualResponse(contentType) ? new TextDecoder().decode(body) : "";
+  let raw = "";
+  if (response.status === 204 || body.byteLength === 0) raw = `HTTP ${response.status} ${response.statusText || "No Content"}`.trim();
+  if (contentType.includes("application/json") || contentType.includes("+json")) {
+    try {
+      raw = JSON.stringify(JSON.parse(text), null, 2);
+    } catch {
+      raw = text;
+    }
+  } else if (text) {
+    raw = text;
+  } else if (!raw) {
+    raw = `HTTP ${response.status} ${response.statusText || "OK"}\n${contentType || "binary"} response (${body.byteLength} bytes)`;
+  }
+  return { ok: response.ok, raw, status: response.status, statusText: response.statusText, contentType, retention };
+}
+
+export function isTextualResponse(contentType: string) {
+  return /(^text\/|json|xml|html|csv|yaml|graphql|javascript)/i.test(contentType);
+}

--- a/admin/src/dashboard-fetch.ts
+++ b/admin/src/dashboard-fetch.ts
@@ -1,9 +1,9 @@
-import { fetchTimeoutSignal, PLAYGROUND_FETCH_TIMEOUT_MS } from "../../shared/fetch-timeout";
+import { DASHBOARD_FETCH_TIMEOUT_MS, fetchTimeoutSignal, PLAYGROUND_FETCH_TIMEOUT_MS } from "../../shared/fetch-timeout";
 import type { PlaygroundHttpResponse } from "./ui-types";
 
 export async function request<T>(baseUrl: string, path: string, init: RequestInit = {}): Promise<T> {
   const headers = new Headers(init.headers);
-  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal) });
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal, DASHBOARD_FETCH_TIMEOUT_MS) });
   if (!response.ok) throw new Error((await response.text()) || `${path} failed with ${response.status}`);
   if (!(response.headers.get("content-type") ?? "").includes("application/json")) throw new Error(`${path} returned a non-JSON response from ${baseUrl}`);
   return response.json() as Promise<T>;

--- a/admin/src/dashboard-fetch.ts
+++ b/admin/src/dashboard-fetch.ts
@@ -1,4 +1,4 @@
-import { fetchTimeoutSignal } from "../../shared/fetch-timeout";
+import { fetchTimeoutSignal, PLAYGROUND_FETCH_TIMEOUT_MS } from "../../shared/fetch-timeout";
 import type { PlaygroundHttpResponse } from "./ui-types";
 
 export async function request<T>(baseUrl: string, path: string, init: RequestInit = {}): Promise<T> {
@@ -9,9 +9,19 @@ export async function request<T>(baseUrl: string, path: string, init: RequestIni
   return response.json() as Promise<T>;
 }
 
-export async function playgroundRequest(baseUrl: string, path: string, init: RequestInit = {}): Promise<PlaygroundHttpResponse> {
+export async function playgroundRequest(
+  baseUrl: string,
+  path: string,
+  init: RequestInit = {},
+  timeoutMs = PLAYGROUND_FETCH_TIMEOUT_MS,
+): Promise<PlaygroundHttpResponse> {
   const headers = new Headers(init.headers);
-  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal) });
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, {
+    ...init,
+    credentials: "same-origin",
+    headers,
+    signal: fetchTimeoutSignal(init.signal, timeoutMs),
+  });
   const contentType = response.headers.get("content-type") ?? "";
   const retention = response.headers.get("x-clawrouter-content-retention") ?? "unknown";
   const body = await response.arrayBuffer();

--- a/admin/src/ui-helpers.ts
+++ b/admin/src/ui-helpers.ts
@@ -25,36 +25,7 @@ export async function settled<T>(loader: () => Promise<T>): Promise<{ ok: true; 
   }
 }
 
-export async function request<T>(baseUrl: string, path: string, init: RequestInit = {}): Promise<T> {
-  const headers = new Headers(init.headers);
-  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers });
-  if (!response.ok) throw new Error((await response.text()) || `${path} failed with ${response.status}`);
-  if (!(response.headers.get("content-type") ?? "").includes("application/json")) throw new Error(`${path} returned a non-JSON response from ${baseUrl}`);
-  return response.json() as Promise<T>;
-}
-
-export async function playgroundRequest(baseUrl: string, path: string, init: RequestInit = {}): Promise<PlaygroundHttpResponse> {
-  const headers = new Headers(init.headers);
-  const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers });
-  const contentType = response.headers.get("content-type") ?? "";
-  const retention = response.headers.get("x-clawrouter-content-retention") ?? "unknown";
-  const body = await response.arrayBuffer();
-  const text = isTextualResponse(contentType) ? new TextDecoder().decode(body) : "";
-  let raw = "";
-  if (response.status === 204 || body.byteLength === 0) raw = `HTTP ${response.status} ${response.statusText || "No Content"}`.trim();
-  if (contentType.includes("application/json") || contentType.includes("+json")) {
-    try {
-      raw = JSON.stringify(JSON.parse(text), null, 2);
-    } catch {
-      raw = text;
-    }
-  } else if (text) {
-    raw = text;
-  } else if (!raw) {
-    raw = `HTTP ${response.status} ${response.statusText || "OK"}\n${contentType || "binary"} response (${body.byteLength} bytes)`;
-  }
-  return { ok: response.ok, raw, status: response.status, statusText: response.statusText, contentType, retention };
-}
+export { isTextualResponse, playgroundRequest, request } from "./dashboard-fetch";
 
 export function createPlaygroundTurn(input: Omit<PlaygroundTurn, "id" | "response" | "rawResponse"> & { raw: string }): PlaygroundTurn {
   return {
@@ -72,10 +43,6 @@ export function createPlaygroundTurn(input: Omit<PlaygroundTurn, "id" | "respons
     retention: input.retention,
     error: input.error,
   };
-}
-
-export function isTextualResponse(contentType: string) {
-  return /(^text\/|json|xml|html|csv|yaml|graphql|javascript)/i.test(contentType);
 }
 
 export function readyCount(services: ServiceItem[]) {

--- a/admin/test/dashboard-fetch.test.mjs
+++ b/admin/test/dashboard-fetch.test.mjs
@@ -44,7 +44,7 @@ test("dashboard JSON request aborts a hung worker with a default timeout and kee
   assert.equal(seen[1].signal.aborted, true);
 });
 
-test("playground request applies the same hung-fetch timeout", async (context) => {
+test("playground request uses the 600s endpoint budget instead of the 30s dashboard timeout", async (context) => {
   const timeouts = [];
   const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
   context.mock.method(AbortSignal, "timeout", (ms) => {
@@ -60,5 +60,18 @@ test("playground request applies the same hung-fetch timeout", async (context) =
   const result = await playgroundRequest("https://console.example/", "/v1/chat/completions");
   assert.equal(result.status, 200);
   assert.ok(init.signal instanceof AbortSignal);
-  assert.deepEqual(timeouts, [30_000]);
+  assert.deepEqual(timeouts, [600_000]);
+});
+
+test("playground request honors an explicit endpoint timeout", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  context.mock.method(globalThis, "fetch", async () => new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }));
+
+  await playgroundRequest("https://console.example/", "/v1/proxy/openai/chat", {}, 180_000);
+  assert.deepEqual(timeouts, [180_000]);
 });

--- a/admin/test/dashboard-fetch.test.mjs
+++ b/admin/test/dashboard-fetch.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname)) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { playgroundRequest, request } = await import("../src/dashboard-fetch.ts");
+
+test("dashboard JSON request aborts a hung worker with a default timeout and keeps a caller signal", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  const seen = [];
+  context.mock.method(globalThis, "fetch", async (_input, init) => {
+    seen.push(init);
+    return Response.json({ ok: true });
+  });
+
+  await request("https://console.example", "/v1/session");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].credentials, "same-origin");
+  assert.ok(seen[0].signal instanceof AbortSignal);
+  assert.equal(seen[0].signal.aborted, false);
+  assert.deepEqual(timeouts, [30_000]);
+
+  const caller = new AbortController();
+  await request("https://console.example", "/v1/me", { signal: caller.signal });
+  assert.equal(seen.length, 2);
+  assert.notEqual(seen[1].signal, caller.signal);
+  assert.ok(seen[1].signal instanceof AbortSignal);
+  assert.deepEqual(timeouts, [30_000, 30_000]);
+  caller.abort();
+  assert.equal(seen[1].signal.aborted, true);
+});
+
+test("playground request applies the same hung-fetch timeout", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let init;
+  context.mock.method(globalThis, "fetch", async (_input, options) => {
+    init = options;
+    return new Response("ok", { status: 200, headers: { "content-type": "text/plain" } });
+  });
+
+  const result = await playgroundRequest("https://console.example/", "/v1/chat/completions");
+  assert.equal(result.status, 200);
+  assert.ok(init.signal instanceof AbortSignal);
+  assert.deepEqual(timeouts, [30_000]);
+});

--- a/admin/test/dashboard-fetch.test.mjs
+++ b/admin/test/dashboard-fetch.test.mjs
@@ -14,7 +14,7 @@ registerHooks({
 
 const { playgroundRequest, request } = await import("../src/dashboard-fetch.ts");
 
-test("dashboard JSON request aborts a hung worker with a default timeout and keeps a caller signal", async (context) => {
+test("dashboard JSON request leaves headroom for a typed 30s Worker timeout and keeps a caller signal", async (context) => {
   const timeouts = [];
   const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
   context.mock.method(AbortSignal, "timeout", (ms) => {
@@ -32,19 +32,19 @@ test("dashboard JSON request aborts a hung worker with a default timeout and kee
   assert.equal(seen[0].credentials, "same-origin");
   assert.ok(seen[0].signal instanceof AbortSignal);
   assert.equal(seen[0].signal.aborted, false);
-  assert.deepEqual(timeouts, [30_000]);
+  assert.deepEqual(timeouts, [60_000]);
 
   const caller = new AbortController();
   await request("https://console.example", "/v1/me", { signal: caller.signal });
   assert.equal(seen.length, 2);
   assert.notEqual(seen[1].signal, caller.signal);
   assert.ok(seen[1].signal instanceof AbortSignal);
-  assert.deepEqual(timeouts, [30_000, 30_000]);
+  assert.deepEqual(timeouts, [60_000, 60_000]);
   caller.abort();
   assert.equal(seen[1].signal.aborted, true);
 });
 
-test("playground request uses the 600s endpoint budget instead of the 30s dashboard timeout", async (context) => {
+test("playground request uses the 600s endpoint budget instead of the bounded dashboard timeout", async (context) => {
   const timeouts = [];
   const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
   context.mock.method(AbortSignal, "timeout", (ms) => {

--- a/shared/fetch-timeout.ts
+++ b/shared/fetch-timeout.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+export const DASHBOARD_FETCH_TIMEOUT_MS = 60_000;
 export const PLAYGROUND_FETCH_TIMEOUT_MS = 600_000;
 
 export function fetchTimeoutSignal(existing?: AbortSignal | null, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): AbortSignal {

--- a/shared/fetch-timeout.ts
+++ b/shared/fetch-timeout.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+export const PLAYGROUND_FETCH_TIMEOUT_MS = 600_000;
 
 export function fetchTimeoutSignal(existing?: AbortSignal | null, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): AbortSignal {
   const timeout = AbortSignal.timeout(timeoutMs);

--- a/shared/fetch-timeout.ts
+++ b/shared/fetch-timeout.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+export function fetchTimeoutSignal(existing?: AbortSignal | null, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return existing ? AbortSignal.any([existing, timeout]) : timeout;
+}

--- a/worker/oauth.ts
+++ b/worker/oauth.ts
@@ -1,3 +1,4 @@
+import { fetchTimeoutSignal } from "../shared/fetch-timeout.ts";
 import { authorizeAdmin, verifiedAccessSession } from "./access";
 import { authorityCall } from "./authority";
 import { syncGrantPoolIndex } from "./grant-selection";
@@ -44,7 +45,12 @@ export async function oauthCallback(request: Request, env: Env): Promise<Respons
     const secret = envString(env, config.clientSecretConfig); if (!secret) return errorResponse("oauth_not_configured", "provider OAuth client secret is not configured", 503); form.set("client_secret", secret);
   }
   for (const [key, value] of Object.entries(config.extraTokenParams)) form.set(key, value);
-  const tokenResponse = await fetch(config.tokenUrl, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" }, body: form });
+  let tokenResponse: Response;
+  try {
+    tokenResponse = await fetch(config.tokenUrl, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" }, body: form, signal: fetchTimeoutSignal(request.signal) });
+  } catch {
+    return callbackPage(false, "Provider token exchange failed.");
+  }
   const payload: Record<string, unknown> = await tokenResponse.json<Record<string, unknown>>().catch(() => ({}));
   if (!tokenResponse.ok || typeof payload.access_token !== "string") return callbackPage(false, "Provider token exchange failed.");
   const existing = await env.POLICY_KV.get<UpstreamGrant>(state.grantKey, "json");

--- a/worker/test/fetch-timeout.test.mjs
+++ b/worker/test/fetch-timeout.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import { DEFAULT_FETCH_TIMEOUT_MS, fetchTimeoutSignal } from "../../shared/fetch-timeout.ts";
+
+test("fetchTimeoutSignal defaults to 30s and combines a caller abort", () => {
+  assert.equal(DEFAULT_FETCH_TIMEOUT_MS, 30_000);
+  const caller = new AbortController();
+  const combined = fetchTimeoutSignal(caller.signal, 5_000);
+  assert.ok(combined instanceof AbortSignal);
+  assert.notEqual(combined, caller.signal);
+  assert.equal(combined.aborted, false);
+  caller.abort();
+  assert.equal(combined.aborted, true);
+});
+
+test("fetchTimeoutSignal aborts a TCP accept that never sends an HTTP response", async () => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    await assert.rejects(
+      fetch(`http://127.0.0.1:${port}/hung`, { signal: fetchTimeoutSignal(undefined, 40) }),
+      (error) => error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError"),
+    );
+  } finally {
+    server.close();
+  }
+});

--- a/worker/test/oauth-token-fetch.mocks.mjs
+++ b/worker/test/oauth-token-fetch.mocks.mjs
@@ -1,0 +1,46 @@
+export async function verifiedAccessSession() {
+  return { role: "admin", email: "admin@example.com" };
+}
+
+export async function authorizeAdmin() {
+  return { email: "admin@example.com" };
+}
+
+export async function authorityCall() {
+  return {
+    state: {
+      state: "state-1",
+      verifier: "verifier",
+      actorEmail: "admin@example.com",
+      grantKey: "oauth/policy/openai",
+      provider: "openai",
+      priority: 100,
+      weight: 1,
+      redirectUri: "https://console.example/v1/oauth/callback",
+      expiresAtMs: Date.now() + 60_000,
+    },
+  };
+}
+
+export function providerById(id) {
+  if (id !== "openai") return null;
+  return {
+    id: "openai",
+    display_name: "OpenAI",
+    auth: {
+      authorization: {
+        tokenUrl: "https://token.example/oauth/token",
+        clientId: "client",
+        clientIdConfig: null,
+        clientSecretConfig: null,
+        scopes: ["openid"],
+        extraTokenParams: {},
+        grantKind: "oauth",
+        accountIdJsonPointer: null,
+        subscriptionPlanJsonPointer: null,
+      },
+    },
+  };
+}
+
+export async function syncGrantPoolIndex() {}

--- a/worker/test/oauth-token-fetch.test.mjs
+++ b/worker/test/oauth-token-fetch.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (context.parentURL === pathToFileURL(new URL("../oauth.ts", import.meta.url).pathname).href) {
+      if (specifier === "./access" || specifier === "./authority" || specifier === "./providers" || specifier === "./grant-selection") {
+        return { shortCircuit: true, url: new URL("./oauth-token-fetch.mocks.mjs", import.meta.url).href };
+      }
+    }
+    if (specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname)) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { oauthCallback } = await import("../oauth.ts");
+
+test("OAuth token exchange aborts a hung tokenUrl instead of stalling the callback", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let tokenInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), "https://token.example/oauth/token");
+    tokenInit = init;
+    return Response.json({ error: "temporarily_unavailable" }, { status: 504 });
+  });
+
+  const response = await oauthCallback(new Request("https://console.example/v1/oauth/callback?state=state-1&code=auth-code"), {});
+  assert.equal(response.status, 400);
+  assert.match(await response.text(), /Provider token exchange failed/);
+  assert.equal(tokenInit.method, "POST");
+  assert.ok(tokenInit.signal instanceof AbortSignal);
+  assert.equal(tokenInit.signal.aborted, false);
+  assert.deepEqual(timeouts, [30_000]);
+});
+
+test("OAuth token timeout returns the connection-failed page instead of throwing", async (context) => {
+  context.mock.method(globalThis, "fetch", async () => {
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  });
+
+  const response = await oauthCallback(new Request("https://console.example/v1/oauth/callback?state=state-1&code=auth-code"), {});
+  assert.equal(response.status, 400);
+  assert.match(await response.text(), /Provider token exchange failed/);
+});


### PR DESCRIPTION
## What Problem This Solves

The admin console `request` / `playgroundRequest` helpers and the `/v1/oauth/callback` token exchange call `fetch` with no `AbortSignal`. If the Worker or the provider `tokenUrl` stalls, the dashboard stays pending and the OAuth callback never returns a connected/failed page. The proxy path already combines the inbound request signal with a timeout; these two call sites did not.

## Evidence

Live Node against a TCP server that accepts the connection and never writes an HTTP response. The shared helper aborts in ~80ms when given an 80ms budget. The production dashboard `request()` helper uses the default 30s budget and returns `TimeoutError` instead of hanging.

```console
$ node --version && uname -srm
v26.7.0
Darwin 25.6.0 arm64

$ node /tmp/oc-clawrouter-fetch-proof.mjs
hung_server=http://127.0.0.1:50817
default_timeout_ms=30000
helper_abort name=TimeoutError elapsed_ms=83
dashboard_request name=TimeoutError elapsed_ms=30004 timeout_ms=[30000]
proof_ok hung fetch aborted
```

Playground fetches use the Worker manifest ceiling (`PLAYGROUND_FETCH_TIMEOUT_MS = 600_000`). Dashboard JSON stays at 30s. A caller can still pass a shorter budget (coverage uses `180_000`).

```console
$ rg -n "PLAYGROUND_FETCH_TIMEOUT_MS|DEFAULT_FETCH_TIMEOUT_MS" shared/fetch-timeout.ts admin/src/dashboard-fetch.ts
shared/fetch-timeout.ts:1:export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
shared/fetch-timeout.ts:2:export const PLAYGROUND_FETCH_TIMEOUT_MS = 600_000;
admin/src/dashboard-fetch.ts: request() -> fetchTimeoutSignal(init.signal)
admin/src/dashboard-fetch.ts: playgroundRequest(..., timeoutMs = PLAYGROUND_FETCH_TIMEOUT_MS)
```

A token-exchange throw (timeout or network) now returns the existing "Provider token exchange failed." callback page instead of an unhandled Worker exception.

## Real behavior proof

**Behavior or issue addressed:** Dashboard JSON fetches and the OAuth token POST carry a 30s `AbortSignal.timeout`. Playground model and service calls use a 600s budget so they can finish inside the Worker endpoint timeout. A hung peer finishes with `TimeoutError` (dashboard) or the OAuth failed page (callback).

**Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, clawrouter checkout `/tmp/oc-impl-clawrouter-fetch` on `fix/fetch-abort-timeout`. Live `node` against a local hanging HTTP server (accept, no response body).

**Exact steps or command run after this patch:** Started a `node:http` server that never writes a response. Called `fetchTimeoutSignal(undefined, 80)` on `POST /oauth/token`, then called production `request(hung, "/v1/session")` so the default 30s budget is the one compiled into `admin/src/dashboard-fetch.ts`. Ran `pnpm --dir admin test` for the 600s playground default and the explicit 180s override.

**Evidence after fix:** terminal output copied below.

```console
hung_server=http://127.0.0.1:50817
default_timeout_ms=30000
helper_abort name=TimeoutError elapsed_ms=83
dashboard_request name=TimeoutError elapsed_ms=30004 timeout_ms=[30000]
proof_ok hung fetch aborted
```

**Observed result after fix:** The 80ms helper path aborted with `TimeoutError` at 83ms. Production dashboard `request()` recorded `AbortSignal.timeout(30000)` and aborted at 30004ms instead of remaining pending. `playgroundRequest` records `AbortSignal.timeout(600000)` unless the caller passes a shorter `timeoutMs`. OAuth callback maps the same abort to the existing failed HTML page.

**What was not tested:** Live Cloudflare Access admin session through a real provider `tokenUrl`. Grant refresh in `worker/providers.ts` (`refreshGrant`) still has no token-fetch timeout. Browser screenshot of a 10-minute playground completion.

## Summary

- Shared `fetchTimeoutSignal` in `shared/fetch-timeout.ts` (30s dashboard default, 600s playground default, preserves a caller signal)
- Admin console JSON stays on the 30s helper; playground uses the 600s Worker ceiling
- `/v1/oauth/callback` token POST uses the same helper and catches abort/network failures
- Same hang class as [openclaw/clickclack#168](https://github.com/openclaw/clickclack/pull/168)
- Unbounded `fetch` landed in [openclaw/clawrouter#55](https://github.com/openclaw/clawrouter/pull/55) (2026-06-22)
- Proxy already uses `AbortSignal.any` plus a timer in `worker/proxy.ts`
