### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-08-16
 
 - Add opt-in self-hosted console sessions with trusted TLS reverse-proxy origin checks and race-free sign-in throttling; thanks @b3nw for the contribution in #106.
 - Add tenant-global monthly provider budgets with preflight enforcement, dual-ledger settlement, retry-safe accounting, and console spend controls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawrouter-workspace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Stamps the changelog and package version for 0.2.0: self-hosted console sessions (thanks @b3nw), tenant-global monthly provider budgets, console scroll fix, and the OAuth/dashboard fetch timeouts.