### PR TITLE
fix: account for Anthropic cache usage in budget settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Correct Anthropic cache-token costs and budget settlement, preserve cumulative streaming usage, and retain reservations for incomplete Anthropic and OpenAI streams.
 - Prevent control-plane runtime details from reaching client errors while preserving explicit validation failures.
 - Validate deployed Access redirects from parsed URL origins and paths.
 - Refresh the bundled autoreview skill from its canonical source and clarify synthetic detector fixtures.

--- a/docs/agent-spend-control.md
+++ b/docs/agent-spend-control.md
@@ -24,12 +24,22 @@ reference. Chat Completions output bounds are multiplied by `n`.
 Input reservation uses the declared cache-write rate when the request contains
 cache controls. After the response completes, ClawRouter settles reported input,
 cached-input, cache-write, and output tokens at the manifest rates and releases
-the unused reservation. Streaming SSE responses are inspected inline; bodies
-retain backpressure and are not persisted. Missing usage, malformed terminal
+the unused reservation. Streaming SSE responses are inspected from a bounded
+response clone without persisting bodies. Missing usage, malformed terminal
 events, oversized JSON responses, and interrupted streams remain charged at
 the reservation.
-Settlement requires a provider terminal marker (`response.completed`,
+Anthropic and OpenAI streaming settlement requires a provider terminal marker (`response.completed`,
 `message_stop`, or `[DONE]`), not merely a clean transport EOF.
+
+Usage events record total input tokens, including cache reads and writes.
+[Anthropic reports these as disjoint counters](https://platform.claude.com/docs/en/build-with-claude/prompt-caching),
+so ClawRouter adds them before pricing and selecting a long-context tier.
+OpenAI's input total already includes its cache-detail counters and is not
+increased. Cache writes are reported once in `cache_write_input_tokens`; known
+five-minute and one-hour writes use their respective rates, and writes without
+a duration use the highest declared cache-write rate. Anthropic streaming
+updates replace cumulative counters while preserving omitted or null counters
+from earlier events; an incomplete stream retains its reservation.
 
 `requestCostMicros` on a policy is an explicit fixed-cost override. Routes
 without pricing use the legacy one-micro fallback only when no monthly budget

--- a/worker/pricing.ts
+++ b/worker/pricing.ts
@@ -53,7 +53,7 @@ export function actualModelCost(pricing: ModelPricing, tokens: PricedTokens): nu
   let remaining = Math.max(0, tokens.input - cached);
   const write5m = Math.min(remaining, tokens.cacheWrite5m ?? 0); remaining -= write5m;
   const write1h = Math.min(remaining, tokens.cacheWrite1h ?? 0); remaining -= write1h;
-  const genericWrite = Math.min(remaining, tokens.cacheWrite ?? 0); remaining -= genericWrite;
+  const genericWrite = Math.min(remaining, Math.max(0, (tokens.cacheWrite ?? 0) - write5m - write1h)); remaining -= genericWrite;
   const write5mRate = rates.cacheWrite5mInput ?? rates.input;
   const write1hRate = rates.cacheWrite1hInput ?? write5mRate;
   const genericWriteRate = rates.cacheWriteInput ?? Math.max(write5mRate, write1hRate);

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -15,7 +15,7 @@ import {
   resolveTemplate, signSigV4, transformRequestBody, upstreamAuth, upstreamPath,
 } from "./providers";
 import { actualModelCost, estimateModelCost } from "./pricing";
-import { extractUsageTokens, type UsageTokens } from "./token-usage";
+import { extractSseUsageTokens, extractUsageTokens, type UsageTokens } from "./token-usage";
 import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, CompiledQuotaConfig, Env, ProviderConnection, UsageEvent } from "./types";
 import {
   errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
@@ -650,7 +650,7 @@ async function finalizeResponse(response: Response, env: Env, auth: AuthorizedId
   try {
     const contentType = response.headers.get("content-type") ?? "";
     if (contentType.includes("json")) tokens = extractUsageTokens(JSON.parse(await readLimited(response, 2 * 1024 * 1024)));
-    else if (contentType.includes("text/event-stream")) tokens = extractSseTokens(await readLimited(response, 2 * 1024 * 1024));
+    else if (contentType.includes("text/event-stream")) tokens = extractSseUsageTokens(await readLimited(response, 2 * 1024 * 1024));
     else await drainResponseBody(response.body);
   } catch { /* usage is best-effort; reservation stays conservative */ }
   const measured = tokens ? actualCost(selection.model, tokens, auth.policy.requestCostMicros) : null;
@@ -696,17 +696,6 @@ function usageEvent(auth: AuthorizedIdentity, selection: ProxySelection, request
     pricing_effective_at: selection.model?.pricing?.effectiveAt ?? null, cost_basis: cost.basis, status_code: statusCode,
     duration_ms: Date.now() - started, content_retained: !!contentRef, content_ref: contentRef, status,
   };
-}
-
-function extractSseTokens(text: string): Tokens | null {
-  let found: Tokens | null = null;
-  for (const line of text.split("\n")) {
-    if (!line.startsWith("data:")) continue;
-    const data = line.slice(5).trim();
-    if (!data || data === "[DONE]") continue;
-    try { found = extractUsageTokens(JSON.parse(data)) ?? found; } catch { /* ignore partial SSE events */ }
-  }
-  return found;
 }
 
 async function readLimited(response: Response, limit: number): Promise<string> {

--- a/worker/test/pricing.test.mjs
+++ b/worker/test/pricing.test.mjs
@@ -26,7 +26,7 @@ test("opaque inputs and provider-added tools reserve the full input window", () 
 test("cache and long-context rates keep settlement within reservation", () => {
   const tiered = { ...pricing, longContext: { thresholdInputTokens: 10, inputMicrosPerMillion: 5_000_000, outputMicrosPerMillion: 22_500_000, cachedInputMicrosPerMillion: 500_000, cacheWriteInputMicrosPerMillion: null, cacheWrite5mInputMicrosPerMillion: null, cacheWrite1hInputMicrosPerMillion: null } };
   const estimate = estimateModelCost(tiered, { input: "hello", max_output_tokens: 1_000, cache_control: { type: "ephemeral", ttl: "1h" } });
-  const actual = actualModelCost(tiered, { input: estimate.inputTokens, output: 1_000, cached: 100, cacheWrite: 0, cacheWrite5m: 50, cacheWrite1h: 50 });
+  const actual = actualModelCost(tiered, { input: estimate.inputTokens, output: 1_000, cached: 100, cacheWrite: 100, cacheWrite5m: 50, cacheWrite1h: 50 });
   assert.ok(actual != null && actual <= estimate.reserveMicros);
 });
 

--- a/worker/test/proxy-usage.test.mjs
+++ b/worker/test/proxy-usage.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { extractUsageTokens } from "../token-usage.ts";
+import { extractSseUsageTokens, extractUsageTokens } from "../token-usage.ts";
+import { actualModelCost } from "../pricing.ts";
 
 test("OpenAI usage extracts cache writes from Chat Completions and Responses details", () => {
   for (const [inputKey, detailsKey] of [
@@ -48,4 +49,71 @@ test("OpenAI Responses SSE payloads expose nested completed usage", () => {
     cacheWrite5m: null,
     cacheWrite1h: null,
   });
+});
+
+const cachePricing = {
+  inputMicrosPerMillion: 1_000_000, outputMicrosPerMillion: 5_000_000,
+  cachedInputMicrosPerMillion: 100_000, cacheWriteInputMicrosPerMillion: null,
+  cacheWrite5mInputMicrosPerMillion: 1_250_000, cacheWrite1hInputMicrosPerMillion: 2_000_000,
+  longContext: null,
+};
+
+test("Anthropic input includes disjoint cache reads and writes before pricing", () => {
+  for (const [usage, expected] of [
+    [{ input_tokens: 10, cache_creation_input_tokens: 4_000 }, { input: 4_010, cached: null, cacheWrite: 4_000, cacheWrite5m: null, cacheWrite1h: null, cost: 8_110 }],
+    [{ input_tokens: 10, cache_read_input_tokens: 4_000, cache_creation_input_tokens: 0 }, { input: 4_010, cached: 4_000, cacheWrite: 0, cacheWrite5m: null, cacheWrite1h: null, cost: 510 }],
+    [{ input_tokens: 0, cache_read_input_tokens: 1_000, cache_creation_input_tokens: 3_000, cache_creation: { ephemeral_5m_input_tokens: 2_000, ephemeral_1h_input_tokens: 1_000 } }, { input: 4_000, cached: 1_000, cacheWrite: 3_000, cacheWrite5m: 2_000, cacheWrite1h: 1_000, cost: 4_700 }],
+    [{ input_tokens: 10, cache_creation_input_tokens: 3_000, cache_creation_ephemeral_5m_input_tokens: 2_000, cache_creation_ephemeral_1h_input_tokens: 1_000 }, { input: 3_010, cached: null, cacheWrite: 3_000, cacheWrite5m: 2_000, cacheWrite1h: 1_000, cost: 4_610 }],
+  ]) {
+    const { cost, ...counts } = expected;
+    const tokens = extractUsageTokens({ usage: { ...usage, output_tokens: 20 } });
+    assert.deepEqual(tokens, { ...counts, output: 20, total: expected.input + 20 });
+    assert.equal(actualModelCost(cachePricing, tokens), cost);
+  }
+});
+
+test("Anthropic long-context pricing uses the full input, including the cache", () => {
+  const tokens = extractUsageTokens({ usage: { input_tokens: 10, cache_read_input_tokens: 1_000, cache_creation_input_tokens: 0, output_tokens: 20 } });
+  const tiered = { ...cachePricing, longContext: { ...cachePricing, thresholdInputTokens: 1_000, inputMicrosPerMillion: 2_000_000, outputMicrosPerMillion: 10_000_000, cachedInputMicrosPerMillion: 200_000 } };
+  assert.equal(actualModelCost(tiered, tokens), 420);
+  assert.equal(actualModelCost(cachePricing, extractUsageTokens({ usage: { cache_creation_input_tokens: 4_000, output_tokens: 20 } })), null);
+});
+
+const sse = (...events) => events.map((event) => `data: ${typeof event === "string" ? event : JSON.stringify(event)}\n\n`).join("");
+
+test("Anthropic cumulative deltas update cache buckets without summing snapshots", () => {
+  const stream = sse(
+    { type: "message_start", message: { usage: { input_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0, cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 0 }, output_tokens: 1 } } },
+    { type: "message_delta", usage: { input_tokens: 10, cache_read_input_tokens: 1_000, cache_creation_input_tokens: 3_000, cache_creation: { ephemeral_5m_input_tokens: 2_000, ephemeral_1h_input_tokens: 1_000 }, output_tokens: 5 } },
+    { type: "message_delta", usage: { output_tokens: 20, input_tokens: null, cache_read_input_tokens: null, cache_creation_input_tokens: null, cache_creation: null } },
+    { type: "message_stop" },
+  );
+  for (const newline of ["\n", "\r\n", "\r"]) {
+    const tokens = extractSseUsageTokens(stream.replaceAll("\n", newline));
+    assert.equal(actualModelCost(cachePricing, tokens), 4_710);
+    assert.equal(tokens.total, 4_030);
+  }
+});
+
+test("OpenAI streams keep inclusive cache usage and require their terminal event", () => {
+  const usage = { input_tokens: 4_000, input_tokens_details: { cached_tokens: 1_000, cache_write_tokens: 2_000 }, output_tokens: 20 };
+  const chunk = { object: "chat.completion.chunk", usage };
+  const completed = { type: "response.completed", response: { usage } };
+  for (const stream of [sse(chunk, "[DONE]"), sse(completed)]) {
+    const tokens = extractSseUsageTokens(stream);
+    assert.equal(tokens.input, 4_000);
+    assert.equal(actualModelCost(cachePricing, tokens), 5_200);
+  }
+  for (const stream of [
+    sse(chunk),
+    sse(chunk, "[DONE]").trimEnd(),
+    sse({ type: "response.in_progress", response: { usage } }),
+    sse({ type: "response.failed", response: { usage } }),
+    sse(chunk, { error: { message: "fixture stream error" } }, "[DONE]"),
+  ]) assert.equal(extractSseUsageTokens(stream), null);
+});
+
+test("other SSE usage metadata and multiline data retain their existing totals", () => {
+  const stream = ': heartbeat\n\ndata: {"usageMetadata": {\ndata: "promptTokenCount": 100, "candidatesTokenCount": 20, "totalTokenCount": 120}}\n\n';
+  assert.deepEqual(extractSseUsageTokens(stream), { input: 100, output: 20, total: 120, cached: null, cacheWrite: null, cacheWrite5m: null, cacheWrite1h: null });
 });

--- a/worker/test/usage-budget.test.mjs
+++ b/worker/test/usage-budget.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { extname } from "node:path";
 import { registerHooks } from "node:module";
+import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 
 registerHooks({
@@ -11,6 +12,7 @@ registerHooks({
 });
 
 const { default: handler } = await import("../index.ts");
+const { BudgetLedgerObject, providerBudgetStatus } = await import("../ledgers.ts");
 const keyMaterial = "abcdefgh";
 const keyDigest = await sha256(keyMaterial);
 
@@ -33,8 +35,8 @@ test("GET /v1/usage preserves the budget response contract while selecting the c
   assert.equal(objectNames[0], "tenant:maintainer_access:owner@example.com");
 });
 
-function usageEnv(objectNames) {
-  const policy = { enabled: true, generation: "policy_v1", providers: ["openai"], tenantId: "tenant", monthlyBudgetMicros: 100, requestCostMicros: 1, budgetScope: "principal", retainRequestContent: true };
+function usageEnv(objectNames, { provider = "openai", limit = 100, fixedCost = 1, retainContent = true } = {}) {
+  const policy = { enabled: true, generation: "policy_v1", providers: [provider], tenantId: "tenant", monthlyBudgetMicros: limit, requestCostMicros: fixedCost, budgetScope: "principal", retainRequestContent: retainContent };
   const credential = { enabled: true, ["sec" + "retSha256"]: keyDigest, policyId: "maintainer_access", policyGeneration: "policy_v1", principalId: "owner@example.com" };
   const access = {
     idFromName: (name) => name,
@@ -43,13 +45,15 @@ function usageEnv(objectNames) {
       if (path === "/credentials/resolve") return Response.json({ initialized: true, credentials: [{ credentialId: "maintainer_key", credential }], missingCredentialIds: [] });
       if (path === "/policies/resolve") return Response.json({ initialized: true, policies: [{ policyId: "maintainer_access", policy }], missingPolicyIds: [] });
       if (path === "/users/resolve") return Response.json({ initialized: true, users: [], missingEmails: [] });
+      if (path === "/connections/resolve") return Response.json({ initialized: true, connections: [{ providerId: provider, enabled: true, monthlyBudgetMicros: limit }], missingProviderIds: [] });
+      if (path === "/grant-pools/resolve") return Response.json({ keys: [], states: {} });
       throw new Error(`unexpected authority path ${path}`);
     } }),
   };
   const budget = { idFromName: (name) => name, get: (name) => ({ fetch: async () => { objectNames.push(name); return Response.json({ spentMicros: 10, remainingMicros: 90 }); } }) };
   const emptyUsage = { ledger: "durable_object", summary: { requestCount: 0, successCount: 0, errorCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, actualCostMicros: 0 }, providers: [], daily: [], events: [] };
   const usage = { idFromName: (name) => name, get: () => ({ fetch: async () => Response.json(emptyUsage) }) };
-  return { ACCESS_CONTROL: access, BUDGET_LEDGER: budget, USAGE_LEDGER: usage, POLICY_KV: { get: async () => null } };
+  return { ACCESS_CONTROL: access, BUDGET_LEDGER: budget, USAGE_LEDGER: usage, POLICY_KV: { get: async (keys) => Array.isArray(keys) ? new Map() : null } };
 }
 
 function proxyKey() { return ["clawrouter", "live", `maintainer_key-${keyMaterial}`].join("-"); }
@@ -57,4 +61,76 @@ function proxyKey() { return ["clawrouter", "live", `maintainer_key-${keyMateria
 async function sha256(value) {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+const messageUsage = { input_tokens: 10, cache_read_input_tokens: 1_000, cache_creation_input_tokens: 3_000, cache_creation: { ephemeral_5m_input_tokens: 2_000, ephemeral_1h_input_tokens: 1_000 }, output_tokens: 20 };
+const messageStart = { type: "message_start", message: { type: "message", usage: { ...messageUsage, output_tokens: 1 } } };
+const messageDelta = { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 20 } };
+const messageStop = { type: "message_stop" };
+const sse = (...events) => events.map((event) => `data: ${typeof event === "string" ? event : JSON.stringify(event)}\n\n`).join("");
+
+for (const [name, body, contentType, measured] of [
+  ["JSON", JSON.stringify({ type: "message", usage: messageUsage }), "application/json", true],
+  ["SSE", sse(messageStart, { type: "message_delta", usage: { output_tokens: 5 } }, messageDelta, messageStop), "text/event-stream", true],
+  ["SSE without message_stop", sse(messageStart, messageDelta), "text/event-stream", false],
+  ["SSE without final usage", sse(messageStart, messageStop), "text/event-stream", false],
+  ["SSE with malformed final usage", sse(messageStart, "{broken", messageStop), "text/event-stream", false],
+]) {
+  test(`Anthropic ${name} settles policy and provider budgets from complete cache usage`, async (t) => {
+    const limit = 13_500;
+    const env = usageEnv([], { provider: "anthropic", limit, fixedCost: null, retainContent: false });
+    env.ANTHROPIC_API_KEY = "fixture-anthropic-key";
+    env.BUDGET_LEDGER = sqlBudgetNamespace(t);
+    const events = [];
+    env.USAGE_QUEUE = { send: async (event) => { events.push(event); } };
+    const upstream = t.mock.method(globalThis, "fetch", async () => new Response(body, { headers: { "content-type": contentType } }));
+    const pending = [];
+    const context = { waitUntil: (promise) => { pending.push(promise); } };
+    const request = new Request("https://clawrouter.example/v1/messages", {
+      method: "POST", headers: { authorization: `Bearer ${proxyKey()}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: "anthropic/claude-haiku-4-5", max_tokens: 20, stream: contentType === "text/event-stream", messages: [{ role: "user", content: [{ type: "text", text: "a".repeat(4_000), cache_control: { type: "ephemeral", ttl: "1h" } }] }] }),
+    });
+    const response = await handler.fetch(request.clone(), env, context);
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), body);
+    await Promise.all(pending);
+    const [event] = events;
+    assert.equal(events.length, 1);
+    const expectedCost = measured ? 4_710 : event.reserved_cost_micros;
+    assert.ok(event.reserved_cost_micros > 4_710);
+    assert.equal(event.actual_cost_micros, expectedCost);
+    if (measured) {
+      assert.deepEqual([event.input_tokens, event.output_tokens, event.total_tokens, event.cached_input_tokens, event.cache_write_input_tokens], [4_010, 20, 4_030, 1_000, 3_000]);
+    }
+    const usageResponse = await handler.fetch(new Request("https://clawrouter.example/v1/usage", { headers: { authorization: `Bearer ${proxyKey()}` } }), env, {});
+    assert.equal((await usageResponse.json()).budget.spentMicros, expectedCost);
+    assert.equal((await providerBudgetStatus(env, "anthropic", limit)).spentMicros, expectedCost);
+    const denied = await handler.fetch(request, env, context);
+    assert.equal(denied.status, 402);
+    assert.equal((await denied.json()).error.code, "budget_exhausted");
+    await Promise.all(pending);
+    assert.equal(upstream.mock.callCount(), 1);
+  });
+}
+
+function sqlBudgetNamespace(t) {
+  const objects = new Map();
+  return {
+    idFromName: (name) => name,
+    get(name) {
+      if (!objects.has(name)) {
+        const db = new DatabaseSync(":memory:");
+        t.after(() => db.close());
+        const sql = { exec(query, ...bindings) {
+          const statement = db.prepare(query);
+          if (statement.columns().length) return statement.all(...bindings);
+          statement.run(...bindings);
+          return [];
+        } };
+        const ledger = new BudgetLedgerObject({ storage: { sql, getAlarm: async () => 1 } });
+        objects.set(name, { fetch: (url, init) => ledger.fetch(new Request(url, init)) });
+      }
+      return objects.get(name);
+    },
+  };
 }

--- a/worker/token-usage.ts
+++ b/worker/token-usage.ts
@@ -3,27 +3,79 @@ export interface UsageTokens {
   output: number | null;
   total: number | null;
   cached: number | null;
-  cacheWrite: number | null;
+  cacheWrite: number | null; // Total writes, including the duration-specific buckets below.
   cacheWrite5m: number | null;
   cacheWrite1h: number | null;
 }
 
 export function extractUsageTokens(value: unknown): UsageTokens | null {
-  if (!value || typeof value !== "object") return null;
-  const root = value as Record<string, unknown>;
-  const response = root.response && typeof root.response === "object" ? root.response as Record<string, unknown> : null;
-  const usage = (root.usage ?? response?.usage ?? root.usageMetadata ?? root.meta) as Record<string, unknown> | undefined;
-  if (!usage || typeof usage !== "object") return null;
-  const input = pickNumber(usage, "input_tokens", "prompt_tokens", "inputTokens", "promptTokenCount");
+  const usage = usageRecord(record(value));
+  if (!usage) return null;
+  const reportedInput = pickNumber(usage, "input_tokens", "prompt_tokens", "inputTokens", "promptTokenCount");
   const output = pickNumber(usage, "output_tokens", "completion_tokens", "outputTokens", "candidatesTokenCount");
-  const total = pickNumber(usage, "total_tokens", "totalTokens", "totalTokenCount") ?? (input != null || output != null ? (input ?? 0) + (output ?? 0) : null);
-  const details = (usage.prompt_tokens_details ?? usage.input_tokens_details) as Record<string, unknown> | undefined;
+  const details = record(usage.prompt_tokens_details ?? usage.input_tokens_details);
   const cached = details ? pickNumber(details, "cached_tokens", "cache_read_input_tokens") : pickNumber(usage, "cache_read_input_tokens");
-  const cacheWrite = (details ? pickNumber(details, "cache_write_tokens") : null) ?? pickNumber(usage, "cache_creation_input_tokens");
-  const cacheCreation = usage.cache_creation as Record<string, unknown> | undefined;
+  const cacheCreation = record(usage.cache_creation);
   const cacheWrite5m = cacheCreation ? pickNumber(cacheCreation, "ephemeral_5m_input_tokens") : pickNumber(usage, "cache_creation_ephemeral_5m_input_tokens");
   const cacheWrite1h = cacheCreation ? pickNumber(cacheCreation, "ephemeral_1h_input_tokens") : pickNumber(usage, "cache_creation_ephemeral_1h_input_tokens");
-  return { input, output, total, cached, cacheWrite: cacheWrite5m != null || cacheWrite1h != null ? Math.max(0, (cacheWrite ?? 0) - (cacheWrite5m ?? 0) - (cacheWrite1h ?? 0)) : cacheWrite, cacheWrite5m, cacheWrite1h };
+  const cacheWrite = (details ? pickNumber(details, "cache_write_tokens") : null) ?? pickNumber(usage, "cache_creation_input_tokens")
+    ?? (cacheWrite5m != null || cacheWrite1h != null ? (cacheWrite5m ?? 0) + (cacheWrite1h ?? 0) : null);
+  // Anthropic's top-level cache buckets exclude ordinary input; OpenAI's details
+  // are already included. Pricing and usage ledgers both consume inclusive input.
+  const input = reportedInput == null ? null : reportedInput + (details ? 0 : (cached ?? 0) + (cacheWrite ?? 0));
+  const total = pickNumber(usage, "total_tokens", "totalTokens", "totalTokenCount") ?? (input != null || output != null ? (input ?? 0) + (output ?? 0) : null);
+  return { input, output, total, cached, cacheWrite, cacheWrite5m, cacheWrite1h };
+}
+
+export function extractSseUsageTokens(text: string): UsageTokens | null {
+  let found: UsageTokens | null = null;
+  let messageUsage: Record<string, unknown> | null = null;
+  let messageDeltaSeen = false;
+  let terminal: "message" | "response" | "chat" | null = null;
+  const events = text.replace(/\r\n|\r/g, "\n").split("\n\n");
+  events.pop(); // An unterminated SSE frame is not a complete usage report.
+  for (const event of events) {
+    const data = event.split("\n").filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim()).join("\n");
+    if (!data) continue;
+    if (data === "[DONE]") return terminal === "message" || terminal === "response" ? null : found;
+    let root: Record<string, unknown> | null;
+    try { root = record(JSON.parse(data)); } catch { return null; }
+    if (!root) return null;
+    if (root.error || root.type === "error" || root.type === "response.failed" || root.type === "response.incomplete") return null;
+    if (root.type === "response.completed") return extractUsageTokens(root);
+    if (typeof root.type === "string" && root.type.startsWith("response.")) terminal = "response";
+    if (root.object === "chat.completion.chunk") terminal = "chat";
+    if (root.type === "message_start") {
+      terminal = "message";
+      messageUsage = usageRecord(root);
+      messageDeltaSeen = false;
+    } else if (root.type === "message_delta") {
+      if (!messageUsage) return null;
+      const delta = usageRecord(root);
+      messageDeltaSeen = delta != null && pickNumber(delta, "output_tokens") != null;
+      if (delta) {
+        // Message deltas are cumulative, but omit unchanged input/cache fields.
+        // Merge the raw counters before normalizing so cached input is added once.
+        const updates = Object.fromEntries(Object.entries(delta).filter(([, value]) => value != null));
+        const creation = record(updates.cache_creation);
+        if (creation) updates.cache_creation = { ...record(messageUsage.cache_creation), ...creation };
+        Object.assign(messageUsage, updates);
+      }
+    } else if (root.type === "message_stop") {
+      return messageUsage && messageDeltaSeen ? extractUsageTokens({ usage: messageUsage }) : null;
+    } else {
+      found = extractUsageTokens(root) ?? found;
+    }
+  }
+  return terminal ? null : found;
+}
+
+function usageRecord(root: Record<string, unknown> | null): Record<string, unknown> | null {
+  return root ? record(root.usage ?? record(root.response)?.usage ?? record(root.message)?.usage ?? root.usageMetadata ?? root.meta) : null;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
 }
 
 function pickNumber(value: Record<string, unknown>, ...keys: string[]): number | null {


### PR DESCRIPTION
Anthropic reports ordinary input, cache reads, and cache writes as disjoint counters. ClawRouter treated them as an inclusive input total, so pricing clamped cache charges to the much smaller ordinary-input count. Streaming also discarded the input/cache snapshot when the final output-only usage delta arrived. This affected both reported cost and authoritative budget settlement.

Normalize usage once at the token-usage boundary: inclusive input, total cache writes, and duration-specific write buckets. Pricing subtracts those buckets before charging any writes with an unknown duration. Accumulate Anthropic message usage until `message_stop`, preserve omitted/null cumulative fields, and require the appropriate completion marker for OpenAI streams too. Remove the old last-usage-row SSE extractor. Usage events and both budget ledgers now consume the same corrected totals. Update the spend-control documentation and changelog.

Protocol evidence: [Anthropic cache counters](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), [cumulative streaming usage](https://platform.claude.com/docs/en/build-with-claude/streaming), and [the SDK accumulation contract](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/lib/MessageStream.ts).

Verification:

- Captured failing regressions before the fix: JSON charged 101 instead of 4,710 microdollars; SSE retained its 10,494-microdollar reservation instead of settling to 4,710.
- `pnpm check` passed: Worker TypeScript/tests, admin TypeScript/tests, and script tests. The initial TypeScript failure in the accumulator expression was corrected before the successful run.
- `pnpm worker:e2e` passed through local workerd.
- Real Anthropic requests through the proxy handler, with synthetic content and actual SQLite budget-ledger objects: a JSON cache write and a subsequent SSE cache read produced matching independently calculated costs, usage events, and policy/provider balances. No production policy or ledger was changed.
- Regression coverage includes cache reads, mixed five-minute/one-hour writes, unknown-duration writes, long-context selection, cumulative/null stream deltas, incomplete streams, unchanged OpenAI inclusive counts, and rejection of the next request based on corrected spend.
- Codex autoreview completed with no actionable findings at its P0 threshold.

Production code: +41 net lines for the missing stream accumulator/completion boundary and normalization, replacing the old extractor. Tests: +144 net lines. No dependencies, configuration, rates, or database schemas change.

Deployment: not deployed by this PR; production uses a separate manual workflow. Existing historical usage and budget entries are not recalculated. Correctly charged cache traffic can reach configured budget limits sooner; incomplete Anthropic/OpenAI streams keep their conservative reservation.
