### PR TITLE
fix(oauth): abort hung grant refresh token fetches

### DIFF
--- a/shared/fetch-timeout.ts
+++ b/shared/fetch-timeout.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+export function fetchTimeoutSignal(existing?: AbortSignal | null, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return existing ? AbortSignal.any([existing, timeout]) : timeout;
+}

--- a/worker/providers.ts
+++ b/worker/providers.ts
@@ -1,3 +1,4 @@
+import { fetchTimeoutSignal } from "../shared/fetch-timeout.ts";
 import snapshotJson from "./generated/provider-snapshot.json" with { type: "json" };
 import { listConnections, resolveConnection } from "./authority.ts";
 import { observeGrantQuota, observeGrantQuotaProbe } from "./grant-quota.ts";
@@ -386,7 +387,9 @@ async function refreshGrant(key: string, grant: UpstreamGrant, provider: Compile
     form.set("client_secret", secret);
   }
   for (const [name, value] of Object.entries(config.extraParams ?? {})) form.set(name, value);
-  const response = await fetch(config.tokenUrl, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" }, body: form });
+  let response: Response;
+  try { response = await fetch(config.tokenUrl, { method: "POST", headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" }, body: form, signal: fetchTimeoutSignal() }); }
+  catch { throw new HttpError(502, "grant_refresh_failed", `provider ${provider.id} rejected the refresh request`); }
   const payload: Record<string, unknown> = await response.json<Record<string, unknown>>().catch(() => ({}));
   if (!response.ok || typeof payload.access_token !== "string") throw new HttpError(502, "grant_refresh_failed", `provider ${provider.id} rejected the refresh request`);
   const now = new Date().toISOString();

--- a/worker/test/fetch-timeout.test.mjs
+++ b/worker/test/fetch-timeout.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import { DEFAULT_FETCH_TIMEOUT_MS, fetchTimeoutSignal } from "../../shared/fetch-timeout.ts";
+
+test("fetchTimeoutSignal defaults to 30s and combines a caller abort", () => {
+  assert.equal(DEFAULT_FETCH_TIMEOUT_MS, 30_000);
+  const caller = new AbortController();
+  const combined = fetchTimeoutSignal(caller.signal, 5_000);
+  assert.ok(combined instanceof AbortSignal);
+  assert.notEqual(combined, caller.signal);
+  assert.equal(combined.aborted, false);
+  caller.abort();
+  assert.equal(combined.aborted, true);
+});
+
+test("fetchTimeoutSignal aborts a TCP accept that never sends an HTTP response", async () => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    await assert.rejects(
+      fetch(`http://127.0.0.1:${port}/hung`, { signal: fetchTimeoutSignal(undefined, 40) }),
+      (error) => error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError"),
+    );
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});

--- a/worker/test/grant-refresh-fetch.test.mjs
+++ b/worker/test/grant-refresh-fetch.test.mjs
@@ -23,8 +23,8 @@ function expiredGrant(tokenUrl) {
     enabled: true,
     provider: "openai",
     kind: "subscription",
-    accessToken: "stale-access",
-    refreshToken: "refresh-fixture",
+    accessToken: "dummy",
+    refreshToken: "placeholder",
     expiresAt: "2020-01-01T00:00:00.000Z",
     refresh: { tokenUrl },
   };
@@ -79,7 +79,7 @@ test("grant refresh attaches a 30s AbortSignal and stores a successful token res
   context.mock.method(globalThis, "fetch", async (input, init) => {
     assert.equal(String(input), "https://token.example/oauth/token");
     tokenInit = init;
-    return Response.json({ access_token: "fresh-access", refresh_token: "fresh-refresh", token_type: "Bearer", expires_in: 3600 });
+    return Response.json({ access_token: "example", refresh_token: "sample", token_type: "Bearer", expires_in: 3600 });
   });
 
   const key = "oauth/policy/openai";
@@ -89,7 +89,7 @@ test("grant refresh attaches a 30s AbortSignal and stores a successful token res
   assert.ok(tokenInit.signal instanceof AbortSignal);
   assert.equal(tokenInit.signal.aborted, false);
   assert.deepEqual(timeouts, [30_000]);
-  assert.equal(updated.accessToken, "fresh-access");
-  assert.equal(updated.refreshToken, "fresh-refresh");
-  assert.equal(env.stored[key].accessToken, "fresh-access");
+  assert.equal(updated.accessToken, "example");
+  assert.equal(updated.refreshToken, "sample");
+  assert.equal(env.stored[key].accessToken, "example");
 });

--- a/worker/test/grant-refresh-fetch.test.mjs
+++ b/worker/test/grant-refresh-fetch.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import { refreshStoredGrant } from "../providers.ts";
+
+function grantEnv(key, grant, stored = {}) {
+  return {
+    stored,
+    POLICY_KV: {
+      async get(requested) {
+        return requested === key ? structuredClone(grant) : null;
+      },
+      async put(requested, value) {
+        stored[requested] = JSON.parse(value);
+      },
+    },
+  };
+}
+
+function expiredGrant(tokenUrl) {
+  return {
+    version: 1,
+    enabled: true,
+    provider: "openai",
+    kind: "subscription",
+    accessToken: "stale-access",
+    refreshToken: "refresh-fixture",
+    expiresAt: "2020-01-01T00:00:00.000Z",
+    refresh: { tokenUrl },
+  };
+}
+
+function isRefreshFailed(error) {
+  return error?.code === "grant_refresh_failed" && error?.status === 502;
+}
+
+test("grant refresh aborts a hung tokenUrl and maps it to grant_refresh_failed", { timeout: 2_000 }, async (context) => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const tokenUrl = `http://127.0.0.1:${port}/oauth/token`;
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  const timeouts = [];
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(40);
+  });
+
+  const key = "oauth/policy/openai";
+  const env = grantEnv(key, expiredGrant(tokenUrl));
+  try {
+    await assert.rejects(() => refreshStoredGrant(env, key), isRefreshFailed);
+    assert.deepEqual(timeouts, [30_000]);
+    assert.equal(env.stored[key], undefined);
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+test("grant refresh timeout uses the existing grant_refresh_failed path", async (context) => {
+  context.mock.method(globalThis, "fetch", async () => {
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  });
+  const key = "oauth/policy/openai";
+  const env = grantEnv(key, expiredGrant("https://token.example/oauth/token"));
+  await assert.rejects(() => refreshStoredGrant(env, key), isRefreshFailed);
+  assert.equal(env.stored[key], undefined);
+});
+
+test("grant refresh attaches a 30s AbortSignal and stores a successful token response", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let tokenInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), "https://token.example/oauth/token");
+    tokenInit = init;
+    return Response.json({ access_token: "fresh-access", refresh_token: "fresh-refresh", token_type: "Bearer", expires_in: 3600 });
+  });
+
+  const key = "oauth/policy/openai";
+  const env = grantEnv(key, expiredGrant("https://token.example/oauth/token"));
+  const updated = await refreshStoredGrant(env, key);
+  assert.equal(tokenInit.method, "POST");
+  assert.ok(tokenInit.signal instanceof AbortSignal);
+  assert.equal(tokenInit.signal.aborted, false);
+  assert.deepEqual(timeouts, [30_000]);
+  assert.equal(updated.accessToken, "fresh-access");
+  assert.equal(updated.refreshToken, "fresh-refresh");
+  assert.equal(env.stored[key].accessToken, "fresh-access");
+});


### PR DESCRIPTION
## What Problem This Solves

`refreshGrant` in `worker/providers.ts` posts the OAuth refresh token to `tokenUrl` with no `AbortSignal`. If the provider token endpoint accepts the TCP connection and never responds, admin grant refresh and proxy grant selection stay pending. The same hang class is already fixed for dashboard fetches and the OAuth callback token POST in #111. This change covers the remaining grant-refresh POST.

## Evidence

Live Node against a TCP server that accepts the connection and never writes an HTTP response. The shared helper aborts in ~80ms when given an 80ms budget. Production `refreshStoredGrant()` uses the default 30s budget, returns `grant_refresh_failed` (502), and does not persist a new grant.

```console
$ node --version && uname -srm
v26.7.0
Darwin 25.6.0 arm64

$ node /tmp/oc-clawrouter-refresh-proof.mjs
hung_server=http://127.0.0.1:51374
default_timeout_ms=30000
helper_abort name=TimeoutError elapsed_ms=91
refresh_grant code=grant_refresh_failed status=502 elapsed_ms=30003 timeout_ms=[30000]
proof_ok hung grant refresh aborted
```

Patched call site on this branch:

```console
$ rg -n "fetchTimeoutSignal|grant_refresh_failed" shared/fetch-timeout.ts worker/providers.ts
shared/fetch-timeout.ts:1:export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
shared/fetch-timeout.ts:3:export function fetchTimeoutSignal(existing?: AbortSignal | null, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): AbortSignal {
worker/providers.ts:1:import { fetchTimeoutSignal } from "../shared/fetch-timeout.ts";
worker/providers.ts:391:  try { response = await fetch(config.tokenUrl, { ..., signal: fetchTimeoutSignal() }); }
worker/providers.ts:392:  catch { throw new HttpError(502, "grant_refresh_failed", `provider ${provider.id} rejected the refresh request`); }
```

A hung or aborted token POST now takes the existing `grant_refresh_failed` path instead of leaving the Worker fetch pending.

## Real behavior proof

- **Behavior or issue addressed:** Grant refresh token POSTs now carry a 30s `AbortSignal.timeout`. A hung `tokenUrl` finishes as `grant_refresh_failed` (502) and does not write a new grant to KV.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, clawrouter checkout `/tmp/oc-impl-clawrouter-refresh` on `fix/refresh-grant-fetch-timeout`. Live `node` against a local hanging HTTP server (accept, no response body).
- **Exact steps or command run after this patch:** Started a `node:http` server that never writes a response. Called `fetchTimeoutSignal(undefined, 80)` on `POST /oauth/token`, then called production `refreshStoredGrant()` with that hung `tokenUrl` so the default 30s budget is the one compiled into `worker/providers.ts`.
- **Evidence after fix:** terminal output copied below.

```console
hung_server=http://127.0.0.1:51374
default_timeout_ms=30000
helper_abort name=TimeoutError elapsed_ms=91
refresh_grant code=grant_refresh_failed status=502 elapsed_ms=30003 timeout_ms=[30000]
proof_ok hung grant refresh aborted
```

- **Observed result after fix:** The 80ms helper path aborted with `TimeoutError` at 91ms. Production `refreshStoredGrant()` recorded `AbortSignal.timeout(30000)` and finished at 30003ms with `grant_refresh_failed` / 502. KV was not updated.
- **What was not tested:** Live Cloudflare Worker against a real provider `tokenUrl`. Dashboard and OAuth callback token POSTs (covered by #111). Browser click of the access-console Refresh action.

## Summary

- Shared `fetchTimeoutSignal` in `shared/fetch-timeout.ts` (30s default). Copied independently because #111 is not on `main` yet. Same helper as that sibling PR.
- `refreshGrant` token POST uses the helper and maps abort or network failure to `grant_refresh_failed`
- Same hang class as [openclaw/clickclack#168](https://github.com/openclaw/clickclack/pull/168) and sibling [openclaw/clawrouter#111](https://github.com/openclaw/clawrouter/pull/111)
- Unbounded refresh `fetch` landed in [openclaw/clawrouter#55](https://github.com/openclaw/clawrouter/pull/55) ([`61cba08`](https://github.com/openclaw/clawrouter/commit/61cba08), 2026-06-22) and has been present for 54 days
- Quota probe in the same file already uses `AbortSignal.timeout(10_000)`
