### PR TITLE
feat: add an isolated alias-only Codex facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Claude Opus 5 and Sonnet 5 with current cache pricing, and release token-priced reservations for Anthropic refusals before any output while preserving reported usage.
 - Correct Anthropic cache-token costs and budget settlement, preserve cumulative streaming usage, and retain reservations for incomplete Anthropic and OpenAI streams.
+- Add an opt-in private Responses alias facade with verified owner or isolated opaque-workload authentication and broker-only OAuth, explicit reasoning capabilities and disclosure of unenforced subscription output limits, bounded native Lite protocol and typed model containment, and no shared catalog, grant, retention, or billing integration; full client and isolation proof remain deployment prerequisites.
 - Prevent control-plane runtime details from reaching client errors while preserving explicit validation failures.
 - Validate deployed Access redirects from parsed URL origins and paths.
 - Refresh the bundled autoreview skill from its canonical source and clarify synthetic detector fixtures.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Clients authenticate with one policy-scoped `clawrouter-` credential. The select
 
 Models use provider-qualified IDs such as `openai/gpt-4.1-mini`. `GET /v1/catalog` reports only the providers, models, and transports the caller can execute. See the [API reference](docs/api-reference.md) for the complete route inventory and authentication boundaries.
 
+The opt-in [private alias facade](docs/private-codex.md) is a separate, Responses-only contract for an isolated owner-only runtime, not a model in the shared catalog or per-user protection for a shared Gateway. It requires separately provisioned secret-store bindings and has no generic billing or retention.
+
 ## Provider catalog
 
 Provider support starts with one manifest:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,8 @@ Browser session, playground, and OAuth routes require a verified Cloudflare Acce
 
 The Docker self-hosting profile has no Cloudflare Access identity. Its admin API uses the bearer token, and clients use normal proxy credentials.
 
+The optional `/private/v1/{models,catalog,responses}` facade has its own pinned owner or isolated-workload authentication and never accepts generic proxy/admin credentials. See the [private alias contract](private-codex.md) for exact paths, configuration, protocol limits, and isolation requirements. It is absent from public discovery.
+
 ## Discovery and client routes
 
 | Method | Path | Purpose |

--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -1,0 +1,454 @@
+# Private alias inference facade
+
+This opt-in, bounded Responses facade is for a **separately isolated, owner-only
+OpenClaw Gateway or Codex runtime**. It is not per-user security for a shared
+Gateway. Production Team must not receive these bindings or credentials. Shared
+agents must have no access to the private ingress credential, process, workspace,
+session namespace, or upstream subscription. Use a separate deployment and
+administrative trust boundary; a deployment operator can change its code or
+bindings and is necessarily trusted. Include owner-authenticated browser profiles
+and remote-node/tool capabilities in that boundary: shared agents must not be able
+to drive a browser carrying the owner's session or administer the private cell.
+
+Nothing in this implementation provisions that isolation. Local synthetic tests
+do not prove live subscription entitlement, client compatibility, owner-only
+ingress, or OS/process isolation. In particular, `/responses` support does not
+establish native Codex integration.
+
+## Runtime configuration
+
+Two separate, owner-controlled secret-store object bindings are required. Each
+implements `get(): Promise<string>` returning one JSON document. These are not
+ordinary string environment credentials, `POLICY_KV` records, manifest values,
+generic grants, or admin configuration. No generic admin read/mutation endpoint
+exposes or changes them. Never place the upstream document in source, fixtures,
+deployment vars, reports, or client configuration. The manifest compiler and
+admin bundle have no private model entry.
+
+`PRIVATE_CODEX_POLICY` has this exact shape (unknown fields are rejected):
+
+```json
+{
+  "version": 1,
+  "enabled": true,
+  "alias": { "id": "codex-latest", "name": "Codex (Latest)" },
+  "auth": {
+    "mode": "access",
+    "issuer": "https://synthetic-owner.cloudflareaccess.com",
+    "audience": "SYNTHETIC-PRIVATE-APPLICATION-AUDIENCE",
+    "githubAccountId": 123456,
+    "identityProviderId": "SYNTHETIC-APPROVED-GITHUB-IDP"
+  }
+}
+```
+
+`alias` may also contain `supportedReasoningEfforts`, using the existing client
+catalog field name. When supplied, it must be a nonempty array of 1–7 unique,
+case-sensitive values from `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+and `max`. Null, empty, duplicate, unknown or oversized lists fail closed.
+The approved list is preserved in authenticated private `/models` and `/catalog`
+model rows only; it is not added to inference requests or public discovery.
+An id/name-only alias remains valid and omits this descriptor. The facade never
+infers reasoning from the alias, provider or upstream identifier, and does not
+assume every private model supports reasoning.
+
+Source the configured capabilities from the actual entitled model's metadata
+through trusted owner provisioning. Publish only its verified intersection with
+the supported public effort enum; do not guess, invent or relabel an unsupported
+upstream level. This is a capability descriptor, not entitlement or a native
+JSON ModelInfo artifact. The parent must continue supplying full alias-only
+native ModelInfo separately. The field does not advertise pricing, token limits,
+context capacity or full context support; those contracts are unchanged.
+
+The example contains synthetic identity values. Replace them through the parent's
+approved provisioning flow. The issuer must be a lowercase HTTPS
+`*.cloudflareaccess.com` origin without a path. Audience and identity-provider ID
+are exact, case-sensitive, non-whitespace ASCII strings of 1–256 characters.
+`githubAccountId` must be a positive safe integer (at most 9007199254740991).
+Both GitHub account and approved IdP pins are required. The earlier unshipped
+`subject`-only configuration is rejected; there is no fallback.
+
+The facade first uses the existing RSA Access JWT verifier for signature,
+audience, issuer and time validation and requires the exact configured issuer.
+Only then does it request that exact assertion's identity from the pinned
+issuer's `/cdn-cgi/access/get-identity`, using `Cookie: CF_Authorization=<assertion>`.
+It never chooses a destination from unverified claims, follows redirects, or
+forwards caller cookies. The lookup uses `cache: "no-store"`, has no application
+cache, and has no stale-identity or management-API fallback. HTTP failure,
+malformed/oversized data, unsupported encoding, timeout or cancellation denies
+access with generic not-found before private upstream secret resolution.
+
+The response must contain `idp.type: "github"`, the exact configured `idp.id`,
+and a numeric positive safe-integer `id` matching `githubAccountId`. Its `email`
+must match the verified JWT's email after trimming and lowercasing; both are
+nonempty strings limited to 1024 characters. Email only correlates the lookup
+with the assertion; it does not authorize. An unchanged email or Access subject
+cannot authorize a different GitHub account. A changed email or subject can be
+accepted when token/identity correlate and the GitHub account and IdP pins match.
+Names, login handles, groups, admin roles, local sessions and caller identity
+headers never substitute for those pins.
+
+[Cloudflare documents Access `sub`](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/)
+as unique to an email address within a Cloudflare account, not as an immutable
+GitHub account identifier. The old subject-only path proved only its configured
+Access subject; no email-transfer exploit is asserted. The replacement binds
+authorization to the numeric GitHub identity and approved IdP reported for the
+verified assertion. Synthetic signed-JWT tests prove the local enforcement, not
+Cloudflare's real GitHub-specific response shape: the parent must prove that
+shape using a real human assertion before enabling Access mode.
+
+Policy and token validity are checked again after awaited lookup/binding work;
+inference repeats verification and identity lookup after upload, then rechecks
+policy and the fixed upstream binding before egress. Each lookup shares a
+ten-second deadline with JWT verification and accepts at most 64 KiB of UTF-8
+JSON. Cancellation propagates through fetch and body reads. The verifier's
+existing clock tolerances remain (30 seconds for `nbf`, 300 for `iat`); expiration
+must remain in the future. No token or identity body enters logs or discovery.
+
+Disable the private policy to revoke subsequent requests. Generic user/admin
+policy changes do not revoke this independent authority. A token-specific
+Cloudflare lookup is not proof of an active GitHub browser session, an immediate
+GitHub revocation check, or ongoing delegated human authority. Cloudflare's
+identity/revocation propagation and the secret store's consistency remain
+external limits. Requests already streaming are not continuously reauthorized
+or terminated by later policy changes. Owner-only ingress and process/browser
+isolation, real identity proof, and the other deployment gates remain required.
+
+Alternatively, replace `auth` with exactly:
+
+```json
+{
+  "mode": "workload",
+  "credentialSha256": "LOWERCASE-SHA256-HEX-DIGEST"
+}
+```
+
+The digest is exactly 64 lowercase hex characters. The separately provisioned
+credential has the form `private-workload-` followed by 32–128 URL-safe ASCII
+characters (`A–Z`, `a–z`, `0–9`, `_`, `-`). Provision at least 256 random bits;
+do not derive it from a user/session or reuse any admin, proxy, or upstream secret.
+Only its SHA-256 digest is stored in policy. Requests use the exact header
+`Authorization: Bearer <private-workload-credential>`. This bearer authenticates
+the dedicated workload, **not the human**, is transferable if stolen, and is not
+delegated human authority. Owner-only ingress and OS/process isolation are
+mandatory. There is no signature/TTL/attribution scheme claiming otherwise.
+
+These are the only two supported authentication modes and are mutually exclusive.
+Workload mode rejects Access JWT authentication; Access mode rejects Authorization.
+Conflicting authentication headers are rejected even when their values are empty.
+Alternate API-key headers, proxy auth, and Access service-token headers are
+rejected. Cookies and caller identity headers
+cannot authenticate. Configuration and authentication are read on each request,
+and rechecked after the request upload immediately before egress.
+
+OAuth credentials must stay **broker-only**. Neither native Codex nor OpenClaw,
+their tools, nor other client processes may receive the upstream token, account
+binding, or access to the broker's secret store, files or process memory. Giving
+a tool-bearing client OAuth would let it bypass the facade and query the raw
+upstream catalogue directly. Inference workloads receive only the independent
+opaque workload credential, which cannot authenticate to the upstream provider. The facade
+serves only alias-safe discovery; it offers no raw catalogue, OAuth, arbitrary
+proxy or account-selection endpoint. Caller `ChatGPT-Account-ID` and custom
+account headers are rejected in both modes. Only the broker constructs the
+upstream account header from its fixed authenticated binding.
+
+`PRIVATE_CODEX_UPSTREAM` has exactly these fields:
+
+| Field | Contract |
+| --- | --- |
+| `version` | Number `1` |
+| `target` | Runtime-only upstream binding; 8–128 ASCII letters/digits/`.`/`_`/`-`, beginning with a letter/digit |
+| `accountId` | Exact subscription account; 8–128 ASCII letters/digits/`_`/`-` |
+| `accessToken` | Separately held subscription access token; 16–8192 ASCII letters/digits/`.`/`_`/`~`/`-` |
+| `expiresAt` | Integer Unix **milliseconds**, at least 30 seconds in the future |
+
+The alias ID is 3–64 lowercase ASCII letters/digits/hyphens, beginning with a
+letter. Its display name is 1–80 printable ASCII characters. Use the safe values
+shown above. Neither may contain the target, account ID, or upstream token.
+Both binding documents are limited to 16 KiB of text. Missing, disabled, malformed,
+expired, inaccessible, or mid-request changed configuration fails closed.
+
+The upstream binding is read **only after authentication**, including on private
+discovery. The adapter sends exactly that account and token to the fixed
+subscription Responses URL already declared by the OpenAI provider manifest.
+No caller can change the provider, account, origin, or target. There are no
+redirects, retries, alternate accounts, API-key fallbacks, generic grant lookups,
+Fusion paths, or arbitrary-model/native routing inside this facade.
+
+Automatic OAuth refresh is intentionally absent. The existing shared refresh
+helper writes shared grant state and does not provide this boundary's required
+revocation/rotation transaction. The parent must provide an owner-only lifecycle
+that atomically replaces this private token/account/expiry document, or accept
+fail-closed expiry. Token/account correspondence and subscription eligibility
+still require trusted provisioning and upstream proof. No refresh tokens are
+accepted here. Binding read freshness depends on the deployed secret store;
+there is no extra application cache or promise of instantaneous revocation of
+already transmitted requests/streams.
+
+Broker token rotation does not require changing the independent client workload
+credential or exposing the new token to clients. Changes during a request's
+upload still fail closed. Binding expiry must reflect the real token lifetime;
+provider expiry/revocation denials remain denials.
+
+## Endpoints and client contract
+
+| Method | Exact path | Result |
+| --- | --- | --- |
+| GET | `/private/v1/models` | One OpenAI-style model: safe ID, `display_name`, `llm.responses` capability |
+| GET | `/private/v1/catalog` | Client catalog v1 with a private Responses provider; model `upstream` equals the alias because the catalog contract requires it |
+| POST | `/private/v1/responses` | Bounded JSON or SSE Responses transport |
+
+The catalog intentionally retains the existing V1 consumer shape:
+`nativeBaseUrl: "/v1/native/private"`, route `path: "/v1/responses"`, and
+`openaiCompatible: true`, with only `llm.responses` advertised. The native base
+is a catalog schema field, not an enabled transport. Only the private unified
+Responses endpoint executes; private and public native/proxy routes do not gain
+access to this binding.
+
+OpenClaw reads `supportedReasoningEfforts` from each catalog model row to enable
+reasoning and construct its compatible effort mapping without depending on an
+opaque alias's spelling. Configure this descriptor for a reasoning-capable model;
+omitting it can change the consumer's request semantics, including whether its
+Responses system prompt uses a developer role. The descriptor does not change
+review requirements, provenance, sandbox settings or the private auth boundary.
+
+Unauthorized callers receive the same generic 404 body and private no-store
+headers as unknown private routes. No private alias appears in public discovery,
+service indexes, provider snapshots, routes, or generic admin metadata. No CORS
+or public correlation/header reflection is added to private responses.
+
+Only the configured alias is accepted in the top-level `model`. `store: false`
+is required, and background execution is rejected. The adapter rewrites `model`
+only when constructing the upstream body. Input, tool schemas, instructions,
+reasoning, encrypted content, and accepted client metadata are not rewritten.
+Top-level request fields are limited to `model`, `input`, `instructions`, `stream`,
+`store`, `tools`, `tool_choice`, `parallel_tool_calls`, `reasoning`, `text`,
+`include`, `max_output_tokens`, `temperature`, `top_p`, `truncation`, `metadata`,
+`previous_response_id`, `prompt_cache_key`, `prompt_cache_retention`,
+`safety_identifier`, `service_tier`, `background` (absent or false),
+`client_metadata`, `stream_options`, and `access_programs`.
+Unknown top-level fields fail closed. Nested tool schemas/data and metadata are
+opaque input, never routing configuration.
+
+The fixed subscription adapter accepts optional `max_output_tokens` only as a
+positive safe integer (1–9,007,199,254,740,991) for client compatibility. It omits
+**only that top-level field** when building the upstream body, without mutating
+the original request or nested data. The subscription backend does not support
+this generation option. All other accepted fields, including `service_tier`,
+review/approval metadata, attestation and genuine client facts, remain unchanged.
+Requests without the field retain their existing semantics apart from the
+alias and routing-hint translation. No client configuration knob is required.
+
+After adapting an authenticated inference request that supplied a valid value,
+the facade generates `x-clawrouter-ignored-parameters: max_output_tokens` on its
+JSON/SSE response, including provider denials and transport failures. The header
+contains only the field name, never the caller's value. It is absent for discovery,
+unauthorized or locally invalid requests, and requests that did not supply the
+option. Caller/upstream copies of that header are not trusted or reflected.
+The disclosure remains subject to private identity containment; if it cannot be
+emitted safely, the request fails without leaking the identity.
+
+**This is not an enforced output limit or budget.** Subscription generation is
+provider-controlled; using this endpoint cannot promise a caller token cap.
+The existing byte, queue and time limits still apply, and private accounting
+remains deliberately unmetered. Native subscription transports already omit
+this option, but that does not justify stripping their broader legacy parameter
+list here or claiming that a discarded limit was honored.
+
+The additional body fields follow the inspected native Codex HTTP wire contract.
+`client_metadata` is a bounded string map containing only `x-codex-installation-id`,
+`session_id`, `thread_id`, `turn_id`, `parent_turn_id`, `root_turn_id`,
+`x-codex-window-id`, `x-codex-parent-thread-id`, `x-openai-subagent`, and
+`x-codex-turn-metadata`. The last field is a JSON object encoded as a string;
+its sandbox, review, workspace and tool-inventory facts remain unchanged.
+`stream_options` permits exactly `reasoning_summary_delivery: "sequential_cutoff"`
+on streaming requests. `access_programs` permits exactly one `cyber` wire token
+(1–64 lowercase letters/digits/underscores, starting with a letter). It is an
+upstream access selection, not entitlement granted by this facade. These optional
+fields may be absent or null. No program, review flag, attestation, or fallback is
+fabricated. Unknown fields and malformed values are rejected.
+
+Forwarded headers are limited to genuine caller `version`, `session-id`, `thread-id`,
+`session_id`, `x-client-request-id`, `user-agent`, `originator`, `openai-beta`,
+`x-openai-internal-codex-responses-lite`, `x-codex-beta-features`,
+`x-codex-turn-state`, `x-codex-turn-metadata`, `x-codex-parent-thread-id`,
+`x-codex-window-id`, `x-oai-attestation`, `x-openai-subagent`,
+`x-openai-memgen-request`, `x-responsesapi-include-timing-metrics`, `traceparent`,
+and `tracestate`. Lite negotiation and attestation are forwarded only when
+present; OpenClaw must retain its truthful originator and user agent. Relaying
+an attestation envelope neither verifies it nor changes the upstream's authority
+to reject it. Caller identity/session facts do not participate in facade auth.
+
+The separately supported `x-codex-routing-hint` must be exactly `model=<alias>`
+or `model=<alias>;tier=<tier>`. Its optional tier must match body `service_tier`.
+After authorization and the final config recheck, only its model is translated
+to the runtime target at egress. No arbitrary model, provider, account or URL
+selector passes. Unknown semantic Codex/review/approval/attestation headers still
+fail closed. The opaque turn-state affinity token is relayed unchanged only
+after bounded inspection of literal, JSON, percent-encoded and base64/JWT text
+for sensitive values and unknown structured model selectors; it is never
+rewritten into invalid signed/ciphertext state.
+
+These contracts were checked against native `core/src/client.rs`,
+`core/src/responses_metadata.rs`, and `codex-api/src/{common.rs,sse/responses.rs,
+rate_limits.rs,safety_buffering.rs}`. Additional protocol requires source review.
+
+Queries, encoded route spellings, trailing slashes, alternate methods,
+compression, non-UTF-8 content, the legacy unary `/responses/compact` endpoint,
+websocket, upload, usage, and every other endpoint are unsupported. Upstream redirects and errors do not trigger another
+provider call. At ingress, enforce rejection of raw dot segments/backslashes
+before URL normalization: the Worker cannot recover path spellings already
+normalized by the HTTP runtime. Normalized routes never select an alternative
+private endpoint/provider/target.
+
+For the separately isolated OpenClaw consumer, the parent's base URL is
+`https://PRIVATE-ORIGIN/private` (plugin appends `/v1`). For a Codex consumer it is
+`https://PRIVATE-ORIGIN/private/v1`. The catalog alone does not prove that a consumer
+honors its Responses-only capabilities, display name, `store: false`, or lack of usage.
+The consumer needs its full, alias-safe native model metadata, including genuine
+Lite, compaction, and safety requirements; a reduced facade discovery row is not
+a substitute. Configured on-request/manual review with a workspace-write sandbox
+is a valid distinct control mode when the selected model does not require
+automatic review. Omitted optional auto-review fields are not a requirement to
+invent or enable automatic review. This does not claim Guardian equivalence and
+does not change trusted-endpoint checks for automatic review.
+The native Codex CLI uses its built-in OpenAI provider with the broker workload
+credential supplied as an API-key credential and full alias-only model metadata.
+It does not receive OAuth or acquire a native ChatGPT account identity through
+the facade. Genuine client metadata, originator, version, review and sandbox
+facts are retained; OpenClaw must not impersonate Codex. This configured mode
+does not claim automatic Guardian or subscription-auth/refresh parity. Native
+Codex and OpenClaw compatibility still require the parent's private proof for
+their respective request shapes and configured control modes. Upstream rejection
+is not a reason to spoof identity or bypass restrictions.
+Native remote compaction v2 is distinct from the unsupported unary endpoint:
+it sends `compaction_trigger` input and consumes a completed compaction item on
+the ordinary Responses stream. The default/manual v2 path in Codex
+`0.150.0-alpha.13`, followed by a tool turn, has been live-verified in the isolated
+workload-authenticated profile described above. Direct OpenClaw manual compaction
+and its subsequent tool turn were also verified. This does not establish automatic
+threshold behavior, full-context capacity, other client versions, or auxiliary
+endpoint support. Required additional or safety protocol remains a deployment
+blocker until implemented and verified; do not bypass it or disable requirements.
+
+## Output, retention and limits
+
+Response headers are generated locally: content type, private no-store,
+`nosniff`, retention `off`, and accounting `private-unmetered`. Cookies, locations,
+request IDs and unknown transport headers do not pass through. Known Codex quota
+families, credit/promo/limit labels, and model catalog etags are stripped without
+rejecting success; labels may name private models. `codex.rate_limits` SSE events
+are also omitted because this facade does not expose quota reporting.
+The source-defined optional timing observation is likewise stripped; accepting
+that observation does not enable the unsupported WebSocket endpoint.
+Discarded quota/timing observations may not carry response or safety envelopes,
+or retained semantic headers. Those combinations fail closed rather than hiding
+model identity, safety or attestation protocol. Ordinary observations, including
+headers containing only discarded quota/transport data, remain discardable.
+
+The exact `OpenAI-Model`/`x-openai-model` identity maps to the alias only when its
+value equals the configured target or alias; a different model fails closed.
+The same projection applies to top-level SSE `headers` and `response.headers`.
+Safe `x-codex-turn-state` affinity and `x-reasoning-included` presence are
+preserved. The known `x-codex-safety-buffering-enabled` flag is preserved,
+including false; the faster-model header and structured `retry_model` may only
+refer to the expected target/alias and are projected to the alias. Null retry
+recommendations remain null. An unknown or different safety reroute fails,
+rather than being relabeled as primary-model success. Moderation and verification
+metadata are preserved, never manufactured. Unknown semantic safety/attestation
+response headers still cause sanitized failure.
+
+HTTP provider denials keep their 4xx status and use `private_upstream_error`,
+without the provider's body. In particular, an upstream HTTP 400 is distinguishable
+from a local 400 `invalid_request`; local request rejection is not evidence of
+upstream incompatibility. Transport/server/protocol errors
+return generic failure; late SSE failures emit a generic `error` event and cancel
+upstream. Source-recognized policy/quota/context denial codes instead retain a
+sanitized `response.failed` envelope and their exact allowlisted code so native
+clients do not lose denial classification. Messages and arbitrary error details
+never pass through. Refusal content and incomplete status remain intact when safe.
+
+Reporting model projection belongs only to the JSON Response root `model` and
+SSE event `response.model`. These reporting fields map to the alias even when
+the backend reports a name different from the requested target. Native Codex's
+`ResponsesStreamEvent::response_model()` reads only `response.headers` and event
+`headers`; its explicit `process_sse_ignores_response_model_field_in_payload`
+test confirms that body `response.model` does not produce a ServerModel event.
+Reporting projection therefore does not authorize or conceal a model-header
+reroute. The configured target remains the separate, immutable authority for
+all model headers and typed safety selectors.
+
+The shared JSON/SSE projection owner learns at most one additional reporting
+name per response, before inspecting sibling data and before releasing any body
+frame or accumulating logical-delta history. The name must be 1–128 printable
+ASCII characters and not blank. It becomes another sensitive value alongside
+the configured target, account ID and token, including in encoded tool JSON,
+opaque affinity and split logical deltas. Repeating it, the target or the alias
+is allowed; changing it or first declaring a new name after output/history
+fails closed. A rejected additional candidate is retained only while sanitizing
+the terminal failure, not added to routing authority. Matcher tables grow only
+before history exists; no held prefix is discarded to accommodate a new name.
+SSE primes one bounded output chunk and reinspects HTTP headers against the
+learned name before releasing them. This may delay the initial HTTP response;
+existing limits, transport deadline and cancellation still apply. There is no
+promise of identifying an undeclared reporting name retroactively.
+
+Only typed protocol envelopes interpret `headers`, Response `error`, and safety
+selectors: SSE `safety_buffering`, or `response.metadata` with metadata
+`type: "safety_buffering"`. Tool schemas, arguments, code, user objects and other
+arbitrary data may contain properties named `model`, `error`, `headers` or
+`retry_model`; their names alone never trigger projection or rejection.
+All retained decoded strings and keys are still inspected for known sensitive
+values. Tool argument JSON is also inspected after decoding. Arbitrary text and
+encrypted/tool data are never redacted into a different successful payload:
+an unrepresentable leak is a sanitized failure. If even the fixed local failure
+text contains a learned name, the facade ends without that text rather than
+echoing it; it never emits a successful completion in that case.
+
+For supported text/refusal/reasoning deltas, the stream holds events containing
+a possible sensitive suffix until that logical stream disambiguates it. This
+survives network chunks, event boundaries and interleaving, and also checks the
+combined text consumed by native Codex's item-independent text-delta event.
+Source-supported missing output indexes and anonymous text/summary events work
+with conservative identity tracking; ambiguous identity changes still fail.
+Function argument events are held until a matching done event or completed
+output item supplies identical, valid JSON. Custom-tool input deltas use the
+same bounded holdback but preserve freeform input, rather than requiring JSON.
+Standalone tool done events are inspected without inventing earlier deltas.
+Encrypted tool/reasoning data is preserved. This can delay tools. A bounded queue preserves original
+event order and metadata. Completed/incomplete events are held until `[DONE]`
+or clean EOF; source-supported completion objects need not contain a status
+field, but an explicit conflicting status fails. Malformed/truncated streams
+fail. `response.metadata` and `codex.response.metadata` remain supported.
+Event types are explicitly allowlisted; an unknown safety/protocol event cannot
+be passed through into an apparently successful stream that ignores it.
+Native SSE may omit Content-Type; a supplied Content-Type must still identify
+UTF-8 SSE and every frame is validated. No unbounded buffering is used.
+
+Limits: 1 MiB request, 4 MiB JSON response, 256 KiB SSE frame, 1 MiB holdback or
+individual network chunk, 1024 held events, 128 logical streams/items, 64 MiB
+total SSE bytes, 48 JSON nesting levels, and 50,000 inspected nodes. Request
+upload has a 30-second deadline; each Access verification plus identity lookup
+has a shared ten-second deadline and a 64 KiB identity response limit;
+upstream transport has a ten-minute deadline and
+propagates client cancellation. Unsupported delta families or missing/changed
+unresolvable logical identities fail closed. Header values remain limited to
+8 KiB each and 64 KiB total; response headers also have a 128-field limit.
+Client metadata has at most 32 fields, 8 KiB ordinary strings, a 256 KiB turn
+metadata string, and 32 levels/10,000 nodes within decoded turn metadata.
+Oversize or unsupported content is never
+silently truncated into success.
+
+This detects exact decoded values and supported logical delta reconstruction;
+it is not a guarantee against arbitrary encodings, ciphertext, semantic model
+identification, or a malicious upstream's covert channels. Operators must also
+disable external request/body/header tracing and restrict logs, crash dumps,
+secret-store access, and the upstream runtime itself.
+
+The private facade never writes to `CONTENT_ARCHIVE`, generic usage queues,
+budget ledgers, admin state, or application logs. There is **no billing, budget
+enforcement, quota reporting, or usage persistence** in this scope. Numeric usage
+may remain in a safe provider response, but is not a billing calculation. Generic
+policy changes cannot enable retention here. The alias facade does not isolate
+the upstream account's own sessions; use only the separately owned account and
+execution cell, with no shared session namespace.

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -133,7 +133,7 @@ async function verifiedGithubEvidence(request: Request, email: string) {
   }
 }
 
-async function verifyAccessJwt(token: string, teamDomain: string, expectedAud: string): Promise<AccessJwtPayload | null> {
+export async function verifyAccessJwt(token: string, teamDomain: string, expectedAud: string, signal?: AbortSignal): Promise<AccessJwtPayload | null> {
   teamDomain = teamDomain.trim().replace(/^https?:\/\//i, "").split(/[/?#]/)[0].toLowerCase();
   const parts = token.split(".");
   if (parts.length !== 3) return null;
@@ -143,7 +143,7 @@ async function verifyAccessJwt(token: string, teamDomain: string, expectedAud: s
     payload = JSON.parse(decodeBase64Url(parts[1]));
   } catch { return null; }
   if (header.alg !== "RS256" || !header.kid || !validPayload(payload, teamDomain, expectedAud)) return null;
-  const response = await fetch(`https://${teamDomain}/cdn-cgi/access/certs`, { cf: { cacheTtl: 300, cacheEverything: true } });
+  const response = await fetch(`https://${teamDomain}/cdn-cgi/access/certs`, { cf: { cacheTtl: 300, cacheEverything: true }, signal });
   if (!response.ok) return null;
   const key = (await response.json<{ keys: Jwk[] }>()).keys.find((candidate) => candidate.kid === header.kid && candidate.kty === "RSA");
   if (!key) return null;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -10,6 +10,7 @@ import { contentRetentionDefault } from "./content-retention.ts";
 import { correlateIngressRequest, withRequestId } from "./correlation.ts";
 import { localAuthEnabled, localLogin, localLogout } from "./local-auth";
 import { oauthCallback } from "./oauth";
+import { privateCodex, privatePath } from "./private-codex";
 import { routeCatalog, snapshot } from "./providers";
 import { sameOrigin } from "./request-origin";
 import { sessionCredentialsApi } from "./session-credentials";
@@ -25,6 +26,8 @@ export { BudgetLedgerObject, UsageLedgerObject };
 
 const handler: ExportedHandler<Env, QueueMessage> = {
   async fetch(request, env, context) {
+    // Private responses must not pass through public correlation, logging, or CORS.
+    if (privatePath(new URL(request.url).pathname)) return privateCodex(request, env);
     const path = canonicalPath(new URL(request.url).pathname);
     const correlated = correlateIngressRequest(request);
     let response: Response;

--- a/worker/private-codex-config.ts
+++ b/worker/private-codex-config.ts
@@ -1,0 +1,141 @@
+import { verifyAccessJwt } from "./access";
+import { boundedJson } from "./private-codex-io";
+import type { Env, ProviderReasoningEffort } from "./types";
+import { safeEqual, sha256Hex } from "./utils";
+
+export interface PrivatePolicy {
+  version: 1;
+  enabled: true;
+  alias: { id: string; name: string; supportedReasoningEfforts?: ProviderReasoningEffort[] };
+  auth: { mode: "access"; issuer: string; audience: string; githubAccountId: number; identityProviderId: string }
+    | { mode: "workload"; credentialSha256: string };
+}
+
+const reasoningEfforts: readonly ProviderReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+export interface PrivateUpstream {
+  version: 1;
+  target: string;
+  accountId: string;
+  accessToken: string;
+  expiresAt: number;
+}
+
+export function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  return Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+
+async function bindingJson(binding: Env["PRIVATE_CODEX_POLICY"]): Promise<unknown> {
+  if (!binding || typeof binding.get !== "function") return null;
+  const value = await binding.get();
+  return typeof value === "string" && value.length <= 16_384 ? JSON.parse(value) : null;
+}
+
+export async function privatePolicy(env: Env): Promise<PrivatePolicy | null> {
+  const value = await bindingJson(env.PRIVATE_CODEX_POLICY);
+  if (!record(value) || !exactKeys(value, ["version", "enabled", "alias", "auth"]) || value.version !== 1 || value.enabled !== true) return null;
+  const { alias, auth } = value;
+  if (!record(alias)) return null;
+  const aliasKeys = ["id", "name"];
+  if (Object.hasOwn(alias, "supportedReasoningEfforts")) aliasKeys.push("supportedReasoningEfforts");
+  if (!exactKeys(alias, aliasKeys) || typeof alias.id !== "string" || !/^[a-z][a-z0-9-]{2,63}$/.test(alias.id)
+    || typeof alias.name !== "string" || !/^[\x20-\x7e]{1,80}$/.test(alias.name)) return null;
+  if (Object.hasOwn(alias, "supportedReasoningEfforts")) {
+    const efforts = alias.supportedReasoningEfforts;
+    if (!Array.isArray(efforts) || efforts.length === 0 || efforts.length > reasoningEfforts.length
+      || efforts.some((effort) => !reasoningEfforts.includes(effort)) || new Set(efforts).size !== efforts.length) return null;
+  }
+  if (!record(auth)) return null;
+  if (auth.mode === "workload") {
+    if (!exactKeys(auth, ["mode", "credentialSha256"]) || typeof auth.credentialSha256 !== "string" || !/^[a-f0-9]{64}$/.test(auth.credentialSha256)) return null;
+  } else if (auth.mode === "access") {
+    if (!exactKeys(auth, ["mode", "issuer", "audience", "githubAccountId", "identityProviderId"]) || typeof auth.issuer !== "string"
+      || !/^https:\/\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.cloudflareaccess\.com$/.test(auth.issuer)
+      || typeof auth.githubAccountId !== "number" || !Number.isSafeInteger(auth.githubAccountId) || auth.githubAccountId <= 0
+      || typeof auth.identityProviderId !== "string" || !/^[\x21-\x7e]{1,256}$/.test(auth.identityProviderId)
+      || typeof auth.audience !== "string" || !/^[\x21-\x7e]{1,256}$/.test(auth.audience)) return null;
+  } else return null;
+  return value as unknown as PrivatePolicy;
+}
+
+interface PrivateAuthorization { current(): boolean }
+
+function conflictingAuth(headers: Headers): boolean {
+  return ["x-api-key", "api-key", "x-goog-api-key", "proxy-authorization", "cf-access-client-id", "cf-access-client-secret"].some((name) => headers.has(name));
+}
+
+function correlatedEmail(value: unknown): string | null {
+  return typeof value === "string" && value.length <= 1024 && value.trim() ? value.trim().toLowerCase() : null;
+}
+
+export async function privateAuthorized(request: Request, policy: PrivatePolicy): Promise<PrivateAuthorization | null> {
+  const headers = request.headers;
+  if (request.signal.aborted || conflictingAuth(headers)) return null;
+  const assertion = headers.get("cf-access-jwt-assertion");
+  const authorization = headers.get("authorization");
+  if (policy.auth.mode === "workload") {
+    // A dedicated namespace prevents ordinary issued proxy credentials from being accepted.
+    const credential = authorization?.match(/^Bearer (private-workload-[A-Za-z0-9_-]{32,128})$/)?.[1];
+    if (headers.has("cf-access-jwt-assertion") || !credential || !safeEqual(await sha256Hex(credential), policy.auth.credentialSha256)) return null;
+    return { current: () => !request.signal.aborted && !conflictingAuth(headers) && !headers.has("cf-access-jwt-assertion") && headers.get("authorization") === authorization };
+  }
+  if (headers.has("authorization") || !assertion || assertion.length > 16_384 || !/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(assertion)) return null;
+  const auth = policy.auth;
+  const signal = AbortSignal.any([request.signal, AbortSignal.timeout(10_000)]);
+  try {
+    const payload = await verifyAccessJwt(assertion, new URL(auth.issuer).hostname, auth.audience, signal);
+    if (!payload || payload.iss !== auth.issuer || typeof payload.exp !== "number" || !Number.isFinite(payload.exp)
+      || (payload.nbf !== undefined && (typeof payload.nbf !== "number" || !Number.isFinite(payload.nbf)))
+      || (payload.iat !== undefined && (typeof payload.iat !== "number" || !Number.isFinite(payload.iat)))) return null;
+    const email = correlatedEmail(payload.email);
+    const expiresAt = payload.exp;
+    // Keep the verifier's clock tolerances, but recheck after every awaited auth/policy phase.
+    const current = () => {
+      const now = Math.floor(Date.now() / 1000);
+      return !request.signal.aborted && !conflictingAuth(headers) && !headers.has("authorization") && headers.get("cf-access-jwt-assertion") === assertion
+        && expiresAt > now && (payload.nbf === undefined || payload.nbf <= now + 30) && (payload.iat === undefined || payload.iat <= now + 300);
+    };
+    if (!email || !current() || signal.aborted) return null;
+    // The destination is policy-pinned, never selected from unverified claims or a redirect.
+    const response = await fetch(`${auth.issuer}/cdn-cgi/access/get-identity`, {
+      headers: { Cookie: `CF_Authorization=${assertion}`, "accept-encoding": "identity" }, redirect: "manual", cache: "no-store", signal,
+    });
+    const encoding = response.headers.get("content-encoding");
+    if (response.status !== 200 || (encoding && encoding !== "identity") || signal.aborted) {
+      void response.body?.cancel().catch(() => {});
+      return null;
+    }
+    const identity = await boundedJson(response.body, 64 * 1024, signal);
+    // Email correlates this assertion's lookup; only the numeric GitHub account and IdP authorize.
+    if (!current() || signal.aborted || !record(identity) || correlatedEmail(identity.email) !== email
+      || !record(identity.idp) || identity.idp.type !== "github" || identity.idp.id !== auth.identityProviderId
+      || typeof identity.id !== "number" || !Number.isSafeInteger(identity.id) || identity.id <= 0 || identity.id !== auth.githubAccountId) return null;
+    return { current };
+  } catch {
+    // Fetch errors can retain the assertion cookie; never log, attach, or return their contents.
+    return null;
+  }
+}
+
+export async function privateAuthorizationCurrent(authorization: PrivateAuthorization, policy: PrivatePolicy, env: Env): Promise<boolean> {
+  if (policy.auth.mode === "access") {
+    const current = await privatePolicy(env);
+    if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return false;
+  }
+  return authorization.current();
+}
+
+export async function privateUpstream(env: Env, policy: PrivatePolicy): Promise<PrivateUpstream | null> {
+  const value = await bindingJson(env.PRIVATE_CODEX_UPSTREAM);
+  if (!record(value) || !exactKeys(value, ["version", "target", "accountId", "accessToken", "expiresAt"]) || value.version !== 1
+    || typeof value.target !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.target)
+    || typeof value.accountId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(value.accountId)
+    || typeof value.accessToken !== "string" || !/^[A-Za-z0-9._~-]{16,8192}$/.test(value.accessToken)
+    || typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt <= Date.now() + 30_000) return null;
+  if ([value.target, value.accountId, value.accessToken].some((secret) => policy.alias.id.includes(secret) || policy.alias.name.includes(secret))) return null;
+  return value as unknown as PrivateUpstream;
+}

--- a/worker/private-codex-io.ts
+++ b/worker/private-codex-io.ts
@@ -1,0 +1,32 @@
+export function cancel(reader: ReadableStreamDefaultReader<Uint8Array>): void { void reader.cancel().catch(() => {}); }
+
+export async function read(reader: ReadableStreamDefaultReader<Uint8Array>, signal: AbortSignal): Promise<ReadableStreamReadResult<Uint8Array>> {
+  signal.throwIfAborted();
+  let listener: () => void = () => {};
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        listener = () => { cancel(reader); reject(new Error("private stream aborted")); };
+        signal.addEventListener("abort", listener, { once: true });
+        if (signal.aborted) listener();
+      }),
+    ]);
+  } finally { signal.removeEventListener("abort", listener); }
+}
+
+export async function boundedJson(body: ReadableStream<Uint8Array> | null, limit: number, signal: AbortSignal): Promise<unknown> {
+  if (!body) throw new Error("missing private body");
+  const reader = body.getReader(), decoder = new TextDecoder("utf-8", { fatal: true });
+  let text = "", bytes = 0;
+  try {
+    while (true) {
+      const result = await read(reader, signal);
+      if (result.done) break;
+      bytes += result.value.byteLength;
+      if (bytes > limit) throw new Error("private body limit");
+      text += decoder.decode(result.value, { stream: true });
+    }
+    return JSON.parse(text + decoder.decode());
+  } finally { cancel(reader); }
+}

--- a/worker/private-codex-output.ts
+++ b/worker/private-codex-output.ts
@@ -1,0 +1,332 @@
+import { boundedJson, cancel, read } from "./private-codex-io";
+import { record, type PrivateUpstream } from "./private-codex-config";
+import { PrivateResponseProjection } from "./private-codex-response";
+
+const encoder = new TextEncoder();
+const frameLimit = 256 * 1024;
+const queueLimit = 1024 * 1024;
+const streamLimit = 64 * 1024 * 1024;
+const errorBody = { type: "error", error: { code: "private_upstream_error", message: "Private upstream request failed." } };
+const denialCodes = new Set(["cyber_policy", "misalignment_policy_violation", "bio_policy", "invalid_prompt", "context_length_exceeded", "insufficient_quota", "usage_not_included", "rate_limit_exceeded"]);
+const eventTypes = new Set([
+  "response.created", "response.in_progress", "response.completed", "response.incomplete", "response.failed", "response.metadata",
+  "response.output_item.added", "response.output_item.done", "response.content_part.added", "response.content_part.done",
+  "response.output_text.delta", "response.output_text.done", "response.refusal.delta", "response.refusal.done",
+  "response.reasoning_text.delta", "response.reasoning_text.done", "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done",
+  "response.reasoning_summary_part.added", "response.reasoning_summary_part.done", "response.function_call_arguments.delta", "response.function_call_arguments.done",
+  "response.custom_tool_call_input.delta", "response.custom_tool_call_input.done", "codex.response.metadata", "codex.rate_limits", "responsesapi.websocket_timing",
+]);
+
+function headers(contentType: string, ignoredMaxOutputTokens = false): HeadersInit {
+  return {
+    "content-type": contentType, "cache-control": "private, no-store", "x-content-type-options": "nosniff",
+    "x-clawrouter-content-retention": "off", "x-clawrouter-accounting": "private-unmetered",
+    ...(ignoredMaxOutputTokens ? { "x-clawrouter-ignored-parameters": "max_output_tokens" } : {}),
+  };
+}
+
+export function privateJson(value: unknown, status = 200, ignoredMaxOutputTokens = false): Response {
+  return new Response(JSON.stringify(value), { status, headers: headers("application/json; charset=utf-8", ignoredMaxOutputTokens) });
+}
+
+export function privateError(status: number, ignoredMaxOutputTokens = false): Response {
+  const error = status === 404 ? { code: "route_not_found", message: "route not found" }
+    : status === 400 ? { code: "invalid_request", message: "Unsupported private request." } : errorBody.error;
+  return privateJson({ error }, status, ignoredMaxOutputTokens);
+}
+
+export async function containResponse(response: Response, alias: string, upstream: PrivateUpstream, streaming: boolean, signal: AbortSignal, abort: () => void, ignoredMaxOutputTokens = false): Promise<Response> {
+  const discard = () => { void response.body?.cancel().catch(() => {}); abort(); };
+  if (!response.ok) {
+    discard();
+    // An upstream 400 is a provider denial, never a local request-validation error.
+    return privateJson({ error: errorBody.error }, response.status >= 400 && response.status < 500 ? response.status : 502, ignoredMaxOutputTokens);
+  }
+  const encoding = response.headers.get("content-encoding");
+  const contentType = response.headers.get("content-type") ?? "";
+  if ((encoding && encoding !== "identity") || response.status !== 200) { discard(); return privateError(502, ignoredMaxOutputTokens); }
+  const projection = new PrivateResponseProjection(alias, upstream);
+  const outputHeaders = () => {
+    const result = new Headers(headers(streaming ? "text/event-stream; charset=utf-8" : "application/json; charset=utf-8", ignoredMaxOutputTokens));
+    for (const [key, value] of Object.entries(projection.headers(response.headers))) result.set(key, value as string);
+    projection.inspect([...result]);
+    return result;
+  };
+  const failure = () => {
+    const result = privateError(502, ignoredMaxOutputTokens);
+    try { projection.inspect(errorBody); projection.inspect([...result.headers]); return result; }
+    catch { return new Response(null, { status: 502 }); }
+  };
+  try { outputHeaders(); } catch { discard(); return failure(); }
+  if (streaming) {
+    // Native subscription SSE can omit Content-Type; the frame parser still validates every byte.
+    if ((contentType && !/^text\/event-stream(?:;\s*charset=utf-8)?$/i.test(contentType)) || !response.body) { discard(); return privateError(502, ignoredMaxOutputTokens); }
+    const reader = containStream(response.body, projection, signal, abort).getReader();
+    try {
+      // Learn the initial reporting identity before releasing opaque HTTP affinity headers.
+      // Priming uses the same bounded parser/queue and cancellation as subsequent reads.
+      let first: ReadableStreamReadResult<Uint8Array> | undefined = await reader.read();
+      const projectedHeaders = outputHeaders();
+      projection.seal();
+      const body = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          const next = first ?? await reader.read();
+          first = undefined;
+          if (next.done) controller.close(); else controller.enqueue(next.value);
+        },
+        cancel() { first = undefined; cancel(reader); abort(); },
+      }, { highWaterMark: 0 });
+      return new Response(body, { headers: projectedHeaders });
+    } catch { cancel(reader); abort(); return failure(); }
+  }
+  if (!/^application\/json(?:;\s*charset=utf-8)?$/i.test(contentType)) { discard(); return privateError(502, ignoredMaxOutputTokens); }
+  try {
+    const value = await boundedJson(response.body, 4 * 1024 * 1024, signal);
+    if (!record(value) || value.object !== "response" || !["completed", "incomplete"].includes(String(value.status))) throw new Error("private response invalid");
+    const projected = projection.response(value);
+    return new Response(JSON.stringify(projected), { headers: outputHeaders() });
+  } catch { return failure(); } finally { abort(); }
+}
+
+interface Pending { sequence: number; frame: string; bytes: number }
+interface DeltaState { matches: number[]; holdFrom: number; tool: boolean; toolFrom: number; arguments: string; argumentBytes: number; done: boolean; custom: boolean }
+
+function prefixTable(pattern: string): number[] {
+  const table = Array<number>(pattern.length).fill(0);
+  for (let index = 1, length = 0; index < pattern.length; index++) {
+    while (length && pattern[index] !== pattern[length]) length = table[length - 1];
+    if (pattern[index] === pattern[length]) length++;
+    table[index] = length;
+  }
+  return table;
+}
+
+function matchDelta(text: string, pattern: string, table: number[], length: number): number {
+  for (let index = 0; index < text.length; index++) {
+    while (length && text[index] !== pattern[length]) length = table[length - 1];
+    if (text[index] === pattern[length]) length++;
+    if (length === pattern.length) throw new Error("private split content rejected");
+  }
+  return length;
+}
+
+function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResponseProjection, signal: AbortSignal, abort: () => void): ReadableStream<Uint8Array> {
+  const reader = body.getReader(), decoder = new TextDecoder("utf-8", { fatal: true });
+  const secrets = projection.sensitiveValues;
+  let tables = secrets.map(prefixTable);
+  const states = new Map<string, DeltaState>(), items = new Map<number, string>(), itemIndexes = new Map<string, number>();
+  const identityModes = new Map<string, "identified" | "anonymous">();
+  const calls = new Map<string, string>(), callOwners = new Map<string, string>(), customItems = new Map<string, string>();
+  // Codex's OutputTextDelta drops item IDs. Guard its combined text as well as each item.
+  const outputText = { matches: secrets.map(() => 0), holdFrom: Infinity };
+  let buffer = "", bytes = 0, sequence = 0, pending: Pending[] = [], pendingSize = 0;
+  let terminal: string | null = null, ended = false, canceled = false;
+  let failure = `event: error\ndata: ${JSON.stringify(errorBody)}\n\n`;
+
+  function flush(controller: ReadableStreamDefaultController<Uint8Array>, force = false): boolean {
+    const hold = force ? Infinity : Math.min(outputText.holdFrom, ...[...states.values()].map((state) => state.holdFrom));
+    let emitted = false;
+    while (pending.length && pending[0].sequence < hold) {
+      const next = pending.shift()!;
+      pendingSize -= next.bytes;
+      projection.seal();
+      controller.enqueue(encoder.encode(next.frame));
+      emitted = true;
+    }
+    return emitted;
+  }
+
+  function delta(event: Record<string, unknown>): void {
+    const type = event.type as string;
+    if (type === "response.output_item.done" && record(event.item)) {
+      const item = event.item;
+      const family = item.type === "function_call" ? "response.function_call_arguments" : item.type === "custom_tool_call" ? "response.custom_tool_call_input" : null;
+      if (family) {
+        const itemId = typeof item.id === "string" ? item.id : undefined;
+        const id = item.type === "custom_tool_call" ? customIdentity(itemId, typeof item.call_id === "string" ? item.call_id : undefined) : itemId;
+        const state = states.get(JSON.stringify([family, id, 0]));
+        if (state && !state.done) finishTool(state, state.custom ? item.input : item.arguments);
+      }
+      return;
+    }
+    if (["response.content_part.done", "response.reasoning_summary_part.done"].includes(type)) return;
+    if (!type.endsWith(".delta") && !type.endsWith(".done")) return;
+    const family = type.replace(/\.(delta|done)$/, "");
+    if (!["response.output_text", "response.refusal", "response.function_call_arguments", "response.custom_tool_call_input", "response.reasoning_text", "response.reasoning_summary_text"].includes(family)) throw new Error("private delta unsupported");
+    projection.seal();
+    const custom = family === "response.custom_tool_call_input", tool = custom || family === "response.function_call_arguments";
+    const validId = (value: unknown) => typeof value === "string" && value.length > 0 && value.length <= 256;
+    if (event.item_id !== undefined && !validId(event.item_id) || event.call_id !== undefined && !validId(event.call_id)) throw new Error("private delta identity");
+    let id = event.item_id as string | undefined;
+    if (custom) id = customIdentity(id, event.call_id as string | undefined);
+    if (event.output_index !== undefined) {
+      if (!Number.isSafeInteger(event.output_index) || Number(event.output_index) < 0) throw new Error("private delta index");
+      const index = event.output_index as number;
+      id ??= items.get(index);
+      if (id) {
+        if (items.has(index) && items.get(index) !== id || itemIndexes.has(id) && itemIndexes.get(id) !== index) throw new Error("private item mismatch");
+        items.set(index, id); itemIndexes.set(id, index);
+      }
+    }
+    const mode = identityModes.get(family) ?? (id ? "identified" : "anonymous");
+    if (type.endsWith(".delta") && mode !== (id ? "identified" : "anonymous") || tool && !id) throw new Error("private delta identity changed");
+    identityModes.set(family, mode);
+    if (mode === "anonymous") id = "anonymous";
+    const part = family === "response.reasoning_summary_text" ? event.summary_index : tool ? 0 : event.content_index ?? 0;
+    if (!Number.isSafeInteger(part) || Number(part) < 0) throw new Error("private delta index");
+    const key = JSON.stringify([family, id, part]);
+    const state = states.get(key) ?? { matches: secrets.map(() => 0), holdFrom: Infinity, tool, custom, toolFrom: sequence, arguments: "", argumentBytes: 0, done: false };
+    if (state.done) throw new Error("private delta after done");
+    if (type.endsWith(".done")) {
+      if (tool && !states.has(key)) {
+        const value = custom ? event.input : event.arguments;
+        if (typeof value !== "string") throw new Error("private tool completion invalid");
+        state.arguments = value;
+      }
+      if (state.tool) finishTool(state, state.custom ? event.input : event.arguments);
+      state.done = true;
+      state.matches.fill(0);
+      state.holdFrom = Infinity;
+    } else {
+      if (typeof event.delta !== "string") throw new Error("private delta invalid");
+      const text = event.delta;
+      if (family === "response.output_text") {
+        outputText.matches = secrets.map((secret, index) => matchDelta(text, secret, tables[index], outputText.matches[index]));
+        const suffix = Math.max(...outputText.matches);
+        outputText.holdFrom = suffix ? suffix > text.length ? outputText.holdFrom : sequence : Infinity;
+      }
+      state.matches = secrets.map((secret, index) => matchDelta(text, secret, tables[index], state.matches[index]));
+      const suffix = Math.max(...state.matches);
+      state.holdFrom = suffix ? suffix > event.delta.length ? state.holdFrom : sequence : Infinity;
+      if (state.tool) {
+        state.holdFrom = state.toolFrom;
+        state.arguments += event.delta;
+        state.argumentBytes += encoder.encode(event.delta).byteLength;
+        if (state.argumentBytes > queueLimit) throw new Error("private arguments limit");
+      }
+    }
+    states.set(key, state);
+    if (states.size > 128 || items.size > 128) throw new Error("private stream count");
+  }
+
+  function customIdentity(itemId: string | undefined, callId: string | undefined): string | undefined {
+    const itemKey = itemId ? customItems.get(itemId) : undefined;
+    const callKey = callId ? calls.get(callId) : undefined;
+    const owner = callId ? callOwners.get(callId) : undefined;
+    if (owner && itemId && owner !== itemId || itemKey && callKey && itemKey !== callKey) throw new Error("private tool identity mismatch");
+    const key = itemKey ?? callKey ?? itemId ?? (callId ? `call:${callId}` : undefined);
+    if (key && itemId) customItems.set(itemId, key);
+    if (key && callId) calls.set(callId, key);
+    if (callId && itemId) callOwners.set(callId, itemId);
+    if (customItems.size > 128 || calls.size > 128) throw new Error("private stream count");
+    return key;
+  }
+
+  function finishTool(state: DeltaState, value: unknown): void {
+    if (typeof value !== "string" || value !== state.arguments) throw new Error("private tool content mismatch");
+    if (state.custom) projection.inspect(value);
+    else projection.inspect(JSON.parse(value));
+    state.arguments = ""; state.done = true; state.holdFrom = Infinity; state.matches.fill(0);
+  }
+
+  function eventFrame(frame: string, controller: ReadableStreamDefaultController<Uint8Array>): boolean {
+    if (encoder.encode(frame).byteLength > frameLimit || frame.includes("\r") && !frame.includes("\r\n")) throw new Error("private SSE frame");
+    let eventName = "", data: string[] = [];
+    for (const line of frame.split(/\r?\n/)) {
+      if (!line || line.startsWith(":")) continue;
+      if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+      else if (line.startsWith("event:") && !eventName) eventName = line.slice(6).replace(/^ /, "");
+      else throw new Error("private SSE field");
+    }
+    if (!data.length) { if (eventName) throw new Error("private SSE data missing"); return false; }
+    const text = data.join("\n");
+    if (text === "[DONE]") {
+      if (!terminal || eventName) throw new Error("private SSE premature done");
+      flush(controller, true);
+      controller.enqueue(encoder.encode(terminal + "data: [DONE]\n\n"));
+      ended = true;
+      return true;
+    }
+    if (terminal) throw new Error("private SSE after terminal");
+    const event: unknown = JSON.parse(text);
+    if (!record(event) || typeof event.type !== "string" || !eventTypes.has(event.type) || eventName && eventName !== event.type) throw new Error("private SSE event type");
+    if (["codex.rate_limits", "responsesapi.websocket_timing"].includes(event.type)) {
+      // Codex consumes common model/safety envelopes before dispatching by event type.
+      const protocol = projection.event({ type: event.type, response: event.response, headers: event.headers, safety_buffering: event.safety_buffering });
+      if (event.response != null || event.safety_buffering !== undefined || record(protocol.headers) && Object.keys(protocol.headers).length) throw new Error("private observation protocol unsupported");
+      return false;
+    }
+    if (event.type === "response.failed") {
+      const error = record(event.response) && record(event.response.error) ? event.response.error : null;
+      if (error && typeof error.code === "string" && denialCodes.has(error.code)) {
+        failure = `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: { status: "failed", error: { code: error.code, message: errorBody.error.message } } })}\n\n`;
+      }
+      projection.event(event);
+      throw new Error("private upstream failed");
+    }
+    const safe = projection.event(event);
+    if (tables.length !== secrets.length) {
+      // Learning is sealed before any delta state or output exists; no prefix is discarded.
+      tables = secrets.map(prefixTable);
+      outputText.matches = secrets.map(() => 0);
+    }
+    const serialized = `${eventName ? `event: ${eventName}\n` : ""}data: ${JSON.stringify(safe)}\n\n`;
+    if (["response.completed", "response.incomplete"].includes(event.type)) {
+      if (!record(event.response) || typeof event.response.id !== "string" || !event.response.id
+        || event.response.status !== undefined && event.response.status !== event.type.slice("response.".length)) throw new Error("private terminal status");
+      for (const state of states.values()) if (state.tool && !state.done) throw new Error("private tool unfinished");
+      terminal = serialized;
+      return false;
+    }
+    delta(event);
+    const frameBytes = encoder.encode(serialized).byteLength;
+    pending.push({ sequence: sequence++, frame: serialized, bytes: frameBytes });
+    pendingSize += frameBytes;
+    if (pendingSize > queueLimit || pending.length > 1024) throw new Error("private holdback limit");
+    return flush(controller);
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        while (!ended && !canceled) {
+          const separator = /\r?\n\r?\n/.exec(buffer);
+          if (separator) {
+            const frame = buffer.slice(0, separator.index);
+            buffer = buffer.slice(separator.index + separator[0].length);
+            if (eventFrame(frame, controller)) {
+              if (ended) { cancel(reader); abort(); controller.close(); }
+              return;
+            }
+            continue;
+          }
+          if (buffer.length > frameLimit) throw new Error("private frame limit");
+          const result = await read(reader, signal);
+          if (canceled) return;
+          if (result.done) {
+            buffer += decoder.decode();
+            if (buffer.trim() || !terminal) throw new Error("private truncated stream");
+            flush(controller, true);
+            controller.enqueue(encoder.encode(terminal));
+            ended = true;
+            abort();
+            controller.close();
+            return;
+          }
+          bytes += result.value.byteLength;
+          if (bytes > streamLimit || result.value.byteLength > queueLimit) throw new Error("private stream limit");
+          buffer += decoder.decode(result.value, { stream: true });
+        }
+      } catch {
+        pending = []; states.clear(); buffer = ""; terminal = null;
+        cancel(reader); abort(); ended = true;
+        if (!canceled) {
+          // Even a local denial code/message must not echo a newly learned identity.
+          try { projection.inspect(failure); controller.enqueue(encoder.encode(failure)); } catch { /* close without content */ }
+          controller.close();
+        }
+      }
+    },
+    cancel() { canceled = true; pending = []; states.clear(); buffer = ""; cancel(reader); abort(); },
+  }, { highWaterMark: 0 });
+}

--- a/worker/private-codex-protocol.ts
+++ b/worker/private-codex-protocol.ts
@@ -1,0 +1,157 @@
+import { record } from "./private-codex-config";
+
+// Wire contracts: codex core/client.rs, core/responses_metadata.rs and codex-api.
+const forwardedHeaders = new Set([
+  // Codex stamps its actual CLI version; dropping it changes backend model compatibility.
+  "version", "session-id", "thread-id", "session_id", "x-client-request-id", "user-agent", "originator", "openai-beta",
+  "x-openai-internal-codex-responses-lite", "x-codex-beta-features", "x-codex-turn-state", "x-codex-turn-metadata",
+  "x-codex-parent-thread-id", "x-codex-window-id", "x-oai-attestation", "x-openai-subagent", "x-openai-memgen-request",
+  "x-responsesapi-include-timing-metrics", "traceparent", "tracestate",
+]);
+const metadataKeys = new Set([
+  "x-codex-installation-id", "session_id", "thread_id", "turn_id", "parent_turn_id", "root_turn_id",
+  "x-codex-window-id", "x-codex-parent-thread-id", "x-openai-subagent", "x-codex-turn-metadata",
+]);
+const routingHint = "x-codex-routing-hint";
+const booleanHeaders = new Set(["x-openai-internal-codex-responses-lite", "x-openai-memgen-request", "x-responsesapi-include-timing-metrics"]);
+const selectorKeys = new Set(["model", "retry_model", "faster_model", "auto_review_model_override"]);
+const encoder = new TextEncoder();
+
+function boundedMetadata(value: unknown, depth = 0, budget = { nodes: 0 }): void {
+  if (++budget.nodes > 10_000 || depth > 32) throw new Error("private metadata limit");
+  if (Array.isArray(value)) for (const item of value) boundedMetadata(item, depth + 1, budget);
+  else if (record(value)) for (const item of Object.values(value)) boundedMetadata(item, depth + 1, budget);
+}
+
+function metadataObject(value: string): boolean {
+  try { const parsed: unknown = JSON.parse(value); boundedMetadata(parsed); return record(parsed); } catch { return false; }
+}
+
+export function validPrivateProtocolBody(body: Record<string, unknown>): boolean {
+  const metadata = body.client_metadata;
+  if (metadata != null) {
+    if (!record(metadata) || Object.keys(metadata).length > 32) return false;
+    for (const [key, value] of Object.entries(metadata)) {
+      if (!metadataKeys.has(key) || typeof value !== "string" || value.length > (key === "x-codex-turn-metadata" ? 256 * 1024 : 8192)) return false;
+      if (key === "x-codex-turn-metadata" && !metadataObject(value)) return false;
+    }
+  }
+  const options = body.stream_options;
+  if (options != null && (!record(options) || Object.keys(options).length !== 1 || options.reasoning_summary_delivery !== "sequential_cutoff" || body.stream !== true)) return false;
+  // This is an upstream access selection, not permission granted by the facade.
+  // Preserve the supplied wire token; never manufacture entitlement or a program fallback.
+  const programs = body.access_programs;
+  if (programs != null && (!record(programs) || Object.keys(programs).length !== 1 || typeof programs.cyber !== "string" || !/^[a-z][a-z0-9_]{0,63}$/.test(programs.cyber))) return false;
+  return true;
+}
+
+function parseRoutingHint(value: string, alias: string): { tier?: string } | null {
+  const match = /^model=([a-z][a-z0-9-]{2,63})(?:;tier=([a-z][a-z0-9_-]{0,63}))?$/.exec(value);
+  return match && match[1] === alias ? { tier: match[2] } : null;
+}
+
+export function validPrivateHeaders(headers: Headers, alias: string, body?: Record<string, unknown>): boolean {
+  if (headers.has("content-encoding") || headers.has("transfer-encoding")) return false;
+  let bytes = 0;
+  for (const [key, value] of headers) {
+    bytes += encoder.encode(key + value).byteLength;
+    if (value.length > 8192 || bytes > 64 * 1024) return false;
+    if (key === routingHint) {
+      const hint = parseRoutingHint(value, alias);
+      if (!hint || body && hint.tier !== (body.service_tier ?? undefined)) return false;
+      continue;
+    }
+    if (/(?:model|provider|base[-_]?url|upstream|account|organization|project)/i.test(key)) return false;
+    if ((key.startsWith("x-codex-") || key.startsWith("x-openai-internal-") || /(?:approval|review|attestation|safety|routing)/i.test(key)) && !forwardedHeaders.has(key)) return false;
+    if (booleanHeaders.has(key) && value !== "true" && value !== "false") return false;
+    if (key === "x-codex-turn-metadata" && !metadataObject(value)) return false;
+    if (forwardedHeaders.has(key) && !/^[\x20-\x7e]+$/.test(value)) return false;
+  }
+  return true;
+}
+
+export function forwardPrivateHeaders(incoming: Headers, outgoing: Headers, alias: string, target: string): void {
+  for (const [key, value] of incoming) if (forwardedHeaders.has(key)) outgoing.set(key, value);
+  const hint = incoming.get(routingHint);
+  if (hint !== null) {
+    const parsed = parseRoutingHint(hint, alias);
+    if (!parsed) throw new Error("private routing hint invalid");
+    outgoing.set(routingHint, `model=${target}${parsed.tier ? `;tier=${parsed.tier}` : ""}`);
+  }
+}
+
+// Opaque affinity is never rewritten. Inspect literal, JSON, percent and base64/JWT
+// representations before returning it; this is not cryptographic attestation verification.
+export function inspectPrivateOpaque(value: unknown, alias: string, secrets: readonly string[], depth = 0, budget = { nodes: 0 }): void {
+  if (++budget.nodes > 10_000 || depth > 12) throw new Error("private opaque limit");
+  if (typeof value === "string") {
+    if (secrets.some((secret) => value.includes(secret))) throw new Error("private opaque identity");
+    if (value.length > 8192) throw new Error("private opaque size");
+    for (const match of value.matchAll(/(?:^|[;,&\s])(?:model|retry_model|faster_model)=([^;,&\s]+)/g)) {
+      if (match[1] !== alias) throw new Error("private opaque selector");
+    }
+    if (/^\s*[\[{]/.test(value)) {
+      let decoded: unknown;
+      try { decoded = JSON.parse(value); } catch { throw new Error("private opaque JSON"); }
+      inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
+    } else if (/%[0-9a-f]{2}/i.test(value)) {
+      const decoded = decodeURIComponent(value);
+      if (decoded !== value) inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
+    } else {
+      for (const part of value.split(".")) {
+        if (!/^[A-Za-z0-9+/_-]{8,}={0,2}$/.test(part)) continue;
+        let decoded: string;
+        try { decoded = atob(part.replaceAll("-", "+").replaceAll("_", "/")); } catch { continue; }
+        if (secrets.some((secret) => decoded.includes(secret))) throw new Error("private opaque encoded identity");
+        if (/^[\x20-\x7e\r\n\t]+$/.test(decoded) && decoded !== value) inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
+      }
+    }
+  } else if (Array.isArray(value)) for (const item of value) inspectPrivateOpaque(item, alias, secrets, depth + 1, budget);
+  else if (record(value)) for (const [key, item] of Object.entries(value)) {
+    inspectPrivateOpaque(key, alias, secrets, depth + 1, budget);
+    if (selectorKeys.has(key) && item != null && item !== alias) throw new Error("private opaque selector");
+    inspectPrivateOpaque(item, alias, secrets, depth + 1, budget);
+  }
+}
+
+function quotaHeader(name: string): boolean {
+  return /^x-codex(?:-[a-z0-9]+)*-(?:(?:primary|secondary)-(?:used-percent|window-minutes|reset-at|reset-after-seconds)|limit-name)$/.test(name)
+    || ["x-codex-plan-type", "x-codex-primary-over-secondary-limit-percent", "x-codex-active-limit", "x-codex-promo-message", "x-codex-rate-limit-reached-type", "x-codex-credits-has-credits", "x-codex-credits-unlimited", "x-codex-credits-balance"].includes(name);
+}
+
+export function privateResponseHeaders(entries: Iterable<[string, unknown]>, alias: string, target: string, secrets: readonly string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = Object.create(null);
+  const seen = new Set<string>();
+  let bytes = 0;
+  for (const [key, original] of entries) {
+    const name = key.toLowerCase();
+    const value = Array.isArray(original) && original.length === 1 ? original[0] : original;
+    // Repeated Set-Cookie is legal upstream and is always discarded below.
+    if (typeof value !== "string" || value.length > 8192 || (seen.has(name) && name !== "set-cookie")) throw new Error("private header invalid");
+    seen.add(name);
+    bytes += encoder.encode(key + value).byteLength;
+    if (bytes > 64 * 1024 || seen.size > 128) throw new Error("private headers limit");
+    // Quota labels can contain private model names. Strip the entire observation.
+    if (quotaHeader(name) || name === "x-models-etag") continue;
+    let projected: string;
+    if (["openai-model", "x-openai-model", "x-codex-safety-buffering-faster-model"].includes(name)) {
+      if (value !== target && value !== alias) throw new Error("private reported model mismatch");
+      projected = alias;
+    } else if (name === "x-codex-turn-state") {
+      inspectPrivateOpaque(value, alias, secrets);
+      projected = value;
+    } else if (name === "x-reasoning-included") {
+      // Codex consumes presence, not a parsed boolean; an empty header is meaningful.
+      inspectPrivateOpaque(value, alias, secrets);
+      projected = value;
+    } else if (name === "x-codex-safety-buffering-enabled") {
+      if (!["true", "false", "1", "0"].includes(value)) throw new Error("private protocol boolean");
+      projected = value;
+    } else {
+      if (name.startsWith("x-codex-") || /(?:approval|review|attestation|reroute|model|provider|safety)/i.test(name)) throw new Error("private header unsupported");
+      continue;
+    }
+    result[key] = Array.isArray(original) ? [projected] : projected;
+  }
+  return result;
+}

--- a/worker/private-codex-response.ts
+++ b/worker/private-codex-response.ts
@@ -1,0 +1,117 @@
+import { record, type PrivateUpstream } from "./private-codex-config";
+import { privateResponseHeaders } from "./private-codex-protocol";
+
+// Inspect data without assigning protocol meaning to its keys or rewriting ciphertext/tool JSON.
+export function inspectPrivateContent(value: unknown, sensitive: readonly string[], depth = 0, budget = { nodes: 0 }): void {
+  if (++budget.nodes > 50_000 || depth > 48) throw new Error("private structure limit");
+  if (typeof value === "string") {
+    if (sensitive.some((secret) => value.includes(secret))) throw new Error("private content rejected");
+    if (/^\s*[\[{]/.test(value)) {
+      let nested: unknown;
+      try { nested = JSON.parse(value); } catch { return; }
+      inspectPrivateContent(nested, sensitive, depth + 1, budget);
+    }
+  } else if (Array.isArray(value)) {
+    for (const item of value) inspectPrivateContent(item, sensitive, depth + 1, budget);
+  } else if (record(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      inspectPrivateContent(key, sensitive, depth + 1, budget);
+      inspectPrivateContent(item, sensitive, depth + 1, budget);
+    }
+  }
+}
+
+// Owns the Responses envelopes, not arbitrary recursively nested model/error/header keys.
+// Reporting identity is sensitive data; it NEVER becomes an authorized routing identity.
+export class PrivateResponseProjection {
+  readonly alias: string;
+  private readonly target: string;
+  private readonly sensitive: string[];
+  private reported: string | undefined;
+  private sealed = false;
+  private rejected = false;
+
+  constructor(alias: string, upstream: PrivateUpstream) {
+    this.alias = alias;
+    this.target = upstream.target;
+    this.sensitive = [upstream.target, upstream.accessToken, upstream.accountId];
+  }
+
+  get sensitiveValues(): readonly string[] { return this.sensitive; }
+
+  // A new matcher cannot safely be introduced after output or logical-delta history.
+  seal(): void { this.sealed = true; }
+
+  inspect(value: unknown): void { inspectPrivateContent(value, this.sensitive); }
+
+  headers(entries: Iterable<[string, unknown]>): Record<string, unknown> {
+    const projected = privateResponseHeaders(entries, this.alias, this.target, this.sensitive);
+    this.inspect(projected);
+    return projected;
+  }
+
+  response(value: Record<string, unknown>): Record<string, unknown> {
+    if (this.rejected) throw new Error("private reporting identity rejected");
+    const projected = this.responseEnvelope(value);
+    this.inspect(projected);
+    return projected;
+  }
+
+  event(value: Record<string, unknown>): Record<string, unknown> {
+    if (this.rejected) throw new Error("private reporting identity rejected");
+    const projected = { ...value };
+    // Register before inspecting any sibling, irrespective of JSON property order.
+    if (value.response != null) {
+      if (!record(value.response)) throw new Error("private response envelope invalid");
+      projected.response = this.responseEnvelope(value.response);
+    }
+    if (value.headers !== undefined) projected.headers = this.headerEnvelope(value.headers);
+    if (value.safety_buffering !== undefined) projected.safety_buffering = this.safety(value.safety_buffering);
+    if (value.type === "response.metadata" && record(value.metadata) && value.metadata.type === "safety_buffering") {
+      projected.metadata = this.safety(value.metadata);
+    }
+    this.inspect(projected);
+    return projected;
+  }
+
+  private responseEnvelope(value: Record<string, unknown>): Record<string, unknown> {
+    const projected = { ...value };
+    if (value.model !== undefined) {
+      this.learn(value.model);
+      projected.model = this.alias;
+    }
+    if (value.error != null) throw new Error("private upstream error");
+    if (value.headers !== undefined) projected.headers = this.headerEnvelope(value.headers);
+    return projected;
+  }
+
+  private learn(value: unknown): void {
+    if (typeof value !== "string" || !/^[\x20-\x7e]{1,128}$/.test(value) || !value.trim()) throw new Error("private reporting identity invalid");
+    if (value === this.alias || value === this.target || value === this.reported) return;
+    // Also contain the first rejected candidate in the terminal failure; parsing stops on throw.
+    if (!this.sensitive.includes(value)) this.sensitive.push(value);
+    // One additional identity per response, declared before any body release/history.
+    if (this.sealed || this.reported !== undefined) {
+      this.rejected = true;
+      throw new Error("private reporting identity changed");
+    }
+    this.reported = value;
+  }
+
+  private headerEnvelope(value: unknown): Record<string, unknown> {
+    if (!record(value)) throw new Error("private protocol headers invalid");
+    return this.headers(Object.entries(value));
+  }
+
+  private safety(value: unknown): Record<string, unknown> {
+    if (!record(value)) throw new Error("private safety envelope invalid");
+    const projected = { ...value };
+    // retry_model is the current wire field. Other selector spellings cannot bypass it.
+    for (const key of ["model", "retry_model", "faster_model", "auto_review_model_override"]) {
+      if (value[key] == null) continue;
+      if (value[key] !== this.target && value[key] !== this.alias) throw new Error("private safety model mismatch");
+      projected[key] = this.alias;
+    }
+    return projected;
+  }
+}

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -1,0 +1,97 @@
+import { boundedJson } from "./private-codex-io";
+import { privateAuthorizationCurrent, privateAuthorized, privatePolicy, privateUpstream, record } from "./private-codex-config";
+import { containResponse, privateError, privateJson } from "./private-codex-output";
+import { forwardPrivateHeaders, inspectPrivateOpaque, validPrivateHeaders, validPrivateProtocolBody } from "./private-codex-protocol";
+import type { Env } from "./types";
+
+const upstreamUrl = "https://chatgpt.com/backend-api/codex/responses";
+const requestFields = new Set([
+  "model", "input", "instructions", "stream", "store", "tools", "tool_choice", "parallel_tool_calls", "reasoning", "text",
+  "include", "max_output_tokens", "temperature", "top_p", "truncation", "metadata", "previous_response_id",
+  "prompt_cache_key", "prompt_cache_retention", "safety_identifier", "service_tier", "background",
+  "client_metadata", "stream_options", "access_programs",
+]);
+
+export function privatePath(path: string): boolean {
+  // Also intercept encoded spellings before public routing/correlation can reflect caller headers.
+  try { return /^\/private(?:\/|$)/i.test(decodeURIComponent(path)); } catch { return path.startsWith("/private"); }
+}
+
+export function privateSubscriptionBody(body: Record<string, unknown>, target: string): Record<string, unknown> {
+  const outgoing: Record<string, unknown> = { ...body, model: target };
+  // The fixed subscription backend controls generation length; retain every other field.
+  delete outgoing.max_output_tokens;
+  return outgoing;
+}
+
+export async function privateCodex(request: Request, env: Env): Promise<Response> {
+  try {
+    const url = new URL(request.url);
+    const discovery = request.method === "GET" && ["/private/v1/models", "/private/v1/catalog"].includes(url.pathname);
+    const inference = request.method === "POST" && url.pathname === "/private/v1/responses";
+    if ((!discovery && !inference) || url.search || url.hash || url.username || url.password) return privateError(404);
+    const policy = await privatePolicy(env);
+    if (!policy) return privateError(404);
+    const authorization = await privateAuthorized(request, policy);
+    if (!authorization || !await privateAuthorizationCurrent(authorization, policy, env)) return privateError(404);
+    if (!validPrivateHeaders(request.headers, policy.alias.id)) return privateError(400);
+
+    // Target/account/credential resolution happens only inside this authenticated boundary.
+    const upstream = await privateUpstream(env, policy);
+    if (!upstream || !await privateAuthorizationCurrent(authorization, policy, env) || upstream.expiresAt <= Date.now() + 30_000) return privateError(404);
+    const { id, name } = policy.alias;
+    if (discovery) {
+      if (request.body) return privateError(400);
+      const reasoning = policy.alias.supportedReasoningEfforts ? { supportedReasoningEfforts: policy.alias.supportedReasoningEfforts } : {};
+      if (url.pathname.endsWith("/models")) return privateJson({ object: "list", data: [{ id, object: "model", owned_by: "private", display_name: name, capabilities: ["llm.responses"], ...reasoning }] });
+      return privateJson({ version: "clawrouter.client-catalog.v1", providers: [{
+        id: "private", displayName: name, allowed: true, executable: true, openaiCompatible: true,
+        nativeBaseUrl: "/v1/native/private", routes: [{ endpoint: "responses", methods: ["POST"], path: "/v1/responses", requestFormat: "openai.responses", responseFormat: "openai.responses", streaming: "sse" }],
+        models: [{ id, displayName: name, upstream: id, capabilities: ["llm.responses"], pricing_ref: null, pricing: null, ...reasoning }],
+      }] });
+    }
+    if (!/^application\/json(?:;\s*charset=utf-8)?$/i.test(request.headers.get("content-type") ?? "")) return privateError(400);
+    let body: unknown;
+    try { body = await boundedJson(request.body, 1024 * 1024, AbortSignal.any([request.signal, AbortSignal.timeout(30_000)])); } catch { return privateError(400); }
+    if (!record(body) || body.model !== id || Object.keys(body).some((key) => !requestFields.has(key))
+      || body.store !== false || body.background === true || (body.background !== undefined && body.background !== false)
+      || (body.stream !== undefined && typeof body.stream !== "boolean") || !validPrivateProtocolBody(body)
+      || (body.max_output_tokens !== undefined && (typeof body.max_output_tokens !== "number" || !Number.isSafeInteger(body.max_output_tokens) || body.max_output_tokens <= 0))
+      || !validPrivateHeaders(request.headers, id, body)) return privateError(400);
+    try {
+      const affinity = request.headers.get("x-codex-turn-state");
+      if (affinity !== null) inspectPrivateOpaque(affinity, id, [upstream.target, upstream.accessToken, upstream.accountId]);
+    } catch { return privateError(400); }
+
+    // Re-read both bindings after a potentially slow upload; no authorization/secret cache or retry.
+    const current = await privatePolicy(env);
+    if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return privateError(404);
+    const refreshed = await privateAuthorized(request, current);
+    if (!refreshed || !await privateAuthorizationCurrent(refreshed, current, env)) return privateError(404);
+    const freshUpstream = await privateUpstream(env, current);
+    if (!freshUpstream || JSON.stringify(freshUpstream) !== JSON.stringify(upstream)
+      || !await privateAuthorizationCurrent(refreshed, current, env) || freshUpstream.expiresAt <= Date.now() + 30_000) return privateError(404);
+    const ignoredMaxOutputTokens = body.max_output_tokens !== undefined;
+    // A fixed disclosure must not echo a runtime identity, including on transport failure.
+    if (ignoredMaxOutputTokens && [upstream.target, upstream.accountId, upstream.accessToken].some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
+    const headers = new Headers({ "content-type": "application/json", accept: body.stream === true ? "text/event-stream" : "application/json", "accept-encoding": "identity" });
+    forwardPrivateHeaders(request.headers, headers, id, upstream.target);
+    headers.set("authorization", `Bearer ${upstream.accessToken}`);
+    headers.set("chatgpt-account-id", upstream.accountId);
+    // Do not manufacture originator, client metadata, review, or attestation evidence.
+    const abort = new AbortController();
+    const signal = AbortSignal.any([request.signal, abort.signal, AbortSignal.timeout(600_000)]);
+    try {
+      const response = await fetch(upstreamUrl, {
+        method: "POST", headers, body: JSON.stringify(privateSubscriptionBody(body, upstream.target)), redirect: "manual", signal,
+      });
+      return await containResponse(response, id, upstream, body.stream === true, signal, () => abort.abort(), ignoredMaxOutputTokens);
+    } catch {
+      abort.abort();
+      return privateError(502, ignoredMaxOutputTokens);
+    }
+  } catch {
+    // Never pass private exceptions through the public logger or error formatter.
+    return privateError(404);
+  }
+}

--- a/worker/test/private-codex-access.test.mjs
+++ b/worker/test/private-codex-access.test.mjs
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { default: worker } = await import("../index.ts");
+const { privatePolicy } = await import("../private-codex-config.ts");
+const issuer = "https://synthetic-owner.cloudflareaccess.com";
+const audience = "synthetic-private-audience";
+const account = 123456;
+const idp = "synthetic-approved-github-idp";
+const email = "synthetic-owner@example.invalid";
+const alias = "codex-latest";
+const paths = ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"];
+const enc = new TextEncoder();
+let keys, jwk;
+test.before(async () => {
+  keys = await crypto.subtle.generateKey({ name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" }, true, ["sign", "verify"]);
+  jwk = { ...await crypto.subtle.exportKey("jwk", keys.publicKey), kid: "synthetic-github-binding-key" };
+});
+async function jwt(patch = {}, header = {}, forged = false) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const payload = { iss: issuer, aud: audience, sub: "synthetic-access-subject", email, exp: Math.floor(Date.now() / 1000) + 300, ...patch };
+  const unsigned = `${encode({ alg: "RS256", kid: jwk.kid, ...header })}.${encode(payload)}`;
+  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", keys.privateKey, enc.encode(unsigned));
+  return `${unsigned}.${forged ? "c3ludGhldGlj" : Buffer.from(signature).toString("base64url")}`;
+}
+const policy = () => ({ version: 1, enabled: true, alias: { id: alias, name: "Codex (Latest)" }, auth: { mode: "access", issuer, audience, githubAccountId: account, identityProviderId: idp } });
+const identity = (patch = {}) => ({ email, id: account, idp: { type: "github", id: idp }, ...patch });
+function harness(context) {
+  const state = { policy: policy(), upstream: { version: 1, target: "SYNTHETIC_ACCESS_TARGET_7Q", accountId: "SYNTHETIC_ACCESS_ACCOUNT_9R", accessToken: "SYNTHETIC_ACCESS_TOKEN_4P", expiresAt: Date.now() + 3600_000 }, secretReads: 0, policyReads: 0, identities: 0, certs: 0, inference: 0, unexpectedFetches: 0, genericReads: [], logs: [], lookup: () => Response.json(identity()) };
+  context.after(() => {
+    assert.equal(state.unexpectedFetches, 0);
+    assert.deepEqual(state.genericReads, []);
+    assert.deepEqual(state.logs, []);
+  });
+  const env = new Proxy({
+    PRIVATE_CODEX_POLICY: { get: async () => { state.policyReads++; return JSON.stringify(state.policy); } },
+    PRIVATE_CODEX_UPSTREAM: { get: async () => { state.secretReads++; return JSON.stringify(state.upstream); } },
+  }, { get(object, key) {
+    if (!Object.hasOwn(object, key)) { state.genericReads.push(key); throw new Error("unexpected generic binding"); }
+    return object[key];
+  } });
+  for (const name of ["log", "info", "warn", "error", "debug"]) context.mock.method(console, name, (...args) => state.logs.push(args));
+  context.mock.method(globalThis, "fetch", async (url, init) => {
+    if (url === `${issuer}/cdn-cgi/access/certs`) { state.certs++; return Response.json({ keys: [jwk] }); }
+    if (url === `${issuer}/cdn-cgi/access/get-identity`) {
+      state.identities++;
+      assert.equal(init.redirect, "manual");
+      assert.equal(init.cache, "no-store");
+      assert.ok(init.signal instanceof AbortSignal);
+      assert.deepEqual([...new Headers(init.headers).keys()], ["accept-encoding", "cookie"]);
+      assert.equal(new Headers(init.headers).get("accept-encoding"), "identity");
+      return state.lookup(init);
+    }
+    if (url !== "https://chatgpt.com/backend-api/codex/responses") { state.unexpectedFetches++; throw new Error("unexpected fetch destination"); }
+    state.inference++;
+    assert.ok(!new Headers(init.headers).has("cf-access-jwt-assertion"));
+    assert.ok(!new Headers(init.headers).has("cookie"));
+    return Response.json({ object: "response", model: state.upstream.target, status: "completed", output: [] });
+  });
+  const run = (assertion, path = paths[0], options = {}) => {
+    const method = path.endsWith("/responses") ? "POST" : "GET";
+    return worker.fetch(new Request(`https://private.example.invalid${path}`, { method, headers: { "cf-access-jwt-assertion": assertion, ...(method === "POST" ? { "content-type": "application/json" } : {}), ...options.headers }, ...(method === "POST" ? { body: JSON.stringify({ model: alias, store: false }) } : {}), ...options }), env, { waitUntil() { assert.fail("no private persistence"); } });
+  };
+  return { state, env, run };
+}
+async function denied(response) {
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: { code: "route_not_found", message: "route not found" } });
+  assert.deepEqual([...response.headers.keys()].sort(), ["cache-control", "content-type", "x-clawrouter-accounting", "x-clawrouter-content-retention", "x-content-type-options"]);
+}
+function noPrivateUse(state) { assert.equal(state.secretReads, 0); assert.equal(state.inference, 0); assert.deepEqual(state.logs, []); }
+async function enteredOrFailed(entered, pending) {
+  await Promise.race([entered.promise, pending.then(() => assert.fail("expected awaited identity lookup"))]);
+}
+
+test("Access policy requires GitHub account and exact IdP; retired subject-only policy cannot authorize", async (context) => {
+  const { state, env, run } = harness(context);
+  assert.ok(await privatePolicy(env));
+  const invalid = [
+    { mode: "access", issuer, audience, subject: "synthetic-access-subject" },
+    ...[undefined, null, 0, -1, 1.5, "123456", Number.MAX_SAFE_INTEGER + 1].map((githubAccountId) => ({ ...policy().auth, githubAccountId })),
+    ...[undefined, null, "", "synthetic idp", "x".repeat(257), "synthetic\nidp"].map((identityProviderId) => ({ ...policy().auth, identityProviderId })),
+    { ...policy().auth, subject: "synthetic-access-subject" },
+    ...[`${issuer}/`, `${issuer}/path`, `${issuer}?query`, "https://synthetic-owner.cloudflareaccess.com.evil.invalid", "http://synthetic-owner.cloudflareaccess.com"].map((issuer) => ({ ...policy().auth, issuer })),
+  ];
+  const assertion = await jwt();
+  for (const auth of invalid) {
+    state.policy.auth = auth;
+    assert.equal(await privatePolicy(env), null);
+    await denied(await run(assertion));
+  }
+  assert.equal(state.identities, 0); noPrivateUse(state);
+});
+
+test("signature, pinned issuer/audience, numeric time and email validate before any identity lookup", async (context) => {
+  const { state, run } = harness(context);
+  for (const patch of [
+    { iss: "https://synthetic-other.cloudflareaccess.com" }, { iss: `${issuer}/` }, { aud: "synthetic-wrong-audience" },
+    { exp: 1 }, { exp: undefined }, { exp: "99999999999" }, { exp: null },
+    { nbf: 99999999999 }, { nbf: "1" }, { iat: 99999999999 }, { iat: "1" },
+    { email: undefined }, { email: "" }, { email: " " }, { email: 123 }, { email: "x".repeat(1025) },
+  ]) for (const path of paths) await denied(await run(await jwt(patch), path));
+  for (const assertion of [await jwt({}, {}, true), await jwt({}, { alg: "HS256" }), await jwt({}, { kid: "synthetic-unknown" }), "synthetic.forged.jwt", `${await jwt()};synthetic=cookie`]) await denied(await run(assertion));
+  assert.equal(state.identities, 0); noPrivateUse(state);
+});
+
+test("exact assertion lookup binds numeric GitHub account and approved IdP, independent of changing email/sub", async (context) => {
+  const { state, run } = harness(context);
+  for (const [emailValue, sub] of [[email, "synthetic-original-sub"], ["synthetic-new@example.invalid", "synthetic-new-sub"], [email, undefined]]) {
+    const assertion = await jwt({ email: emailValue, sub });
+    state.lookup = (init) => {
+      assert.ok(new Headers(init.headers).get("cookie") === `CF_Authorization=${assertion}`, "exact verified assertion cookie");
+      return Response.json(identity({ email: ` ${emailValue.toUpperCase()} `, name: "SYNTHETIC_PRIVATE_IDENTITY_NAME", groups: ["synthetic-admin"] }));
+    };
+    for (const path of paths) {
+      const response = await run(assertion, path);
+      assert.equal(response.status, 200);
+      const body = await response.text();
+      assert.ok(body.includes(alias));
+      for (const sensitive of [assertion, emailValue, idp, String(account), "synthetic-admin", "SYNTHETIC_PRIVATE_IDENTITY_NAME", ...Object.values(state.upstream).filter((value) => typeof value === "string")]) assert.ok(!body.includes(sensitive), "no private identity in response");
+    }
+  }
+  assert.equal(state.identities, 12); assert.equal(state.inference, 3); assert.deepEqual(state.logs, []);
+});
+
+test("same email and Access subject never authorize a different GitHub account or IdP", async (context) => {
+  const { state, run } = harness(context);
+  const assertion = await jwt();
+  const patches = [
+    ...[account + 1, undefined, null, 0, -1, 1.5, String(account), Number.MAX_SAFE_INTEGER + 1].map((id) => ({ id })),
+    ...[undefined, null, {}, { type: "github" }, { id: idp }, { type: "GitHub", id: idp }, { type: "oidc", id: idp }, { type: "github", id: `${idp}-other` }, { type: "github", id: null }].map((idp) => ({ idp })),
+    ...[undefined, null, "", "synthetic-other@example.invalid", 123].map((email) => ({ email })),
+  ];
+  for (const patch of patches) {
+    state.lookup = () => Response.json(identity({ ...patch, login: "synthetic-owner", user_uuid: "synthetic-access-subject", account_id: account, groups: ["admin"], admin: true }));
+    for (const path of paths) await denied(await run(assertion, path));
+  }
+  noPrivateUse(state);
+});
+
+test("identity failures, invalid UTF-8, encoding, oversize and redirects are generic and cancel bodies", async (context) => {
+  const { state, run } = harness(context);
+  const assertion = await jwt();
+  for (const make of [
+    () => Response.json(null), () => Response.json([]), () => new Response("{"),
+    () => new Response(new Uint8Array([0xff])),
+    () => Response.json(identity(), { headers: { "content-encoding": "gzip" } }),
+    () => Response.json(identity({ padding: "x".repeat(65536) })),
+    ...[301, 302, 307, 308, 401, 403, 429, 500, 503].map((status) => () => new Response("SYNTHETIC_IDENTITY_ERROR", { status, headers: { location: "https://synthetic-other.invalid/identity" } })),
+    () => { throw new Error(`SYNTHETIC_COOKIE_ERROR CF_Authorization=${assertion}`); },
+  ]) {
+    state.lookup = make;
+    await denied(await run(assertion));
+  }
+  for (const status of [200, 302]) {
+    let canceled = false;
+    state.lookup = () => new Response(new ReadableStream({ start(c) { c.enqueue(enc.encode("x".repeat(65537))); }, cancel() { canceled = true; } }), { status });
+    await denied(await run(assertion));
+    assert.equal(canceled, true);
+  }
+  assert.equal(state.inference, 0); noPrivateUse(state);
+});
+
+test("conflicting auth including empty headers denies before certificate or identity fetch", async (context) => {
+  const { state, run } = harness(context);
+  const assertion = await jwt();
+  for (const name of ["authorization", "x-api-key", "api-key", "x-goog-api-key", "proxy-authorization", "cf-access-client-id", "cf-access-client-secret"]) {
+    for (const value of ["", "SYNTHETIC_CONFLICT"]) {
+      await denied(await run(assertion, paths[0], { headers: { "cf-access-jwt-assertion": assertion, [name]: value } }));
+    }
+  }
+  assert.equal(state.identities, 0); assert.equal(state.certs, 0); noPrivateUse(state);
+});
+
+for (const phase of ["fetch", "body"]) for (const cause of ["timeout", "abort"]) {
+  test(`identity ${phase} ${cause} fails closed and cancels without echoing assertion`, async (context) => {
+    const { state, run } = harness(context);
+    const entered = Promise.withResolvers(), abort = new AbortController(), deadline = new AbortController();
+    if (cause === "timeout") context.mock.method(AbortSignal, "timeout", (ms) => { assert.equal(ms, 10000); return deadline.signal; });
+    let canceled = false;
+    state.lookup = (init) => {
+      entered.resolve();
+      if (phase === "fetch") return new Promise((_, reject) => init.signal.addEventListener("abort", () => { canceled = true; reject(new Error(`SYNTHETIC_FETCH_FAILURE ${new Headers(init.headers).get("cookie")}`)); }, { once: true }));
+      return new Response(new ReadableStream({ cancel() { canceled = true; } }));
+    };
+    const pending = run(await jwt(), paths[0], { signal: abort.signal });
+    await enteredOrFailed(entered, pending);
+    if (phase === "body") await new Promise((resolve) => setImmediate(resolve));
+    if (cause === "abort") abort.abort(); else deadline.abort(new DOMException("synthetic deadline", "TimeoutError"));
+    await denied(await pending); assert.equal(canceled, true); noPrivateUse(state);
+  });
+}
+
+test("policy rotation while identity lookup is pending denies before private secret reads", async (context) => {
+  const { state, run } = harness(context);
+  for (const change of [
+    () => { state.policy.enabled = false; },
+    () => { state.policy.auth.githubAccountId++; },
+    () => { state.policy.auth.identityProviderId += "-rotated"; },
+    () => { state.policy.auth = { mode: "workload", credentialSha256: "a".repeat(64) }; },
+  ]) {
+    state.policy = policy();
+    const entered = Promise.withResolvers(), release = Promise.withResolvers();
+    state.lookup = () => { entered.resolve(); return release.promise; };
+    const pending = run(await jwt());
+    await enteredOrFailed(entered, pending); change(); release.resolve(Response.json(identity()));
+    await denied(await pending);
+  }
+  noPrivateUse(state);
+});
+
+test("JWT expiration during awaited identity or subsequent policy/secret reads denies", async (context) => {
+  const { state, env, run } = harness(context);
+  const originalNow = Date.now;
+  const now = originalNow(); let clock = now;
+  context.mock.method(Date, "now", () => clock);
+  for (const phase of ["identity", "policy", "secret"]) {
+    clock = now;
+    const expire = () => { clock = now + 400000; };
+    state.lookup = () => { if (phase === "identity") expire(); return Response.json(identity()); };
+    const policyGet = env.PRIVATE_CODEX_POLICY.get, upstreamGet = env.PRIVATE_CODEX_UPSTREAM.get;
+    if (phase === "policy") env.PRIVATE_CODEX_POLICY.get = async () => { if (state.identities > 0) expire(); return policyGet(); };
+    if (phase === "secret") env.PRIVATE_CODEX_UPSTREAM.get = async () => { expire(); return upstreamGet(); };
+    state.identities = 0; state.secretReads = 0;
+    await denied(await run(await jwt()));
+    assert.equal(state.secretReads, phase === "secret" ? 1 : 0);
+    env.PRIVATE_CODEX_POLICY.get = policyGet; env.PRIVATE_CODEX_UPSTREAM.get = upstreamGet;
+  }
+  assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});
+
+test("upload revalidates current GitHub identity and rejects policy or upstream rotation", async (context) => {
+  const { state, env } = harness(context);
+  for (const change of ["identity", "policy", "upstream", "expired"]) {
+    state.policy = policy(); state.lookup = () => Response.json(identity());
+    state.upstream.expiresAt = Date.now() + 3600000;
+    let controller; const waiting = Promise.withResolvers();
+    const body = new ReadableStream({ start(c) { controller = c; }, pull() { waiting.resolve(); } }, { highWaterMark: 0 });
+    const request = new Request(`https://private.example.invalid${paths[2]}`, { method: "POST", body, duplex: "half", headers: { "content-type": "application/json", "cf-access-jwt-assertion": await jwt() } });
+    const pending = worker.fetch(request, env, { waitUntil() { assert.fail("no persistence"); } });
+    await Promise.race([waiting.promise, pending.then(() => assert.fail("expected paused upload"))]);
+    const reads = state.secretReads;
+    if (change === "identity") state.lookup = () => Response.json(identity({ id: account + 1 }));
+    if (change === "policy") state.policy.auth.identityProviderId += "-rotated";
+    if (change === "upstream") state.upstream.accessToken += "_ROTATED";
+    if (change === "expired") state.upstream.expiresAt = 1;
+    controller.enqueue(enc.encode(JSON.stringify({ model: alias, store: false }))); controller.close();
+    await denied(await pending);
+    assert.equal(state.secretReads - reads, ["identity", "policy"].includes(change) ? 0 : 1);
+  }
+  assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});
+
+test("final awaited identity lookup cannot bypass policy or upstream revalidation", async (context) => {
+  const { state, run } = harness(context);
+  for (const change of ["policy", "upstream"]) {
+    state.policy = policy(); state.identities = 0;
+    state.lookup = () => {
+      if (state.identities === 2) {
+        if (change === "policy") state.policy.auth.githubAccountId++;
+        else state.upstream.accessToken += "_ROTATED";
+      }
+      return Response.json(identity());
+    };
+    const reads = state.secretReads;
+    await denied(await run(await jwt(), paths[2]));
+    assert.equal(state.identities, 2);
+    assert.equal(state.secretReads - reads, change === "policy" ? 1 : 2);
+  }
+  assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});
+
+test("successful identity is never cached or used as fallback on a later request", async (context) => {
+  const { state, run } = harness(context);
+  const assertion = await jwt();
+  assert.equal((await run(assertion)).status, 200);
+  const reads = state.secretReads;
+  for (const lookup of [
+    () => Response.json(identity({ id: account + 1 })),
+    () => new Response(null, { status: 503 }),
+    () => { throw new Error("SYNTHETIC_REVOKED_IDENTITY"); },
+  ]) {
+    state.lookup = lookup;
+    await denied(await run(assertion));
+  }
+  assert.equal(state.identities, 4); assert.equal(state.secretReads, reads);
+  assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});
+
+test("identity byte bound accepts exactly 64 KiB including split UTF-8 and rejects one byte more", async (context) => {
+  const { state, run } = harness(context);
+  state.policy.auth.githubAccountId = Number.MAX_SAFE_INTEGER;
+  state.policy.auth.identityProviderId = "x".repeat(256);
+  const assertion = await jwt();
+  const payload = identity({ id: Number.MAX_SAFE_INTEGER, idp: { type: "github", id: state.policy.auth.identityProviderId }, padding: "é" });
+  payload.padding += "x".repeat(65536 - Buffer.byteLength(JSON.stringify(payload)));
+  const bytes = enc.encode(JSON.stringify(payload));
+  assert.equal(bytes.length, 65536);
+  for (const chunkSize of [1, 17, 65536]) {
+    let offset = 0;
+    state.lookup = () => new Response(new ReadableStream({ pull(controller) {
+      if (offset === bytes.length) { controller.close(); return; }
+      const end = Math.min(offset + chunkSize, bytes.length); controller.enqueue(bytes.slice(offset, end)); offset = end;
+    } }));
+    assert.equal((await run(assertion)).status, 200);
+  }
+  const reads = state.secretReads;
+  state.lookup = () => Response.json({ ...payload, padding: `${payload.padding}x` });
+  await denied(await run(assertion));
+  assert.equal(state.secretReads, reads); assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});
+
+test("expired verification or pre-aborted requests cannot start identity lookup", async (context) => {
+  const { state, run } = harness(context);
+  const now = Date.now(); let clock = now;
+  context.mock.method(Date, "now", () => clock);
+  const assertion = await jwt();
+  const abort = new AbortController(); abort.abort();
+  await denied(await run(assertion, paths[0], { signal: abort.signal }));
+  assert.equal(state.certs, 0);
+  context.mock.method(globalThis, "fetch", async (url) => {
+    assert.equal(url, `${issuer}/cdn-cgi/access/certs`);
+    clock = now + 400000;
+    return Response.json({ keys: [jwk] });
+  });
+  await denied(await run(assertion));
+  assert.equal(state.identities, 0); noPrivateUse(state);
+});
+
+test("policy changes during secret reads and subscription expiry during final policy await deny", async (context) => {
+  const { state, env, run } = harness(context);
+  const originalGet = env.PRIVATE_CODEX_UPSTREAM.get;
+  for (const phase of ["first", "final"]) {
+    state.policy = policy(); state.secretReads = 0;
+    env.PRIVATE_CODEX_UPSTREAM.get = async () => {
+      const result = await originalGet();
+      if (state.secretReads === (phase === "first" ? 1 : 2)) state.policy.auth.identityProviderId += "-rotated";
+      return result;
+    };
+    await denied(await run(await jwt(), paths[2]));
+    assert.equal(state.secretReads, phase === "first" ? 1 : 2);
+  }
+  env.PRIVATE_CODEX_UPSTREAM.get = originalGet;
+  state.policy = policy(); state.secretReads = 0;
+  const now = Date.now(); let clock = now;
+  context.mock.method(Date, "now", () => clock);
+  state.upstream.expiresAt = now + 60000;
+  const policyGet = env.PRIVATE_CODEX_POLICY.get;
+  env.PRIVATE_CODEX_POLICY.get = async () => { if (state.secretReads === 2) clock = now + 31000; return policyGet(); };
+  await denied(await run(await jwt(), paths[2]));
+  assert.equal(state.secretReads, 2); assert.equal(state.inference, 0); assert.deepEqual(state.logs, []);
+});

--- a/worker/test/private-codex-adversarial.test.mjs
+++ b/worker/test/private-codex-adversarial.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { default: worker } = await import("../index.ts");
+const { containResponse } = await import("../private-codex-output.ts");
+const { privateResponseHeaders } = await import("../private-codex-protocol.ts");
+const { sha256Hex } = await import("../utils.ts");
+const alias = "codex-latest", target = "SYNTHETIC_TARGET_ABABAC", reported = "SYNTHETIC_REPORT_ABABAC";
+const accountId = "SYNTHETIC_ACCOUNT_ABABAC", accessToken = "SYNTHETIC_TOKEN_ABABAC";
+const credential = "private-workload-SYNTHETIC_ACCEPTANCE_CREDENTIAL_123456789";
+const upstream = () => ({ version: 1, target, accountId, accessToken, expiresAt: Date.now() + 3600_000 });
+const enc = new TextEncoder();
+const done = (extra = {}) => ({ type: "response.completed", response: { id: "synthetic-response", model: target, status: "completed", ...extra } });
+const created = () => ({ type: "response.created", response: { id: "synthetic-response", model: reported } });
+const textDelta = (delta, extra = {}) => ({ type: "response.output_text.delta", item_id: "synthetic-text", content_index: 0, delta, ...extra });
+const frame = (event) => `data: ${JSON.stringify(event)}\n\n`;
+const wire = (events) => enc.encode(events.map(frame).join("") + "data: [DONE]\n\n");
+const events = (text) => [...text.matchAll(/^data: (.+)$/gm)].filter((m) => m[1] !== "[DONE]").map((m) => JSON.parse(m[1]));
+function contained(text) {
+  for (const value of [target, reported, accountId, accessToken]) assert.equal(text.includes(value), false);
+}
+function failed(text) {
+  contained(text); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed|\[DONE\]/);
+}
+function chunkSizes(seed) {
+  let state = seed;
+  return Array.from({ length: 19 }, () => { state = (Math.imul(state, 1664525) + 1013904223) >>> 0; return 1 + state % 97; });
+}
+function source(bytes, sizes = [bytes.length]) {
+  let offset = 0, chunk = 0;
+  const observed = { canceled: false, pulls: 0 };
+  const body = new ReadableStream({ pull(controller) {
+    observed.pulls++;
+    if (offset === bytes.length) { controller.close(); return; }
+    const end = Math.min(bytes.length, offset + sizes[chunk++ % sizes.length]);
+    controller.enqueue(bytes.slice(offset, end)); offset = end;
+  }, cancel() { observed.canceled = true; } }, { highWaterMark: 0 });
+  return { body, observed };
+}
+async function streamResult(bytes, sizes, headers = {}) {
+  const { body, observed } = source(bytes, sizes);
+  let aborts = 0;
+  const result = await containResponse(new Response(body, { headers: { "content-type": "text/event-stream", ...headers } }), alias, upstream(), true, new AbortController().signal, () => { aborts++; });
+  const text = await result.text();
+  return { result, text, observed, aborts };
+}
+async function fixture() {
+  const state = { policy: { version: 1, enabled: true, alias: { id: alias, name: "Codex (Latest)" }, auth: { mode: "workload", credentialSha256: await sha256Hex(credential) } }, upstream: upstream(), policies: 0, secrets: 0 };
+  const env = {
+    PRIVATE_CODEX_POLICY: { get: async () => { state.policies++; return JSON.stringify(state.policy); } },
+    PRIVATE_CODEX_UPSTREAM: { get: async () => { state.secrets++; return JSON.stringify(state.upstream); } },
+  };
+  return { env, state };
+}
+function request(path = "/private/v1/responses", options = {}) {
+  const method = options.method ?? (path.endsWith("/responses") ? "POST" : "GET");
+  return new Request(`https://synthetic.invalid${path}`, { method,
+    headers: { authorization: `Bearer ${credential}`, "content-type": "application/json", ...options.headers },
+    ...(method === "POST" ? { body: JSON.stringify({ model: alias, store: false }) } : {}),
+  });
+}
+const run = (req, env) => worker.fetch(req, env, { waitUntil() { assert.fail("Private work entered background accounting"); } });
+test.beforeEach((context) => context.mock.method(globalThis, "fetch", () => assert.fail("Unexpected network call in offline acceptance")));
+
+test("adversarial blank and duplicate authentication contexts never resolve private secrets", async () => {
+  const { env, state } = await fixture();
+  for (const headers of [
+    { "cf-access-jwt-assertion": "" }, { "cf-access-jwt-assertion": " \t " },
+    { "x-api-key": "" }, { "proxy-authorization": "" }, { "cf-access-client-id": "" },
+    { authorization: `Bearer ${credential}, Bearer ${credential}` },
+  ]) {
+    const response = await run(request("/private/v1/models", { headers }), env);
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: { code: "route_not_found", message: "route not found" } });
+  }
+  assert.equal(state.secrets, 0);
+});
+
+test("adversarial discarded observations cannot conceal protocol identity or safety envelopes", async () => {
+  for (const type of ["codex.rate_limits", "responsesapi.websocket_timing"]) {
+    for (const envelope of [
+      { headers: { "OpenAI-Model": "SYNTHETIC_ALTERNATE_TARGET" } },
+      { headers: { "OpenAI-Model": target } },
+      { headers: { "x-codex-safety-buffering-enabled": "true" } },
+      { headers: { "x-oai-attestation": "synthetic-required" } },
+      { response: { model: reported, headers: { "x-openai-model": reported } } },
+      { safety_buffering: { use_cases: ["synthetic"], reasons: [], retry_model: "SYNTHETIC_ALTERNATE_TARGET" } },
+      { safety_buffering: { use_cases: ["synthetic"], reasons: [], retry_model: null } },
+    ]) {
+      for (const sizes of [[1], chunkSizes(7), [65536]]) {
+        const result = await streamResult(wire([created(), { type, ...envelope }, done({ model: reported })]), sizes);
+        failed(result.text); assert.ok(result.aborts > 0);
+      }
+    }
+    const pure = { type, metered_limit_name: target, metadata: { model: target }, headers: { "x-codex-primary-used-percent": "1" } };
+    const result = await streamResult(wire([pure, created(), done({ model: reported })]), chunkSizes(13));
+    assert.deepEqual(events(result.text), [{ ...created(), response: { id: "synthetic-response", model: alias } }, done({ model: alias })]);
+  }
+});
+
+test("adversarial seeded chunkings preserve CRLF multiline SSE, UTF-8 and intact tool protocol", async (context) => {
+  const args = '{"model":"synthetic-data","error":null,"value":"\\u0061"}';
+  const input = "synthetic freeform\n🦞";
+  const data = [created(), textDelta("safe 🦞 text"),
+    { type: "response.function_call_arguments.delta", item_id: "synthetic-tool", delta: args.slice(0, 13) },
+    { type: "response.function_call_arguments.delta", item_id: "synthetic-tool", delta: args.slice(13) },
+    { type: "response.function_call_arguments.done", item_id: "synthetic-tool", arguments: args },
+    { type: "response.custom_tool_call_input.delta", call_id: "synthetic-custom-call", delta: input.slice(0, 8) },
+    { type: "response.custom_tool_call_input.delta", call_id: "synthetic-custom-call", item_id: "synthetic-custom-item", delta: input.slice(8) },
+    { type: "response.output_item.done", item: { type: "custom_tool_call", id: "synthetic-custom-item", call_id: "synthetic-custom-call", input } },
+    { type: "response.metadata", metadata: { openai_verification_recommendation: ["synthetic-required"], openai_chatgpt_moderation_metadata: { required: true } } },
+    done({ model: reported }),
+  ];
+  const bytes = enc.encode(data.map((event) => `: discarded ${target}\r\nevent: ${event.type}\r\n${JSON.stringify(event, null, 1).split("\n").map((line) => `data: ${line}\r\n`).join("")}\r\n`).join("") + "data: [DONE]\r\n\r\n");
+  const expected = [{ ...created(), response: { id: "synthetic-response", model: alias } }, ...data.slice(1, -1), done({ model: alias })];
+  const layouts = [[bytes.length], [1], [2, 3, 5, 7, 11], ...Array.from({ length: 24 }, (_, i) => chunkSizes(i + 1))];
+  for (const sizes of layouts) {
+    const result = await streamResult(bytes, sizes);
+    contained(result.text); assert.deepEqual(events(result.text), expected);
+  }
+  context.diagnostic(`${layouts.length} deterministic network layouts`);
+});
+
+test("adversarial three-part and empty logical deltas contain every known canary in each supported family", async (context) => {
+  const families = ["output_text", "refusal", "reasoning_text", "reasoning_summary_text", "function_call_arguments", "custom_tool_call_input"];
+  let cases = 0;
+  for (const secret of [target, reported, accountId, accessToken]) {
+    for (const family of families) {
+      for (const split of [1, Math.floor(secret.length / 2), secret.length - 2]) {
+        const fragments = [secret.slice(0, split), "", secret.slice(split, split + 1), secret.slice(split + 1)];
+        if (family === "function_call_arguments") { fragments[0] = '{"value":"' + fragments[0]; fragments[3] += '"}'; }
+        const deltas = fragments.map((delta) => ({ type: `response.${family}.delta`, item_id: `synthetic-${family}`, content_index: 0, summary_index: 0, delta }));
+        for (const sizes of [[1], chunkSizes(split)]) {
+          const result = await streamResult(wire([created(), ...deltas, done({ model: reported })]), sizes);
+          failed(result.text); assert.equal(events(result.text).some((event) => event.type.endsWith(".delta")), false);
+          cases++;
+        }
+      }
+    }
+  }
+  context.diagnostic(`${cases} canary/family/logical split/network combinations`);
+});
+
+test("adversarial UTF-8 errors never become successful SSE at any injection chunk boundary", async () => {
+  for (const invalid of [[0xc0, 0xaf], [0xed, 0xa0, 0x80], [0xf4, 0x90, 0x80, 0x80], [0xe2, 0x82]]) {
+    const prefix = enc.encode(frame(created()));
+    const bytes = new Uint8Array([...prefix, ...invalid]);
+    for (const sizes of [[1], [prefix.length, 1], chunkSizes(31), [bytes.length]]) {
+      const result = await streamResult(bytes, sizes);
+      failed(result.text); assert.ok(result.aborts > 0);
+    }
+  }
+});
+
+test("adversarial frame, response-header and total-stream limits hold at their actual byte boundaries", async () => {
+  for (const [size, valid] of [[256 * 1024, true], [256 * 1024 + 1, false]]) {
+    const result = await streamResult(enc.encode(":" + "x".repeat(size - 1) + "\n\n" + frame(done()) + "data: [DONE]\n\n"), [65536]);
+    if (valid) assert.deepEqual(events(result.text), [done({ model: alias })]); else failed(result.text);
+  }
+  const multibyte = await streamResult(enc.encode(":" + "🦞".repeat(65536) + "\n\n" + frame(done())), [65536]);
+  failed(multibyte.text);
+  const secretValues = [target, accountId, accessToken];
+  assert.doesNotThrow(() => privateResponseHeaders([["x-reasoning-included", "a".repeat(8192)]], alias, target, secretValues));
+  assert.throws(() => privateResponseHeaders([["x-reasoning-included", "a".repeat(8193)]], alias, target, secretValues));
+  const entries = Array.from({ length: 128 }, (_, i) => [`x-synthetic-${i}`, "safe"]);
+  assert.deepEqual({ ...privateResponseHeaders(entries, alias, target, secretValues) }, {});
+  assert.throws(() => privateResponseHeaders([...entries, ["x-synthetic-extra", "safe"]], alias, target, secretValues));
+  assert.throws(() => privateResponseHeaders([["OpenAI-Model", target], ["openai-model", alias]], alias, target, secretValues));
+  const fullHeaders = Array.from({ length: 8 }, (_, i) => { const key = `x-synthetic-${i}`; return [key, "s".repeat(8192 - key.length)]; });
+  assert.deepEqual({ ...privateResponseHeaders(fullHeaders, alias, target, secretValues) }, {});
+  fullHeaders[7][1] += "s";
+  assert.throws(() => privateResponseHeaders(fullHeaders, alias, target, secretValues));
+  const total = 64 * 1024 * 1024, tail = enc.encode(frame(done()) + "data: [DONE]\n\n");
+  for (const extra of [0, 1]) {
+    let remaining = total - tail.length + extra, emitted = 0, canceled = false;
+    const body = new ReadableStream({ pull(controller) {
+      if (remaining) {
+        const length = Math.min(65536, remaining);
+        controller.enqueue(enc.encode(":" + "x".repeat(length - 3) + "\n\n")); remaining -= length; emitted += length;
+      } else if (emitted < total + extra) { controller.enqueue(tail); emitted += tail.length; }
+      else controller.close();
+    }, cancel() { canceled = true; } }, { highWaterMark: 0 });
+    const result = await containResponse(new Response(body, { headers: { "content-type": "text/event-stream" } }), alias, upstream(), true, new AbortController().signal, () => {});
+    const text = await result.text();
+    assert.equal(emitted, total + extra);
+    if (extra) { failed(text); assert.equal(canceled, true); } else assert.deepEqual(events(text), [done({ model: alias })]);
+  }
+});
+
+test("adversarial request bytes and response structure limits accept the boundary but not the next unit", async (context) => {
+  const { env } = await fixture(); let calls = 0;
+  context.mock.method(globalThis, "fetch", () => {
+    calls++; return Response.json({ object: "response", id: "synthetic-response", status: "completed", model: target });
+  });
+  const empty = JSON.stringify({ model: alias, store: false, input: "" });
+  for (const extra of [0, 1]) {
+    const body = JSON.stringify({ model: alias, store: false, input: "x".repeat(1024 * 1024 - enc.encode(empty).length + extra) });
+    assert.equal(enc.encode(body).length, 1024 * 1024 + extra);
+    const req = new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" }, body });
+    const response = await run(req, env);
+    assert.equal(response.status, extra ? 400 : 200); contained(await response.text());
+  }
+  assert.equal(calls, 1);
+  const metadataCases = [];
+  for (const depth of [47, 48]) {
+    let value = "safe";
+    for (let i = 0; i < depth; i++) value = { nested: value };
+    metadataCases.push([value, depth === 47]);
+  }
+  // Root + five keys + four scalar values + the metadata array use eleven nodes.
+  for (const length of [49_989, 49_990]) metadataCases.push([Array(length).fill("safe"), length === 49_989]);
+  for (const [metadata, valid] of metadataCases) {
+    const body = { object: "response", id: "synthetic-response", status: "completed", model: target, metadata };
+    const response = await containResponse(Response.json(body), alias, upstream(), false, new AbortController().signal, () => {});
+    assert.equal(response.status, valid ? 200 : 502); contained(await response.text());
+  }
+});
+
+test("adversarial cancellation while tool holdback waits discards all pending protocol data", async () => {
+  const waiting = Promise.withResolvers(); let canceled = false, aborts = 0, pulls = 0;
+  const body = new ReadableStream({ pull(controller) {
+    pulls++;
+    if (pulls === 1) controller.enqueue(enc.encode(frame(created())));
+    else if (pulls === 2) controller.enqueue(enc.encode(frame({ type: "response.custom_tool_call_input.delta", item_id: "synthetic-tool", delta: reported.slice(0, 10) })));
+    else waiting.resolve();
+  }, cancel() { canceled = true; } }, { highWaterMark: 0 });
+  const result = await containResponse(new Response(body, { headers: { "content-type": "text/event-stream" } }), alias, upstream(), true, new AbortController().signal, () => { aborts++; });
+  const reader = result.body.getReader();
+  const first = await reader.read(); contained(new TextDecoder().decode(first.value));
+  const pending = reader.read(); await waiting.promise; await reader.cancel();
+  assert.deepEqual(await pending, { done: true, value: undefined });
+  assert.equal(canceled, true); assert.ok(aborts > 0); assert.equal(pulls, 3);
+});
+
+test("adversarial paused uploads fail closed across policy, credential, binding and expiry races", async () => {
+  const changes = [
+    (state) => { state.policy.enabled = false; },
+    (state) => { state.policy.auth.credentialSha256 = "0".repeat(64); },
+    (state) => { state.policy.alias.name = "Synthetic changed alias"; },
+    (state) => { state.policy.alias.supportedReasoningEfforts = ["high"]; },
+    (state) => { state.policy.auth = { mode: "access", issuer: "https://synthetic-owner.cloudflareaccess.com", githubAccountId: 123456, identityProviderId: "synthetic-github-idp", audience: "synthetic-aud" }; },
+    (state) => { state.upstream.target = "SYNTHETIC_ROTATED_TARGET"; },
+    (state) => { state.upstream.accountId = "SYNTHETIC_ROTATED_ACCOUNT"; },
+    (state) => { state.upstream.accessToken = "SYNTHETIC_ROTATED_ACCESS_TOKEN"; },
+    (state) => { state.upstream.expiresAt = Date.now() + 29_000; },
+  ];
+  for (const change of changes) {
+    const { env, state } = await fixture(); const waiting = Promise.withResolvers(); let controller;
+    const body = new ReadableStream({ start(c) { controller = c; }, pull() { waiting.resolve(); } }, { highWaterMark: 0 });
+    const req = new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" }, body, duplex: "half" });
+    const pending = run(req, env); await waiting.promise;
+    assert.equal(state.policies, 1); assert.equal(state.secrets, 1);
+    change(state);
+    controller.enqueue(enc.encode(JSON.stringify({ model: alias, store: false }))); controller.close();
+    const result = await pending; assert.equal(result.status, 404);
+    assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+  }
+});
+
+test("adversarial aborted and malformed uploads cancel their reader before inference", async () => {
+  for (const abortRequest of [false, true]) {
+    const { env } = await fixture(); const waiting = Promise.withResolvers(); const abort = new AbortController();
+    let controller, canceled = false;
+    const body = new ReadableStream({ start(c) { controller = c; }, pull() { waiting.resolve(); }, cancel() { canceled = true; } }, { highWaterMark: 0 });
+    const pending = run(new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" }, body, duplex: "half", signal: abort.signal }), env);
+    await waiting.promise;
+    if (abortRequest) abort.abort(); else controller.enqueue(new Uint8Array([0xff]));
+    const result = await pending; assert.equal(result.status, 400); assert.equal(canceled, true); contained(await result.text());
+  }
+});
+
+test("adversarial workload rotation is fresh on every request and never becomes a public or admin grant", async (context) => {
+  const { env, state } = await fixture();
+  const rotated = "private-workload-SYNTHETIC_ROTATED_CREDENTIAL_123456789";
+  assert.equal((await run(request("/private/v1/models"), env)).status, 200);
+  state.policy.auth.credentialSha256 = await sha256Hex(rotated);
+  const reads = state.secrets;
+  assert.equal((await run(request("/private/v1/models"), env)).status, 404); assert.equal(state.secrets, reads);
+  assert.equal((await run(request("/private/v1/models", { headers: { authorization: `Bearer ${rotated}` } }), env)).status, 200);
+  const admin = "SYNTHETIC_ADMIN_ACCEPTANCE_TOKEN";
+  const publicEnv = { ...env, CLAWROUTER_ADMIN_TOKEN_SHA256: await sha256Hex(admin) };
+  const before = state.secrets;
+  const logs = [];
+  for (const name of ["log", "info", "warn", "error"]) context.mock.method(console, name, (...args) => logs.push(args));
+  for (const token of [rotated, admin]) {
+    for (const path of ["/v1/providers", "/v1/catalog", "/v1/models", "/v1/routes", "/v1/admin/private-codex", "/v1/native/private/v1/responses", "/v1/proxy/private/responses"]) {
+      const result = await run(request(path, { headers: { authorization: `Bearer ${token}` } }), publicEnv);
+      const text = await result.text(); contained(text); assert.equal(text.includes(alias), false);
+    }
+  }
+  assert.equal(state.secrets, before); contained(JSON.stringify(logs));
+});

--- a/worker/test/private-codex-projection.test.mjs
+++ b/worker/test/private-codex-projection.test.mjs
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { containResponse } = await import("../private-codex-output.ts");
+const alias = "codex-latest";
+const target = "SYNTHETIC_SELECTED_TARGET_8T";
+const reported = "SYNTHETIC_BACKEND_REPORT_9R";
+const upstream = { version: 1, target, accountId: "SYNTHETIC_ACCOUNT_3A", accessToken: "SYNTHETIC_TOKEN_4T", expiresAt: 9999999999999 };
+const enc = new TextEncoder();
+const responseBody = (extra = {}) => ({ object: "response", id: "synthetic-response", status: "completed", model: target, output: [], ...extra });
+const created = (extra = {}) => ({ type: "response.created", response: responseBody({ status: "in_progress", ...extra }) });
+const completed = (extra = {}) => ({ type: "response.completed", response: responseBody(extra) });
+const delta = (text, extra = {}) => ({ type: "response.output_text.delta", item_id: "synthetic-item", content_index: 0, output_index: 0, delta: text, ...extra });
+
+function sse(events, headers = {}, chunkSize = 17) {
+  const bytes = enc.encode(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n");
+  let offset = 0;
+  return new Response(new ReadableStream({ pull(controller) {
+    if (offset === bytes.length) { controller.close(); return; }
+    const end = Math.min(offset + chunkSize, bytes.length); controller.enqueue(bytes.slice(offset, end)); offset = end;
+  } }), { headers: { "content-type": "text/event-stream", ...headers } });
+}
+const contain = (response, stream = false) => containResponse(response, alias, upstream, stream, new AbortController().signal, () => {});
+const parseEvents = (text) => [...text.matchAll(/^data: (.+)$/gm)].filter((match) => match[1] !== "[DONE]").map((match) => JSON.parse(match[1]));
+function assertPrivate(text, extras = [reported]) {
+  for (const value of [target, upstream.accountId, upstream.accessToken, ...extras]) assert.equal(text.includes(value), false);
+}
+
+function arbitraryData() {
+  const properties = { model: { type: "object", properties: { error: { type: "string" } } }, error: { type: "string" }, headers: { type: "object" } };
+  return {
+    tools: [{ type: "function", name: "synthetic_simple", parameters: { type: "object", properties } },
+      { type: "namespace", name: "synthetic_namespace", tools: Array.from({ length: 5 }, (_, index) => ({ type: "function", name: `synthetic_${index}`, parameters: { type: "object", properties } })) }],
+    metadata: { code: { model: "synthetic-domain-model", error: { message: "synthetic user error" }, headers: ["synthetic-header"], retry_model: "synthetic-data", faster_model: "synthetic-data", auto_review_model_override: "synthetic-data" },
+      user: { response: { model: "synthetic-user-model", headers: { "openai-model": "synthetic-user-header" }, error: "synthetic-user-error" } } },
+    output: [{ type: "function_call", name: "synthetic_tool", call_id: "synthetic-call", arguments: '{"model":"synthetic-data","error":{"code":1},"headers":{"model":"synthetic-data"}}' }, { type: "reasoning", encrypted_content: "synthetic-encrypted-bytes" }],
+  };
+}
+
+test("reporting model projection aliases JSON and SSE body identity without changing arbitrary response data", async () => {
+  const data = arbitraryData();
+  const body = responseBody({ ...data, model: reported, headers: { "OpenAI-Model": target } });
+  const json = await contain(Response.json(body, { headers: { "OpenAI-Model": target } }));
+  assert.equal(json.status, 200);
+  const text = await json.text(); assertPrivate(text); assert.equal(json.headers.get("openai-model"), alias);
+  assert.deepEqual(JSON.parse(text), { ...body, model: alias, headers: { "OpenAI-Model": alias } });
+  const events = [created({ ...data, model: reported, headers: { "x-openai-model": target } }), completed({ model: reported })];
+  const stream = await contain(sse(events, { "OpenAI-Model": target }), true);
+  const wire = await stream.text(); assertPrivate(wire); assert.doesNotMatch(wire, /private_upstream_error/);
+  assert.deepEqual(parseEvents(wire), [created({ ...data, model: alias, headers: { "x-openai-model": alias } }), completed({ model: alias })]);
+});
+
+test("arbitrary response data model/error/headers names never become protocol selectors", async () => {
+  const data = arbitraryData();
+  const json = await contain(Response.json(responseBody(data)));
+  assert.equal(json.status, 200);
+  assert.deepEqual(await json.json(), responseBody({ ...data, model: alias }));
+  const stream = await contain(sse([created(data), { type: "response.output_item.done", item: { type: "tool_search_call", arguments: data.metadata } }, completed()]), true);
+  const wire = await stream.text(); assert.doesNotMatch(wire, /private_upstream_error/);
+  assert.deepEqual(parseEvents(wire), [created({ ...data, model: alias }), { type: "response.output_item.done", item: { type: "tool_search_call", arguments: data.metadata } }, completed({ model: alias })]);
+});
+
+test("reporting names are decoded and learned before inspecting any JSON/SSE sibling", async () => {
+  const escaped = [...reported].map((char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`).join("");
+  const wire = JSON.stringify(responseBody({ model: reported })).replace(reported, escaped);
+  const json = await contain(new Response(wire, { headers: { "content-type": "application/json" } }));
+  assert.equal(json.status, 200); assert.equal((await json.json()).model, alias);
+  const cases = [
+    { metadata: { model: reported } }, { metadata: { error: reported } }, { metadata: { [reported]: true } },
+    { tools: [{ parameters: { properties: { model: { description: reported } } } }] },
+    { output: [{ arguments: `{"value":"${escaped}"}` }] }, { output: [{ encrypted_content: reported }] },
+    { metadata: { response: { headers: { "OpenAI-Model": reported } } } },
+    { output: [{ text: target }] }, { output: [{ text: upstream.accountId }] }, { output: [{ text: upstream.accessToken }] },
+  ];
+  for (const extra of cases) {
+    // model is deliberately inserted last, after arbitrary data containing the name.
+    const body = { object: "response", id: "synthetic-response", status: "completed", ...extra, model: reported };
+    const result = await contain(Response.json(body));
+    assert.equal(result.status, 502); assertPrivate(await result.text());
+    const stream = await contain(sse([{ type: "response.created", response: { ...body, status: "in_progress" } }, completed({ model: reported })]), true);
+    const text = await stream.text(); assertPrivate(text); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed/);
+  }
+  const stream = await contain(sse([{ type: "response.created", metadata: { echo: reported }, response: { model: reported } }]), true);
+  const text = await stream.text(); assertPrivate(text); assert.match(text, /private_upstream_error/);
+});
+
+test("learned reporting identity cannot authorize actual HTTP or typed event model headers", async () => {
+  for (const name of ["OpenAI-Model", "x-openai-model", "x-codex-safety-buffering-faster-model"]) {
+    for (const model of [reported, "SYNTHETIC_UNAUTHORIZED_MODEL_7U"]) {
+      const result = await contain(Response.json(responseBody({ model: reported }), { headers: { [name]: model } }));
+      assert.equal(result.status, 502); assertPrivate(await result.text(), [reported, model]);
+      const json = await contain(Response.json(responseBody({ model: reported, headers: { [name]: [model] } })));
+      assert.equal(json.status, 502); assertPrivate(await json.text(), [reported, model]);
+      for (const event of [
+        created({ model: reported, headers: { [name]: model } }),
+        { type: "response.metadata", headers: { [name]: [model] } },
+        completed({ model: reported, headers: { [name]: model } }),
+      ]) {
+        const stream = await contain(sse([created({ model: reported }), event, completed({ model: reported })]), true);
+        const text = await stream.text(); assertPrivate(text, [reported, model]); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed/);
+      }
+    }
+  }
+});
+
+test("only typed safety selectors are projected and still require the authorized target", async () => {
+  const safety = { use_cases: ["synthetic-case"], reasons: ["synthetic-reason"], retry_model: target };
+  const metadata = { openai_verification_recommendation: ["synthetic-required-verification"], openai_chatgpt_moderation_metadata: { required: true }, code: arbitraryData().metadata.code };
+  const events = [created({ model: reported }), { type: "response.metadata", metadata, safety_buffering: safety },
+    { type: "response.metadata", metadata: { type: "safety_buffering", ...safety } },
+    { type: "response.metadata", safety_buffering: { ...safety, retry_model: null } }, completed({ model: reported })];
+  const stream = await contain(sse(events, { "x-codex-safety-buffering-enabled": "false", "x-codex-safety-buffering-faster-model": target }), true);
+  const text = await stream.text(); assertPrivate(text); assert.doesNotMatch(text, /private_upstream_error/);
+  assert.equal(stream.headers.get("x-codex-safety-buffering-enabled"), "false");
+  assert.equal(stream.headers.get("x-codex-safety-buffering-faster-model"), alias);
+  assert.deepEqual(parseEvents(text), [created({ model: alias }), { type: "response.metadata", metadata, safety_buffering: { ...safety, retry_model: alias } },
+    { type: "response.metadata", metadata: { type: "safety_buffering", ...safety, retry_model: alias } },
+    { type: "response.metadata", safety_buffering: { ...safety, retry_model: null } }, completed({ model: alias })]);
+  for (const key of ["retry_model", "faster_model", "auto_review_model_override", "model"]) {
+    for (const model of [reported, "SYNTHETIC_SAFETY_ALTERNATE_6S"]) {
+      for (const envelope of [{ safety_buffering: { ...safety, [key]: model } }, { metadata: { type: "safety_buffering", ...safety, [key]: model } }]) {
+        const result = await contain(sse([created({ model: reported }), { type: "response.metadata", ...envelope }, completed({ model: reported })]), true);
+        const wire = await result.text(); assertPrivate(wire, [reported, model]); assert.match(wire, /private_upstream_error/); assert.doesNotMatch(wire, /response.completed/);
+      }
+    }
+  }
+});
+
+test("learned identities are held across network chunks and logical text/tool deltas", async () => {
+  const first = reported.slice(0, 12), last = reported.slice(12);
+  const custom = { type: "response.custom_tool_call_input.delta", item_id: "synthetic-custom" };
+  const tool = { type: "response.function_call_arguments.delta", item_id: "synthetic-function" };
+  const escaped = [...reported].map((char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`).join("");
+  const args = `{"model":"${escaped}","error":null}`;
+  const cases = [
+    [delta(first), delta(last)],
+    [delta(first), delta("safe interleaved data", { item_id: "synthetic-other", output_index: 1 }), delta(last)],
+    [delta(first), delta(last, { item_id: "synthetic-other", output_index: 1 })],
+    [{ type: "response.reasoning_summary_text.delta", summary_index: 0, delta: first }, { type: "response.reasoning_summary_text.delta", summary_index: 0, delta: last }],
+    [{ ...custom, delta: first }, { ...custom, delta: last }],
+    [{ ...tool, delta: `{"value":"${first}` }, { ...tool, delta: `${last}"}` }],
+    [{ ...tool, delta: args.slice(0, 35) }, { ...tool, delta: args.slice(35) }, { type: "response.function_call_arguments.done", item_id: tool.item_id, arguments: args }],
+    [{ type: "response.output_text.done", text: reported }],
+    [{ type: "response.custom_tool_call_input.done", item_id: custom.item_id, input: reported }],
+  ];
+  for (const events of cases) {
+    const stream = await contain(sse([created({ model: reported }), ...events, completed({ model: reported })], {}, 1), true);
+    const text = await stream.text(); assertPrivate(text); assert.match(text, /private_upstream_error/);
+    assert.equal(text.includes(first), false); assert.equal(text.includes(last), false); assert.doesNotMatch(text, /response.completed/);
+    assert.deepEqual(parseEvents(text)[0], created({ model: alias }));
+  }
+});
+
+test("learned matcher safely disambiguates prefixes and preserves encoded tool data", async () => {
+  const prefix = reported.slice(0, 12), safeTail = "unrelated-safe-ending";
+  const args = '{"model":"synthetic-domain","error":{"code":1},"headers":["synthetic-header"]}';
+  const events = [created({ model: reported }), delta(prefix), delta(safeTail),
+    { type: "response.function_call_arguments.delta", item_id: "synthetic-tool", delta: args.slice(0, 15) },
+    { type: "response.function_call_arguments.delta", item_id: "synthetic-tool", delta: args.slice(15) },
+    { type: "response.function_call_arguments.done", item_id: "synthetic-tool", arguments: args }, completed({ model: reported })];
+  const stream = await contain(sse(events), true);
+  const text = await stream.text(); assertPrivate(text); assert.doesNotMatch(text, /private_upstream_error/);
+  assert.deepEqual(parseEvents(text), [created({ model: alias }), ...events.slice(1, -1), completed({ model: alias })]);
+});
+
+test("learning is bounded and never resets matcher history or accepts a late reporting change", async () => {
+  for (const model of ["", " ", null, {}, [], "x".repeat(129), "synthetic\nmodel", "synthetic-🦞"]) {
+    const json = await contain(Response.json(responseBody({ model })));
+    assert.equal(json.status, 502); assertPrivate(await json.text());
+    const stream = await contain(sse([created({ model })]), true);
+    assert.match(await stream.text(), /private_upstream_error/);
+  }
+  const changed = "SYNTHETIC_CHANGED_REPORT_5C";
+  for (const events of [
+    [created(), created({ model: reported })],
+    [delta("safe"), created({ model: reported })],
+    [delta(target.slice(0, 12)), created({ model: reported })],
+    [created({ model: reported }), created({ model: changed })],
+    [created({ model: reported }), delta(reported.slice(0, 12)), completed({ model: changed })],
+  ]) {
+    const stream = await contain(sse([...events, completed({ model: reported })]), true);
+    const text = await stream.text(); assertPrivate(text, [reported, changed]); assert.match(text, /private_upstream_error/);
+    assert.equal(text.includes(target.slice(0, 12)), false); assert.equal(text.includes(reported.slice(0, 12)), false); assert.doesNotMatch(text, /response.completed/);
+  }
+  // Repeating the learned name, target or alias cannot replace the original sensitive set.
+  const stream = await contain(sse([created({ model: reported }), created({ model: target }), created({ model: alias }), delta(reported.slice(0, 12)), delta(reported.slice(12))]), true);
+  const text = await stream.text(); assertPrivate(text); assert.match(text, /private_upstream_error/);
+});
+
+test("HTTP and typed affinity are inspected against reporting identity before release", async () => {
+  const unsafe = [reported, JSON.stringify({ affinity: reported }), encodeURIComponent(JSON.stringify({ affinity: reported })), Buffer.from(JSON.stringify({ affinity: reported })).toString("base64url")];
+  for (const value of unsafe) {
+    for (const name of ["x-codex-turn-state", "x-reasoning-included"]) {
+      for (const streaming of [false, true]) {
+        const upstreamResponse = streaming ? sse([created({ model: reported }), completed({ model: reported })], { [name]: value })
+          : Response.json(responseBody({ model: reported }), { headers: { [name]: value } });
+        const result = await contain(upstreamResponse, streaming);
+        assert.equal(result.status, 502); assert.equal(result.headers.get(name), null);
+        assertPrivate(JSON.stringify([...result.headers]) + await result.text());
+      }
+      const stream = await contain(sse([created({ model: reported, headers: { [name]: value } })]), true);
+      const text = await stream.text(); assertPrivate(text); assert.match(text, /private_upstream_error/);
+    }
+  }
+  const affinity = Buffer.from(JSON.stringify({ affinity: "synthetic-cell" })).toString("base64url");
+  const stream = await contain(sse([created({ model: reported }), completed({ model: reported })], { "x-codex-turn-state": affinity, "x-reasoning-included": "" }), true);
+  assert.equal(stream.headers.get("x-codex-turn-state"), affinity); assert.equal(stream.headers.get("x-reasoning-included"), "");
+  assert.doesNotMatch(await stream.text(), /private_upstream_error/);
+});
+
+test("reporting names cannot escape via terminal responses, genuine errors or local failure text", async () => {
+  for (const event of [
+    completed({ model: reported, output: [{ text: reported }] }),
+    { type: "response.failed", response: { model: reported, status: "failed", error: { code: "cyber_policy", message: reported } } },
+    { type: "error", error: { message: reported } },
+    { type: "response.created", response: { model: reported, error: { message: reported } } },
+  ]) {
+    const stream = await contain(sse([created({ model: reported }), event]), true);
+    const text = await stream.text(); assertPrivate(text); assert.doesNotMatch(text, /response.completed/);
+    if (event.type === "response.failed") { assert.match(text, /response.failed/); assert.match(text, /cyber_policy/); }
+    else assert.match(text, /private_upstream_error/);
+  }
+  const model = "private_upstream_error";
+  const stream = await contain(sse([created({ model }), { type: "error" }]), true);
+  const text = await stream.text(); assert.equal(text.includes(model), false); assert.doesNotMatch(text, /response.completed/);
+  const late = await contain(sse([created(), created({ model })]), true);
+  assert.equal((await late.text()).includes(model), false);
+  const json = await contain(Response.json(responseBody({ model, error: { message: model } })));
+  assert.equal(json.status, 502); assert.equal((await json.text()).includes(model), false);
+});

--- a/worker/test/private-codex.test.mjs
+++ b/worker/test/private-codex.test.mjs
@@ -1,0 +1,938 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { default: worker } = await import("../index.ts");
+const { sha256Hex } = await import("../utils.ts");
+const { privateSubscriptionBody } = await import("../private-codex.ts");
+
+const target = "SYNTHETIC_PRIVATE_TARGET_7Q";
+const accessToken = "SYNTHETIC_SUBSCRIPTION_TOKEN_4P";
+const accountId = "SYNTHETIC_ACCOUNT_9R";
+const credential = "private-workload-SYNTHETIC_WORKLOAD_CREDENTIAL_0123456789";
+const alias = "codex-latest";
+const enc = new TextEncoder();
+const fixture = () => ({ version: 1, target, accessToken, accountId, expiresAt: Date.now() + 3600_000 });
+const workloadPolicy = async () => ({ version: 1, enabled: true, alias: { id: alias, name: "Codex (Latest)" }, auth: { mode: "workload", credentialSha256: await sha256Hex(credential) } });
+
+async function environment() {
+  const state = { policy: await workloadPolicy(), upstream: fixture(), policyReads: 0, secretReads: 0, genericReads: [] };
+  const env = new Proxy({
+    PRIVATE_CODEX_POLICY: { get: async () => { state.policyReads++; return JSON.stringify(state.policy); } },
+    PRIVATE_CODEX_UPSTREAM: { get: async () => { state.secretReads++; return JSON.stringify(state.upstream); } },
+  }, { get(object, key) {
+    if (Object.hasOwn(object, key)) return object[key];
+    state.genericReads.push(key);
+    throw new Error(`SYNTHETIC_FORBIDDEN_GENERIC_BINDING_${String(key)}`);
+  } });
+  return { env, state };
+}
+
+function request(path = "/private/v1/responses", options = {}) {
+  const method = options.method ?? (path.endsWith("/responses") ? "POST" : "GET");
+  return new Request(`https://private.example.invalid${path}`, {
+    method, signal: options.signal,
+    headers: { authorization: `Bearer ${credential}`, ...(method === "POST" ? { "content-type": "application/json" } : {}), ...options.headers },
+    ...(method === "POST" ? { body: typeof options.body === "string" ? options.body : JSON.stringify(options.body ?? { model: alias, input: "SYNTHETIC_INPUT", store: false }) } : {}),
+  });
+}
+const run = (req, env) => worker.fetch(req, env, { waitUntil() { assert.fail("Private work must not enqueue accounting or retention"); } });
+const responseObject = (extra = {}) => ({ id: "synthetic-response", object: "response", model: target, status: "completed", output: [], ...extra });
+const jsonResponse = (extra = {}, headers = {}) => Response.json(responseObject(extra), { headers });
+const frame = (event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+const textDelta = (delta, extra = {}) => ({ type: "response.output_text.delta", item_id: "synthetic-item", output_index: 0, content_index: 0, delta, ...extra });
+const completed = (extra = {}) => ({ type: "response.completed", response: responseObject(extra) });
+function sse(events, chunkSize = 19, ending = true) {
+  const text = events.map((event) => typeof event === "string" ? event : frame(event)).join("") + (ending ? "data: [DONE]\n\n" : "");
+  const bytes = enc.encode(text);
+  let offset = 0;
+  return new Response(new ReadableStream({ pull(controller) {
+    if (offset === bytes.length) { controller.close(); return; }
+    const end = Math.min(bytes.length, offset + chunkSize);
+    controller.enqueue(bytes.slice(offset, end)); offset = end;
+  } }), { headers: { "content-type": "text/event-stream", "x-synthetic-secret": target } });
+}
+function assertContained(text) {
+  for (const secret of [target, accessToken, accountId]) assert.equal(text.includes(secret), false);
+}
+async function withFetch(mock, action) {
+  const original = globalThis.fetch;
+  globalThis.fetch = mock;
+  try { return await action(); } finally { globalThis.fetch = original; }
+}
+
+test("private unauthorized callers are indistinguishable; no target resolution or upstream call", async () => {
+  const { env, state } = await environment();
+  const attempts = [
+    {}, { authorization: "Bearer SYNTHETIC_ADMIN_TOKEN" }, { authorization: "Bearer clawrouter-live-synthetic-key-secret" },
+    { "x-api-key": credential }, { cookie: "clawrouter_session=SYNTHETIC_LOCAL_LOGIN" },
+    { "cf-access-authenticated-user-email": "owner@example.invalid", "x-user-id": "synthetic-owner", "session-id": "synthetic-owner-session" },
+    { authorization: `Bearer ${credential}`, "x-api-key": "synthetic-shared" },
+    { authorization: `Bearer ${credential}`, "cf-access-jwt-assertion": "synthetic.forged.jwt" },
+    { authorization: `Bearer ${credential}`, "cf-access-client-secret": "synthetic" },
+  ];
+  await withFetch(() => assert.fail("Unauthorized upstream fetch"), async () => {
+    for (const headers of attempts) {
+      for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses", "/private/v1/unknown"]) {
+        const req = request(path); req.headers.delete("authorization");
+        for (const [key, value] of Object.entries(headers)) req.headers.set(key, value);
+        const result = await run(req, env);
+        assert.equal(result.status, 404);
+        assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+      }
+    }
+  });
+  assert.equal(state.secretReads, 0);
+  assert.deepEqual(state.genericReads, []);
+});
+
+test("provider, admin and proxy bearers cannot authenticate even with a matching workload digest", async () => {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const jwtShaped = `${encode({ alg: "RS256", typ: "JWT" })}.${encode({ sub: "synthetic-owner", account_id: accountId })}.${encode("synthetic-signature")}`;
+  await withFetch(() => assert.fail("Non-workload bearer reached a network endpoint"), async () => {
+    for (const token of [accessToken, jwtShaped, "SYNTHETIC_ADMIN_TOKEN", "clawrouter-live-synthetic-key-secret"]) {
+      for (const mode of ["workload", "access"]) {
+        const { env, state } = await environment();
+        state.policy.auth = mode === "workload" ? { mode, credentialSha256: await sha256Hex(token) }
+          : { mode, issuer: "https://synthetic-owner.cloudflareaccess.com", githubAccountId: 123456, identityProviderId: "synthetic-github-idp", audience: "synthetic-audience" };
+        for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"]) {
+          const result = await run(request(path, { headers: { authorization: `Bearer ${token}` } }), env);
+          assert.equal(result.status, 404);
+          assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+        }
+        assert.equal(state.secretReads, 0); assert.deepEqual(state.genericReads, []);
+      }
+    }
+  });
+});
+
+test("account selection stays broker-only and OAuth rotation leaves workload authentication independent", async () => {
+  const { env, state } = await environment();
+  await withFetch(() => assert.fail("Caller account selection reached upstream"), async () => {
+    for (const name of ["chatgpt-account-id", "x-chatgpt-account-id", "chatgpt_account_id", "openai-account-id", "x-account-id"]) {
+      for (const value of [accountId, "SYNTHETIC_OTHER_ACCOUNT", "", `${accountId}, ${accountId}`]) {
+        for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"]) {
+          const result = await run(request(path, { headers: { [name]: value } }), env);
+          assert.equal(result.status, 400); assertContained(await result.text());
+        }
+      }
+    }
+    for (const path of ["/private/backend-api/codex/models", "/private/v1/models/upstream", "/private/v1/oauth/refresh"]) {
+      assert.equal((await run(request(path), env)).status, 404);
+    }
+  });
+  assert.equal(state.secretReads, 0);
+  const digest = state.policy.auth.credentialSha256;
+  let calls = 0;
+  await withFetch((_, init) => {
+    calls++;
+    assert.equal(init.headers.get("authorization"), `Bearer ${state.upstream.accessToken}`);
+    assert.notEqual(init.headers.get("authorization"), `Bearer ${credential}`);
+    assert.equal(init.headers.get("chatgpt-account-id"), accountId);
+    assert.equal(JSON.parse(init.body).model, target);
+    return jsonResponse();
+  }, async () => {
+    for (const token of [accessToken, `${accessToken}_ROTATED`]) {
+      state.upstream.accessToken = token;
+      const result = await run(request(), env);
+      assert.equal(result.status, 200); assertContained(await result.text());
+      assert.equal(state.policy.auth.credentialSha256, digest);
+    }
+  });
+  assert.equal(calls, 2); assert.deepEqual(state.genericReads, []);
+});
+
+test("safe authorized discovery uses only alias metadata; binding absent from every public inventory", async () => {
+  const { env, state } = await environment();
+  await withFetch(() => assert.fail("Discovery must not fetch upstream"), async () => {
+    const models = await run(request("/private/v1/models"), env);
+    assert.equal(models.status, 200);
+    assert.deepEqual((await models.json()).data, [{ id: alias, object: "model", owned_by: "private", display_name: "Codex (Latest)", capabilities: ["llm.responses"] }]);
+    const catalog = await run(request("/private/v1/catalog"), env);
+    const body = await catalog.text(); assertContained(body);
+    const provider = JSON.parse(body).providers[0];
+    const model = provider.models[0];
+    // OpenClaw validates the native namespace even when selecting unified Responses.
+    assert.equal(provider.nativeBaseUrl, "/v1/native/private");
+    assert.equal(provider.openaiCompatible, true);
+    assert.deepEqual(provider.routes, [{ endpoint: "responses", methods: ["POST"], path: "/v1/responses", requestFormat: "openai.responses", responseFormat: "openai.responses", streaming: "sse" }]);
+    assert.deepEqual(model.capabilities, ["llm.responses"]);
+    assert.equal(model.upstream, alias); assert.equal(model.displayName, "Codex (Latest)");
+    assert.equal(body.includes("accountId"), false); assert.equal(body.includes("credentialSha256"), false);
+    assert.match(catalog.headers.get("cache-control"), /no-store/);
+    assert.equal(catalog.headers.get("access-control-allow-origin"), null);
+    assert.equal(catalog.headers.get("x-request-id"), null);
+  });
+  const reads = state.secretReads;
+  const publicEnv = { ...env, CLAWROUTER_ADMIN_TOKEN_SHA256: "0".repeat(64) };
+  for (const path of ["/v1/providers", "/v1/routes", "/v1", "/v1/models", "/v1/catalog", "/v1/admin/bootstrap"]) {
+    const result = await run(request(path), publicEnv);
+    const text = await result.text(); assertContained(text); assert.equal(text.includes(alias), false);
+  }
+  assert.equal(state.secretReads, reads);
+  assert.deepEqual(state.genericReads, []);
+});
+
+test("private reasoning capabilities are explicit, optional and projected only as approved descriptors", async () => {
+  const efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+  await withFetch(() => assert.fail("Private discovery called upstream"), async () => {
+    for (const supported of [undefined, ...efforts.map((effort) => [effort]), efforts, ["low", "medium", "high", "xhigh", "max"], ["high", "low"]]) {
+      for (const id of [alias, "synthetic-opaque"]) {
+        const { env, state } = await environment();
+        state.policy.alias.id = id;
+        if (supported !== undefined) state.policy.alias.supportedReasoningEfforts = supported;
+        for (const path of ["/private/v1/models", "/private/v1/catalog"]) {
+          const result = await run(request(path), env);
+          assert.equal(result.status, 200);
+          const text = await result.text(); assertContained(text);
+          assert.doesNotMatch(text, /credentialSha256|accountId|accessToken|expiresAt|contextWindow|maxTokens|ModelInfo/);
+          const value = JSON.parse(text);
+          const capabilities = supported === undefined ? {} : { supportedReasoningEfforts: supported };
+          if (path.endsWith("/models")) assert.deepEqual(value.data, [{ id, object: "model", owned_by: "private", display_name: "Codex (Latest)", capabilities: ["llm.responses"], ...capabilities }]);
+          else {
+            assert.deepEqual(value.providers[0].models, [{ id, displayName: "Codex (Latest)", upstream: id, capabilities: ["llm.responses"], pricing_ref: null, pricing: null, ...capabilities }]);
+            assert.equal(value.providers[0].nativeBaseUrl, "/v1/native/private");
+            assert.equal(value.providers[0].routes[0].path, "/v1/responses");
+          }
+        }
+        assert.deepEqual(state.genericReads, []);
+      }
+    }
+  });
+});
+
+test("private reasoning lists reject malformed, duplicate, unsupported and oversized policy values before secrets", async () => {
+  await withFetch(() => assert.fail("Malformed reasoning policy reached upstream"), async () => {
+    for (const supportedReasoningEfforts of [null, false, "high", {}, [], ["high", "high"], ["HIGH"], [" high"], ["off"], ["synthetic-unsupported-effort"], [target], [accountId], [accessToken], [1], [null], [["high"]], ["low", {}], Array(8).fill("high"), Array(20_000).fill("high")]) {
+      const { env, state } = await environment();
+      state.policy.alias.supportedReasoningEfforts = supportedReasoningEfforts;
+      for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"]) {
+        const result = await run(request(path), env);
+        assert.equal(result.status, 404);
+        assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+      }
+      assert.equal(state.secretReads, 0); assert.deepEqual(state.genericReads, []);
+    }
+    for (const extra of [{ reasoning: true }, { target }, { accountId }, { pricing: {} }, { maxTokens: 1 }]) {
+      const { env, state } = await environment();
+      state.policy.alias = { ...state.policy.alias, supportedReasoningEfforts: ["high"], ...extra };
+      assert.equal((await run(request("/private/v1/catalog"), env)).status, 404);
+      assert.equal(state.secretReads, 0);
+    }
+  });
+});
+
+test("private reasoning descriptors remain absent for unauthorized callers and public discovery", async () => {
+  const { env, state } = await environment();
+  state.policy.alias.supportedReasoningEfforts = ["low", "high"];
+  await withFetch(() => assert.fail("Discovery/auth rejection reached upstream"), async () => {
+    for (const headers of [{}, { authorization: "Bearer SYNTHETIC_ADMIN_TOKEN" }, { authorization: "Bearer clawrouter-live-synthetic-secret" }, { "cf-access-jwt-assertion": "synthetic.forged.jwt" }, { "x-user-id": "synthetic-owner" }, { authorization: `Bearer ${credential}`, "cf-access-jwt-assertion": "synthetic.forged.jwt" }]) {
+      for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"]) {
+        const req = request(path); req.headers.delete("authorization");
+        for (const [key, value] of Object.entries(headers)) req.headers.set(key, value);
+        const result = await run(req, env); assert.equal(result.status, 404);
+        assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+      }
+    }
+    assert.equal(state.secretReads, 0);
+    const publicEnv = { ...env };
+    for (const path of ["/v1/models", "/v1/catalog", "/v1/providers", "/v1/routes", "/v1/admin/bootstrap"]) {
+      const result = await run(request(path), publicEnv);
+      const text = await result.text(); assertContained(text); assert.equal(text.includes(alias), false);
+    }
+    assert.equal(state.secretReads, 0);
+    const allowed = await run(request("/private/v1/catalog"), env);
+    assert.equal(allowed.status, 200);
+    assert.deepEqual((await allowed.json()).providers[0].models[0].supportedReasoningEfforts, ["low", "high"]);
+    state.policy.alias.supportedReasoningEfforts = ["medium"];
+    assert.deepEqual((await (await run(request("/private/v1/models"), env)).json()).data[0].supportedReasoningEfforts, ["medium"]);
+  });
+});
+
+test("only the alias is accepted and all routing/encoding/auth overrides fail before fetch", async () => {
+  const { env } = await environment();
+  await withFetch(() => assert.fail("Rejected request reached provider"), async () => {
+    for (const model of [target, `private/${alias}`, `openai/${alias}`, "synthetic-other", null, [alias]]) {
+      assert.equal((await run(request(undefined, { body: { model, store: false } }), env)).status, 400);
+    }
+    for (const key of ["provider", "base_url", "baseUrl", "upstream", "headers", "auth", "account_id", "model_override"]) {
+      assert.equal((await run(request(undefined, { body: { model: alias, store: false, [key]: "synthetic-override" } }), env)).status, 400);
+    }
+    for (const headers of [
+      { "content-type": "application/json; charset=utf-16" }, { "content-encoding": "gzip" },
+      { "x-model": "synthetic" }, { "openai-organization": "synthetic" }, { "chatgpt-account-id": accountId },
+      { "x-base-url": "https://elsewhere.invalid" }, { "x-codex-attestation": "synthetic-proof" },
+    ]) assert.equal((await run(request(undefined, { headers }), env)).status, 400);
+    for (const body of ["{", "[]", JSON.stringify({ model: alias }), JSON.stringify({ model: alias, store: true }), JSON.stringify({ model: alias, store: false, background: true }), JSON.stringify({ model: alias, store: false, stream: "true" })]) {
+      assert.equal((await run(request(undefined, { body }), env)).status, 400);
+    }
+    for (const path of ["/private/v1/responses/compact", "/private/v1/chat/completions", "/private/v1/usage", "/private/v1/native/openai/responses", "/private/v1/native/private/v1/responses", "/private/v1/responses?model=synthetic", "/private/v1/%72esponses", "/private/v1/responses%2f..%2fmodels", "/private/v1/responses/", "/private//v1/models", "/%70rivate/v1/models"]) {
+      assert.equal((await run(request(path, { method: "POST" }), env)).status, 404);
+    }
+    assert.equal((await run(request("/private/v1/responses", { method: "GET" }), env)).status, 404);
+    assert.equal((await run(request("/private/v1/models", { method: "OPTIONS" }), env)).status, 404);
+  });
+});
+
+test("request rewriting is confined to egress; preserve genuine metadata, tool protocol and safe output", async () => {
+  const { env, state } = await environment();
+  state.policy.alias.supportedReasoningEfforts = ["high"];
+  const input = { model: alias, store: false, input: "SYNTHETIC_INPUT", instructions: "SYNTHETIC_INSTRUCTIONS", metadata: { approval: "required", review: "synthetic-review", attestation: "synthetic-attestation" }, tools: [{ type: "function", name: "synthetic_tool", parameters: { type: "object", properties: { model: { type: "string" } } } }], include: ["reasoning.encrypted_content"] };
+  let calls = 0;
+  await withFetch(async (url, init) => {
+    calls++;
+    assert.equal(url, "https://chatgpt.com/backend-api/codex/responses");
+    assert.equal(init.redirect, "manual");
+    assert.deepEqual(JSON.parse(init.body), { ...input, model: target });
+    assert.equal(init.headers.get("authorization"), `Bearer ${accessToken}`);
+    assert.equal(init.headers.get("chatgpt-account-id"), accountId);
+    assert.equal(init.headers.get("originator"), "synthetic-genuine-client");
+    assert.equal(init.headers.get("session-id"), "synthetic-session");
+    assert.equal(init.headers.get("user-agent"), "synthetic-client/1");
+    assert.equal(init.headers.get("x-user-id"), null);
+    return jsonResponse({ nested: { model: "synthetic-data-model" }, output: [{ type: "reasoning", encrypted_content: "synthetic-opaque-ciphertext" }, { type: "function_call", name: "synthetic_tool", arguments: '{"value":"synthetic-safe"}', call_id: "synthetic-call" }], metadata: input.metadata, usage: { input_tokens: 11, output_tokens: 7 } }, { "x-secret": target, "set-cookie": accessToken, "location": `https://example.invalid/${target}`, "x-request-id": target });
+  }, async () => {
+    const result = await run(request(undefined, { body: input, headers: { originator: "synthetic-genuine-client", "session-id": "synthetic-session", "user-agent": "synthetic-client/1", "x-user-id": "synthetic-forged-human" } }), env);
+    assert.equal(result.status, 200);
+    const text = await result.text(); assertContained(text);
+    const value = JSON.parse(text);
+    assert.equal(value.model, alias); assert.equal(value.nested.model, "synthetic-data-model");
+    assert.equal(value.output[0].encrypted_content, "synthetic-opaque-ciphertext");
+    assert.equal(value.output[1].arguments, '{"value":"synthetic-safe"}');
+    assert.deepEqual(value.metadata, input.metadata); assert.deepEqual(value.usage, { input_tokens: 11, output_tokens: 7 });
+    assert.deepEqual([...result.headers.keys()].sort(), ["cache-control", "content-type", "x-clawrouter-accounting", "x-clawrouter-content-retention", "x-content-type-options"]);
+    assert.equal(result.headers.get("x-clawrouter-accounting"), "private-unmetered");
+  });
+  assert.equal(input.model, alias); assert.equal(calls, 1); assert.deepEqual(state.genericReads, []);
+});
+
+test("subscription output option adaptation omits only the top-level field and discloses the unenforced limit", async () => {
+  const marker = "x-clawrouter-ignored-parameters";
+  function freeze(value) {
+    if (value && typeof value === "object") { for (const item of Object.values(value)) freeze(item); Object.freeze(value); }
+    return value;
+  }
+  for (const streaming of [false, true]) {
+    for (const max of [undefined, 1, 32768, Number.MAX_SAFE_INTEGER]) {
+      const { env } = await environment();
+      const input = {
+        ...nativeBody(), stream: streaming, service_tier: "priority", temperature: 0.4, top_p: 0.8, prompt_cache_retention: "24h",
+        metadata: { approval: "required", review: "synthetic-review", attestation: "synthetic-attestation", max_output_tokens: 17 },
+        text: { verbosity: "low", format: { type: "json_object" } },
+        tools: [{ type: "function", name: "synthetic_tool", parameters: { type: "object", properties: { max_output_tokens: { type: "integer" } } } }],
+        ...(max === undefined ? {} : { max_output_tokens: max }),
+      };
+      if (!streaming) delete input.stream_options;
+      const original = structuredClone(input); freeze(input);
+      const { max_output_tokens: ignored, ...retained } = input;
+      const expected = { ...retained, model: target };
+      const projected = privateSubscriptionBody(input, target);
+      assert.notEqual(projected, input); assert.deepEqual(projected, expected); assert.deepEqual(input, original);
+      const headers = { originator: "synthetic-genuine-client", "user-agent": "synthetic-client/1", version: "0.0.0-synthetic", "x-codex-routing-hint": `model=${alias};tier=priority`, "x-oai-attestation": "synthetic-host-attestation", [marker]: "synthetic-caller-forgery" };
+      let calls = 0;
+      await withFetch((_, init) => {
+        calls++; assert.equal(init.body, JSON.stringify(expected));
+        assert.equal(init.headers.get("x-codex-routing-hint"), `model=${target};tier=priority`);
+        for (const name of ["originator", "user-agent", "version", "x-oai-attestation"]) assert.equal(init.headers.get(name), headers[name]);
+        assert.equal(init.headers.get(marker), null);
+        const response = streaming ? sse([completed()]) : jsonResponse();
+        response.headers.set(marker, "synthetic-upstream-forgery");
+        return response;
+      }, async () => {
+        const req = request(undefined, { body: input, headers });
+        const originalWire = req.clone();
+        const result = await run(req, env);
+        assert.equal(result.status, 200);
+        assert.equal(result.headers.get(marker), max === undefined ? null : "max_output_tokens");
+        assert.equal(result.headers.get("x-clawrouter-accounting"), "private-unmetered");
+        const text = await result.text(); assertContained(text); assert.doesNotMatch(text, /private_upstream_error|synthetic-.*-forgery/);
+        assert.equal(await originalWire.text(), JSON.stringify(original));
+      });
+      assert.equal(calls, 1); assert.deepEqual(input, original);
+    }
+  }
+});
+
+test("subscription output option rejects malformed values before upstream without echoing them", async () => {
+  const { env } = await environment();
+  await withFetch(() => assert.fail("Invalid output option reached upstream"), async () => {
+    for (const value of [null, true, false, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, "1", "synthetic-invalid-limit", target, accountId, accessToken, [], [1], {}, { value: 1 }]) {
+      const result = await run(request(undefined, { body: { model: alias, store: false, max_output_tokens: value } }), env);
+      assert.equal(result.status, 400); assert.equal(result.headers.get("x-clawrouter-ignored-parameters"), null);
+      assert.deepEqual(await result.json(), { error: { code: "invalid_request", message: "Unsupported private request." } });
+    }
+    const result = await run(request(undefined, { body: `{"model":"${alias}","store":false,"max_output_tokens":1e309}` }), env);
+    assert.equal(result.status, 400); assert.equal(result.headers.get("x-clawrouter-ignored-parameters"), null);
+  });
+});
+
+test("subscription output option disclosure survives provider denials, transport and late SSE failures", async () => {
+  const { env } = await environment();
+  const body = { model: alias, store: false, max_output_tokens: 12345 };
+  for (const code of [400, 403, 404, 429, 500]) {
+    await withFetch(() => new Response(target, { status: code }), async () => {
+      const result = await run(request(undefined, { body }), env);
+      assert.equal(result.status, code < 500 ? code : 502);
+      assert.equal(result.headers.get("x-clawrouter-ignored-parameters"), "max_output_tokens");
+      const text = await result.text(); assertContained(text); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /12345/);
+    });
+  }
+  for (const make of [() => { throw new Error(target); }, () => new Response(target, { headers: { "content-type": "text/html" } }), () => jsonResponse({ output: [{ text: target }] })]) {
+    await withFetch(make, async () => {
+      const result = await run(request(undefined, { body }), env);
+      assert.equal(result.status, 502); assert.equal(result.headers.get("x-clawrouter-ignored-parameters"), "max_output_tokens"); assertContained(await result.text());
+    });
+  }
+  await withFetch(() => sse([textDelta("safe"), { type: "error", error: { message: target } }]), async () => {
+    const result = await run(request(undefined, { body: { ...body, stream: true } }), env);
+    assert.equal(result.headers.get("x-clawrouter-ignored-parameters"), "max_output_tokens");
+    const text = await result.text(); assertContained(text); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed/);
+  });
+});
+
+test("subscription output option disclosure neither authenticates callers nor escapes reporting-name containment", async () => {
+  const { env, state } = await environment();
+  const marker = "x-clawrouter-ignored-parameters";
+  await withFetch(() => assert.fail("Unauthorized output option reached upstream"), async () => {
+    for (const authorization of ["Bearer SYNTHETIC_ADMIN_TOKEN", "Bearer clawrouter-live-synthetic-key", "Bearer synthetic.forged.jwt"]) {
+      const result = await run(request(undefined, { body: { model: alias, store: false, max_output_tokens: 1 }, headers: { authorization, [marker]: "max_output_tokens" } }), env);
+      assert.equal(result.status, 404); assert.equal(result.headers.get(marker), null);
+      assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+    }
+    assert.equal(state.secretReads, 0);
+    for (const path of ["/private/v1/models", "/private/v1/catalog"]) {
+      const result = await run(request(path, { headers: { [marker]: "max_output_tokens" } }), env);
+      assert.equal(result.status, 200); assert.equal(result.headers.get(marker), null);
+    }
+  });
+  // A protocol reporting name can collide with even a fixed local header value.
+  await withFetch(() => assert.fail("Unsafe disclosure reached upstream"), async () => {
+    for (const key of ["target", "accountId", "accessToken"]) {
+      const { env, state } = await environment(); state.upstream[key] = "max_output_tokens";
+      const result = await run(request(undefined, { body: { model: alias, store: false, max_output_tokens: 1 } }), env);
+      assert.equal(result.status, 502); assert.equal(result.headers.get(marker), null);
+      assert.equal((await result.text()).includes("max_output_tokens"), false);
+    }
+  });
+  for (const stream of [false, true]) {
+    await withFetch(() => stream ? sse([completed({ model: "max_output_tokens" })]) : jsonResponse({ model: "max_output_tokens" }), async () => {
+      const result = await run(request(undefined, { body: { model: alias, store: false, stream, max_output_tokens: 1 } }), env);
+      assert.equal(result.status, 502); assert.equal(result.headers.get(marker), null);
+      assert.equal((await result.text()).includes("max_output_tokens"), false);
+    });
+  }
+});
+
+test("missing, malformed, revoked, expired or rotated configuration fails closed", async () => {
+  await withFetch(() => assert.fail("Invalid config reached provider"), async () => {
+    for (const patch of [null, {}, { enabled: false }, { version: 2 }, { extra: true }, { auth: { mode: "local" } }, { auth: { mode: "workload", credentialSha256: credential } }]) {
+      const { env, state } = await environment();
+      state.policy = patch === null ? null : { ...state.policy, ...patch };
+      if (patch && !Object.keys(patch).length) state.policy = {};
+      assert.equal((await run(request("/private/v1/models"), env)).status, 404);
+      assert.equal(state.secretReads, 0);
+    }
+    for (const patch of [{ target: "" }, { target: alias }, { accountId: "" }, { accessToken: "" }, { expiresAt: 1 }, { expiresAt: "tomorrow" }, { extra: "invalid" }]) {
+      const { env, state } = await environment(); state.upstream = { ...state.upstream, ...patch };
+      assert.equal((await run(request(), env)).status, 404);
+    }
+    const { env, state } = await environment();
+    env.PRIVATE_CODEX_POLICY.get = async () => { state.policyReads++; return JSON.stringify({ ...state.policy, enabled: state.policyReads === 1 }); };
+    assert.equal((await run(request(), env)).status, 404);
+    env.PRIVATE_CODEX_POLICY.get = async () => JSON.stringify(state.policy);
+    env.PRIVATE_CODEX_UPSTREAM.get = async () => JSON.stringify({ ...state.upstream, accessToken: `${accessToken}_${state.secretReads++}` });
+    assert.equal((await run(request(), env)).status, 404);
+    env.PRIVATE_CODEX_UPSTREAM.get = async () => { throw new Error(target); };
+    const failed = await run(request(), env); assert.equal(failed.status, 404); assertContained(await failed.text());
+  });
+});
+
+test("provider failures, redirects and transport exceptions do not retry or leak", async () => {
+  for (const code of [301, 401, 403, 429, 500]) {
+    const { env } = await environment(); let calls = 0;
+    await withFetch(() => { calls++; return new Response(target, { status: code, headers: { location: `https://elsewhere.invalid/${target}` } }); }, async () => {
+      const result = await run(request(), env); assert.equal(result.status, code >= 400 && code < 500 ? code : 502); assertContained(await result.text());
+    });
+    assert.equal(calls, 1);
+  }
+  const { env } = await environment();
+  await withFetch(() => { throw new Error(target); }, async () => { const result = await run(request(), env); assert.equal(result.status, 502); assertContained(await result.text()); });
+});
+
+test("JSON containment decodes escapes, rejects leaks and reroutes, and preserves refusal semantics", async () => {
+  const { env } = await environment();
+  const escaped = [...target].map((char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`).join("");
+  const wire = JSON.stringify(responseObject()).replace(target, escaped);
+  await withFetch(() => new Response(wire, { headers: { "content-type": "application/json" } }), async () => {
+    const result = await run(request(), env); assert.equal(result.status, 200); assert.equal((await result.json()).model, alias);
+  });
+  for (const extra of [
+    { output: [{ text: target }] }, { nested: { model: target } }, { headers: { "OpenAI-Model": "synthetic-rerouted-model" } }, { error: { message: target } },
+    { output: [{ arguments: `{"value":"${escaped}"}` }] }, { output: [{ encrypted_content: target }] },
+    { metadata: { [target]: true } }, { output: [{ text: accessToken }] }, { output: [{ text: accountId }] },
+  ]) await withFetch(() => jsonResponse(extra), async () => { const result = await run(request(), env); assert.equal(result.status, 502); assertContained(await result.text()); });
+  await withFetch(() => jsonResponse({ output: [{ type: "refusal", refusal: "SYNTHETIC_UPSTREAM_DENIAL" }], metadata: { review_required: true } }), async () => {
+    const result = await run(request(), env); assert.equal(result.status, 200);
+    const value = await result.json(); assert.equal(value.output[0].refusal, "SYNTHETIC_UPSTREAM_DENIAL"); assert.equal(value.metadata.review_required, true);
+  });
+});
+
+test("SSE handles byte/chunk boundaries and preserves complete, done, tool and review events", async () => {
+  const { env } = await environment();
+  const toolBase = { item_id: "synthetic-tool", output_index: 1 };
+  const events = [
+    { type: "response.created", response: responseObject({ status: "in_progress" }) },
+    textDelta("Safe 🦞 text"),
+    { type: "response.output_text.done", item_id: "synthetic-item", output_index: 0, content_index: 0, text: "Safe 🦞 text" },
+    { type: "response.function_call_arguments.delta", ...toolBase, delta: '{"safe":' },
+    { type: "response.function_call_arguments.delta", ...toolBase, delta: '"value"}' },
+    { type: "response.function_call_arguments.done", ...toolBase, arguments: '{"safe":"value"}' },
+    { type: "response.output_item.done", output_index: 1, item: { type: "function_call", arguments: '{"safe":"value"}', call_id: "synthetic-call", name: "synthetic-tool" } },
+    completed({ metadata: { review_required: true }, output: [{ type: "reasoning", encrypted_content: "synthetic-opaque" }] }),
+  ];
+  await withFetch(() => sse(events, 1), async () => {
+    const result = await run(request(undefined, { body: { model: alias, stream: true, store: false } }), env);
+    const text = await result.text(); assertContained(text); assert.doesNotMatch(text, /private_upstream_error/);
+    const parsed = [...text.matchAll(/^data: (.+)$/gm)].filter((match) => match[1] !== "[DONE]").map((match) => JSON.parse(match[1]));
+    const safeEvents = JSON.parse(JSON.stringify(events).replaceAll(target, alias));
+    assert.deepEqual(parsed, safeEvents);
+    assert.equal(result.headers.get("x-synthetic-secret"), null);
+  });
+});
+
+test("SSE split text/tool leaks are held back across events, including interleaved logical streams", async () => {
+  const { env } = await environment();
+  for (let split = 1; split < target.length; split++) {
+    const first = target.slice(0, split), rest = target.slice(split);
+    const events = [textDelta("safe preface "), textDelta(first), textDelta("safe other item", { output_index: 1, item_id: "synthetic-other" }), textDelta(rest), completed()];
+    await withFetch(() => sse(events), async () => {
+      const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+      const text = await result.text(); assertContained(text);
+      assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed/);
+      assert.equal(text.includes(JSON.stringify({ ...textDelta(first) }).slice(1, -1)), false);
+    });
+  }
+  const escaped = [...target].map((char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`).join("");
+  for (const argumentsText of [`{"value":"${target}"}`, `{"value":"${escaped}"}`]) {
+    const base = { item_id: "synthetic-tool", output_index: 0 };
+    const events = [...argumentsText].map((delta) => ({ type: "response.function_call_arguments.delta", ...base, delta }));
+    events.push({ type: "response.function_call_arguments.done", ...base, arguments: argumentsText }, completed());
+    await withFetch(() => sse(events), async () => {
+      const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+      const text = await result.text(); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /function_call_arguments.delta/); assertContained(text);
+    });
+  }
+});
+
+test("SSE late errors, malformed/unsupported frames, mismatched identities and incomplete streams fail sanitized", async () => {
+  const { env } = await environment();
+  const badStreams = [
+    [textDelta("safe"), { type: "error", message: target }],
+    [textDelta("safe"), { type: "response.failed", response: { error: { message: target } } }],
+    [textDelta("safe"), completed({ output: [{ text: target }] })],
+    [textDelta("safe"), { type: "response.output_text.done", item_id: "synthetic-item", output_index: 0, content_index: 0, text: target }],
+    [textDelta(target.slice(0, 5)), textDelta(target.slice(5), { item_id: "synthetic-spoof" })],
+    [textDelta(target.slice(0, 5)), textDelta(target.slice(5), { output_index: 1 })],
+    ["data: {invalid}\n\n"], ["id: synthetic\ndata: {}\n\n"], ["data: [DONE]\n\n"],
+    [textDelta("safe")], ["event: response.created\ndata: {\"type\":\"response.completed\"}\n\n"],
+    [{ type: "response.unsupported.delta", delta: target.slice(0, 3) }],
+    [completed(), { type: "error", message: target }],
+  ];
+  for (const events of badStreams) await withFetch(() => sse(events, 19, false), async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+    const text = await result.text(); assertContained(text); assert.match(text, /private_upstream_error/);
+  });
+});
+
+test("bounded request/JSON/SSE and unsupported content cancel upstream without exposure", async () => {
+  const { env } = await environment();
+  await withFetch(() => assert.fail("Oversized request reached upstream"), async () => {
+    assert.equal((await run(request(undefined, { body: { model: alias, store: false, input: "x".repeat(1024 * 1024) } }), env)).status, 400);
+  });
+  for (const make of [
+    () => new Response("{", { headers: { "content-type": "application/json" } }),
+    () => new Response(new Uint8Array([0xff]), { headers: { "content-type": "application/json" } }),
+    () => jsonResponse({}, { "content-encoding": "gzip" }),
+    () => jsonResponse({}, { "x-codex-attestation": "synthetic-attestation" }),
+    () => jsonResponse({}, { "x-review-required": "true" }),
+    () => jsonResponse({}, { "x-upstream-model": "synthetic-reroute" }),
+    () => jsonResponse({}, { "x-safety-required": "true" }),
+    () => new Response(target, { headers: { "content-type": "text/html" } }),
+    () => jsonResponse({ output: ["x".repeat(4 * 1024 * 1024)] }),
+  ]) await withFetch(make, async () => { const result = await run(request(), env); assert.equal(result.status, 502); assertContained(await result.text()); });
+  await withFetch(() => sse([textDelta("x".repeat(300 * 1024)), completed()]), async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+    const text = await result.text(); assert.match(text, /private_upstream_error/); assert.ok(text.length < 1024);
+  });
+});
+
+test("client cancellation and request abort cancel the provider stream", async () => {
+  const { env } = await environment();
+  for (const abortRequest of [false, true]) {
+    let canceled = false, upstreamSignal;
+    const abort = new AbortController();
+    const started = Promise.withResolvers();
+    await withFetch((_, init) => {
+      upstreamSignal = init.signal;
+      started.resolve();
+      return new Response(new ReadableStream({ pull(controller) { if (!abortRequest) controller.enqueue(enc.encode(frame(textDelta("safe")))); }, cancel() { canceled = true; } }), { headers: { "content-type": "text/event-stream" } });
+    }, async () => {
+      const pending = run(request(undefined, { signal: abort.signal, body: { model: alias, store: false, stream: true } }), env);
+      await started.promise;
+      if (abortRequest) abort.abort();
+      const result = await pending;
+      const reader = result.body.getReader();
+      await reader.read();
+      if (!abortRequest) await reader.cancel();
+      assert.equal(upstreamSignal.aborted, true); assert.equal(canceled, true);
+    });
+  }
+});
+
+test("Access auth pins verified GitHub account/IdP, never email/admin/local identity", async () => {
+  const { env, state } = await environment();
+  state.policy.auth = { mode: "access", issuer: "https://synthetic-owner.cloudflareaccess.com", audience: "synthetic-audience", githubAccountId: 123456, identityProviderId: "synthetic-github-idp" };
+  state.policy.alias.supportedReasoningEfforts = ["low", "high"];
+  const keys = await crypto.subtle.generateKey({ name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" }, true, ["sign", "verify"]);
+  const jwk = { ...await crypto.subtle.exportKey("jwk", keys.publicKey), kid: "synthetic-key" };
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  async function jwt(patch = {}, forged = false) {
+    const payload = { iss: state.policy.auth.issuer, sub: "synthetic-owner-subject", aud: state.policy.auth.audience, exp: Math.floor(Date.now() / 1000) + 300, email: "synthetic-owner@example.invalid", ...patch };
+    const unsigned = `${encode({ alg: "RS256", kid: jwk.kid })}.${encode(payload)}`;
+    const signed = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", keys.privateKey, enc.encode(unsigned));
+    return `${unsigned}.${forged ? "c3ludGhldGlj" : Buffer.from(signed).toString("base64url")}`;
+  }
+  let inference = 0;
+  await withFetch((url, init) => {
+    if (String(url) === "https://synthetic-owner.cloudflareaccess.com/cdn-cgi/access/certs") return Response.json({ keys: [jwk] });
+    if (String(url) === "https://synthetic-owner.cloudflareaccess.com/cdn-cgi/access/get-identity") {
+      const payload = JSON.parse(Buffer.from(new Headers(init.headers).get("cookie").split(".")[1], "base64url").toString());
+      return Response.json({ email: payload.email, id: 123456, idp: { type: "github", id: "synthetic-github-idp" } });
+    }
+    inference++; return jsonResponse();
+  }, async () => {
+    for (const [patch, forged] of [
+      [{ email: undefined }, false], [{ email: "" }, false], [{ iss: "https://synthetic-other.cloudflareaccess.com" }, false],
+      [{ aud: "synthetic-other-audience" }, false], [{ exp: 1 }, false], [{ exp: "99999999999" }, false],
+      [{ nbf: 99999999999 }, false], [{ iat: 99999999999 }, false], [{}, true],
+    ]) {
+      for (const path of ["/private/v1/models", "/private/v1/catalog", "/private/v1/responses"]) {
+        const req = request(path); req.headers.delete("authorization"); req.headers.set("cf-access-jwt-assertion", await jwt(patch, forged));
+        const result = await run(req, env); assert.equal(result.status, 404);
+        assert.deepEqual(await result.json(), { error: { code: "route_not_found", message: "route not found" } });
+      }
+    }
+    assert.equal(state.secretReads, 0); assert.equal(inference, 0);
+    const req = request(undefined, { body: { model: alias, store: false, max_output_tokens: 256 } }); req.headers.delete("authorization"); req.headers.set("cf-access-jwt-assertion", await jwt({ email: "synthetic-changed@example.invalid", sub: "synthetic-changed-subject" }));
+    const accepted = await run(req, env);
+    assert.equal(accepted.status, 200); assert.equal(accepted.headers.get("x-clawrouter-ignored-parameters"), "max_output_tokens"); assert.equal(inference, 1);
+    for (const path of ["/private/v1/models", "/private/v1/catalog"]) {
+      const owner = request(path); owner.headers.delete("authorization"); owner.headers.set("cf-access-jwt-assertion", await jwt());
+      const result = await run(owner, env); assert.equal(result.status, 200);
+      const text = await result.text(); assertContained(text);
+      const body = JSON.parse(text);
+      const descriptor = path.endsWith("/models") ? body.data[0] : body.providers[0].models[0];
+      assert.deepEqual(descriptor.supportedReasoningEfforts, ["low", "high"]);
+    }
+    assert.equal(inference, 1);
+    const conflict = request(); conflict.headers.set("cf-access-jwt-assertion", await jwt());
+    assert.equal((await run(conflict, env)).status, 404); assert.equal(inference, 1);
+    conflict.headers.set("authorization", "");
+    assert.equal((await run(conflict, env)).status, 404); assert.equal(inference, 1);
+    const accountOverride = request(); accountOverride.headers.delete("authorization");
+    accountOverride.headers.set("cf-access-jwt-assertion", await jwt()); accountOverride.headers.set("chatgpt-account-id", accountId);
+    assert.equal((await run(accountOverride, env)).status, 400); assert.equal(inference, 1);
+  });
+  assert.deepEqual(state.genericReads, []);
+});
+
+test("private workload credentials cannot execute generic proxy, native, manifest or Fusion paths", async () => {
+  const { env, state } = await environment();
+  const publicEnv = { ...env };
+  await withFetch(() => assert.fail("Private credential escaped the facade"), async () => {
+    for (const path of ["/v1/responses", "/v1/chat/completions", "/v1/proxy/openai/responses", "/v1/native/openai/v1/responses", "/v1/native/private/v1/responses"]) {
+      const result = await run(request(path, { method: "POST", body: { model: "clawrouter/fusion", store: false } }), publicEnv);
+      assert.ok(result.status >= 400);
+      assertContained(await result.text());
+    }
+  });
+  assert.equal(state.secretReads, 0); assert.equal(state.policyReads, 0);
+});
+
+test("no private failures or request metadata enter application logs", async (context) => {
+  const { env } = await environment(); const logs = [];
+  for (const method of ["log", "info", "warn", "error", "debug"]) context.mock.method(console, method, (...values) => logs.push(values));
+  await withFetch(() => { throw new Error(target); }, async () => {
+    const result = await run(request(undefined, { headers: { "x-request-id": target, "traceparent": accessToken } }), env);
+    assert.equal(result.status, 502); assertContained(await result.text());
+  });
+  env.PRIVATE_CODEX_UPSTREAM.get = async () => { throw new Error(accessToken); };
+  assert.equal((await run(request(), env)).status, 404);
+  assert.deepEqual(logs, []);
+});
+
+test("holdback disambiguates overlapping prefixes and safely ends incomplete Responses", async () => {
+  const { env, state } = await environment();
+  state.upstream.target = "SYNTHETIC_ABABABAC";
+  const text = "SYNTHETIC_ABABABAB is safe";
+  const events = [...text].map((delta) => textDelta(delta));
+  events.push({ type: "response.incomplete", response: { ...responseObject(), model: state.upstream.target, status: "incomplete", incomplete_details: { reason: "max_output_tokens" } } });
+  await withFetch(() => sse(events, 7, false), async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+    const output = await result.text(); assert.doesNotMatch(output, /private_upstream_error/);
+    const parsed = [...output.matchAll(/^data: (.+)$/gm)].map((match) => JSON.parse(match[1]));
+    assert.equal(parsed.filter((event) => event.type.endsWith(".delta")).map((event) => event.delta).join(""), text);
+    assert.equal(parsed.at(-1).response.model, alias);
+    assert.equal(parsed.at(-1).response.incomplete_details.reason, "max_output_tokens");
+  });
+});
+
+test("logical stream and pending-event limits fail closed without flushing held fragments", async () => {
+  const { env } = await environment();
+  const cases = [
+    Array.from({ length: 129 }, (_, index) => textDelta(target.slice(0, 3), { output_index: index, item_id: `synthetic-item-${index}` })),
+    [textDelta(target.slice(0, 3)), ...Array.from({ length: 1024 }, () => ({ type: "response.in_progress", response: { model: target } }))],
+    [{ type: "response.function_call_arguments.delta", item_id: "synthetic-tool", output_index: 0, delta: '{"value":1}' }, { type: "response.function_call_arguments.done", item_id: "synthetic-tool", output_index: 0, arguments: '{"value":2}' }],
+  ];
+  for (const events of cases) await withFetch(() => sse([...events, completed()], 4096), async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+    const text = await result.text(); assert.match(text, /private_upstream_error/); assertContained(text);
+    assert.doesNotMatch(text, /response.output_text.delta|response.function_call_arguments.delta/);
+  });
+});
+
+function nativeBody() {
+  return {
+    model: alias, input: [{ type: "additional_tools", role: "developer", tools: [] }, { type: "message", role: "developer", content: [{ type: "input_text", text: "Synthetic base instructions" }] }],
+    tool_choice: "auto", parallel_tool_calls: false, reasoning: { effort: "high", summary: "auto" }, store: false, stream: true,
+    include: ["reasoning.encrypted_content"], prompt_cache_key: "synthetic-thread", text: { verbosity: "low" },
+    stream_options: { reasoning_summary_delivery: "sequential_cutoff" }, access_programs: { cyber: "standard" },
+    client_metadata: {
+      "x-codex-installation-id": "synthetic-installation", session_id: "synthetic-session", thread_id: "synthetic-thread", turn_id: "synthetic-turn",
+      "x-codex-window-id": "synthetic-window", "x-codex-parent-thread-id": "synthetic-parent", parent_turn_id: "synthetic-parent-turn", root_turn_id: "synthetic-root-turn", "x-openai-subagent": "review",
+      "x-codex-turn-metadata": JSON.stringify({ sandbox: "workspace-write", sandbox_mode: "workspace-write", auto_review_enabled: false, node_repl_auto_review_required: false, request_kind: "turn", tool_namespaces_info: { synthetic_tools: ["synthetic_tool"] } }),
+    },
+  };
+}
+
+test("source-shaped native Lite request reaches egress with metadata, real header slots and no fabricated identity", async () => {
+  const { env, state } = await environment(); const body = nativeBody();
+  const headers = {
+    "x-openai-internal-codex-responses-lite": "true", "x-codex-beta-features": "synthetic_beta_one,synthetic_beta_two",
+    "x-codex-turn-state": "synthetic-affinity-token", "x-codex-turn-metadata": JSON.stringify({ sandbox_mode: "workspace-write", auto_review_enabled: false }),
+    "x-codex-parent-thread-id": "synthetic-parent", "x-codex-window-id": "synthetic-window", "x-oai-attestation": "synthetic-opaque-host-attestation",
+    "x-openai-subagent": "review", "x-openai-memgen-request": "false", "x-responsesapi-include-timing-metrics": "true",
+    "session-id": "synthetic-session", "thread-id": "synthetic-thread", "originator": "codex_cli_rs", "user-agent": "codex_cli_rs/0.0.0 (synthetic)", "version": "0.0.0-synthetic",
+    "openai-beta": "responses=experimental", "x-codex-routing-hint": `model=${alias}`, "traceparent": "00-11111111111111111111111111111111-1111111111111111-01",
+  };
+  let calls = 0;
+  await withFetch((_, init) => {
+    calls++; assert.deepEqual(JSON.parse(init.body), { ...body, model: target });
+    assert.equal(init.headers.get("authorization"), `Bearer ${accessToken}`);
+    assert.equal(init.headers.get("chatgpt-account-id"), accountId);
+    for (const [name, value] of Object.entries(headers)) assert.equal(init.headers.get(name), name === "x-codex-routing-hint" ? `model=${target}` : value);
+    assert.ok(state.policyReads >= 2); assert.ok(state.secretReads >= 2);
+    return sse([{ type: "response.completed", response: { id: "synthetic-response", end_turn: true } }]);
+  }, async () => {
+    const result = await run(request(undefined, { body, headers }), env);
+    assert.equal(result.status, 200); assert.doesNotMatch(await result.text(), /private_upstream_error|invalid_request/);
+  });
+  assert.equal(calls, 1); assert.equal(body.model, alias); assert.equal(headers["x-codex-routing-hint"], `model=${alias}`);
+});
+
+test("native SSE without a content type tolerates discarded repeated cookies and still validates frames", async () => {
+  const { env } = await environment();
+  for (const valid of [true, false]) {
+    await withFetch(() => {
+      const source = valid ? sse([textDelta("safe"), completed()]) : new Response(`<html>${target}</html>`);
+      const headers = new Headers(source.headers);
+      headers.delete("content-type");
+      headers.append("set-cookie", "synthetic-one=value; Secure");
+      headers.append("set-cookie", "synthetic-two=value; Secure");
+      return new Response(source.body, { headers });
+    }, async () => {
+      const result = await run(request(undefined, { body: { model: alias, store: false, stream: true } }), env);
+      assert.equal(result.status, 200);
+      assert.equal(result.headers.has("set-cookie"), false);
+      const output = await result.text(); assertContained(output);
+      assert.equal(output.includes("response.completed"), valid);
+      assert.equal(output.includes("private_upstream_error"), !valid);
+    });
+  }
+});
+
+test("OpenClaw originator stays truthful and genuine upstream HTTP400 is never labeled local rejection", async () => {
+  const { env } = await environment();
+  for (const lite of [false, true]) {
+    let calls = 0;
+    await withFetch((_, init) => {
+      calls++;
+      assert.equal(init.headers.get("originator"), "openclaw"); assert.equal(init.headers.get("user-agent"), "OpenClaw/0.0.0-synthetic");
+      assert.equal(init.headers.get("x-openai-internal-codex-responses-lite"), lite ? "true" : null);
+      assert.equal(init.headers.get("x-oai-attestation"), null); assert.equal(init.headers.get("x-codex-routing-hint"), null);
+      return new Response(JSON.stringify({ error: { message: target, code: "synthetic-denial" } }), { status: 400, headers: { "openai-model": target } });
+    }, async () => {
+      const result = await run(request(undefined, { body: nativeBody(), headers: { originator: "openclaw", "user-agent": "OpenClaw/0.0.0-synthetic", ...(lite ? { "x-openai-internal-codex-responses-lite": "true" } : {}) } }), env);
+      assert.equal(result.status, 400); const text = await result.text(); assertContained(text);
+      assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /invalid_request|Unsupported private request/);
+    });
+    assert.equal(calls, 1);
+  }
+});
+
+test("optional automatic-review facts are neither required nor rewritten", async () => {
+  const { env } = await environment();
+  for (const autoReview of [undefined, false, true]) {
+    const metadata = { sandbox_mode: "workspace-write", ...(autoReview === undefined ? {} : { auto_review_enabled: autoReview }) };
+    const body = { model: alias, store: false, client_metadata: { "x-codex-turn-metadata": JSON.stringify(metadata) }, access_programs: null };
+    await withFetch((_, init) => {
+      assert.deepEqual(JSON.parse(init.body), { ...body, model: target });
+      assert.equal(init.headers.get("x-oai-attestation"), null); assert.equal(init.headers.get("originator"), null);
+      return jsonResponse({}, { "x-reasoning-included": "" });
+    }, async () => {
+      const result = await run(request(undefined, { body }), env); assert.equal(result.status, 200); assert.equal(result.headers.get("x-reasoning-included"), "");
+    });
+  }
+});
+
+test("routing hints are alias-only, agree with service tier and never authenticate a caller", async () => {
+  const { env, state } = await environment();
+  await withFetch(() => assert.fail("Invalid routing hint reached upstream"), async () => {
+    for (const hint of [`model=${target}`, "model=synthetic-other", `model=${alias};model=${alias}`, `model=${alias};provider=synthetic`, `model=${alias};tier=priority`, `model=${alias}%3Btier=priority`, `model=${alias},model=synthetic-other`]) {
+      assert.equal((await run(request(undefined, { body: nativeBody(), headers: { "x-codex-routing-hint": hint } }), env)).status, 400);
+    }
+    const req = request(undefined, { body: nativeBody(), headers: { "x-codex-routing-hint": `model=${alias}` } }); req.headers.delete("authorization");
+    const reads = state.secretReads; assert.equal((await run(req, env)).status, 404); assert.equal(state.secretReads, reads);
+  });
+  await withFetch((_, init) => { assert.equal(init.headers.get("x-codex-routing-hint"), `model=${target};tier=priority`); return jsonResponse(); }, async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, service_tier: "priority" }, headers: { "x-codex-routing-hint": `model=${alias};tier=priority` } }), env);
+    assert.equal(result.status, 200);
+  });
+});
+
+test("new protocol fields remain bounded and unknown semantic protocol still fails before egress", async () => {
+  const { env } = await environment();
+  await withFetch(() => assert.fail("Malformed native protocol reached upstream"), async () => {
+    for (const patch of [
+      { client_metadata: [] }, { client_metadata: { "x-codex-routing-hint": `model=${alias}` } },
+      { client_metadata: { "x-codex-window-id": 123 } }, { client_metadata: { "x-codex-window-id": "x".repeat(8193) } },
+      { client_metadata: { "x-codex-turn-metadata": "{" } },
+      { stream_options: { reasoning_summary_delivery: "synthetic-unknown" } }, { stream_options: { model: alias } },
+      { access_programs: { cyber: "standard", model: alias } }, { access_programs: { cyber: ["standard"] } }, { access_programs: { cyber: "model=synthetic" } },
+    ]) assert.equal((await run(request(undefined, { body: { ...nativeBody(), ...patch } }), env)).status, 400);
+    for (const headers of [
+      { "x-openai-internal-codex-responses-lite": "synthetic" }, { "x-openai-internal-unknown": "true" }, { "x-codex-turn-metadata": "{" },
+      { "x-oai-attestation": "x".repeat(8193) }, { "x-codex-attestation": "synthetic" }, { "x-codex-review-override": "false" },
+      { "x-codex-turn-state": Buffer.from(JSON.stringify({ model: "synthetic-other" })).toString("base64url") },
+    ]) assert.equal((await run(request(undefined, { body: nativeBody(), headers }), env)).status, 400);
+  });
+});
+
+test("subscription quota headers are stripped without rejecting success; exact model and affinity are contained", async () => {
+  const { env } = await environment();
+  const upstreamHeaders = {
+    "OpenAI-Model": target, "x-codex-turn-state": "synthetic-affinity-token", "x-reasoning-included": "true",
+    "x-codex-primary-used-percent": "12.5", "x-codex-primary-window-minutes": "300", "x-codex-primary-reset-at": "9999999999",
+    "x-codex-secondary-used-percent": "19", "x-codex-secondary-window-minutes": "10080", "x-codex-secondary-reset-at": "9999999999",
+    "x-codex-plan-type": "synthetic-plan", "x-codex-primary-over-secondary-limit-percent": "10",
+    "x-codex-primary-reset-after-seconds": "60", "x-codex-secondary-reset-after-seconds": "120",
+    "x-codex-synthetic-limit-name": target, "x-codex-synthetic-primary-used-percent": "1", "x-codex-active-limit": target,
+    "x-codex-credits-has-credits": "true", "x-codex-credits-unlimited": "false", "x-codex-credits-balance": "42",
+    "x-codex-promo-message": target, "x-codex-rate-limit-reached-type": "synthetic-quota", "x-models-etag": target,
+    "x-codex-safety-buffering-enabled": "false", "x-codex-safety-buffering-faster-model": target,
+  };
+  for (const streaming of [false, true]) await withFetch(() => {
+    const result = streaming ? sse([completed()]) : jsonResponse();
+    for (const [name, value] of Object.entries(upstreamHeaders)) result.headers.set(name, value);
+    return result;
+  }, async () => {
+    const result = await run(request(undefined, { body: { model: alias, store: false, stream: streaming } }), env);
+    assert.equal(result.status, 200); assert.equal(result.headers.get("openai-model"), alias);
+    assert.equal(result.headers.get("x-codex-turn-state"), "synthetic-affinity-token");
+    assert.equal(result.headers.get("x-codex-safety-buffering-enabled"), "false"); assert.equal(result.headers.get("x-codex-safety-buffering-faster-model"), alias);
+    assert.equal(result.headers.get("x-reasoning-included"), "true"); assert.equal(result.headers.get("x-codex-primary-used-percent"), null);
+    assertContained(JSON.stringify([...result.headers])); const text = await result.text(); assertContained(text); assert.doesNotMatch(text, /private_upstream_error/);
+  });
+  for (const headers of [
+    { "openai-model": "synthetic-reroute" }, { "openai-model": `${target}, ${target}` },
+    { "x-codex-safety-buffering-faster-model": "synthetic-reroute" }, { "x-codex-safety-buffering-enabled": "synthetic" },
+    { "x-oai-attestation": "synthetic-unknown-response-attestation" }, { "x-codex-unknown-safety-protocol": "synthetic" },
+  ]) await withFetch(() => jsonResponse({}, headers), async () => { const result = await run(request(), env); assert.equal(result.status, 502); assertContained(await result.text()); });
+});
+
+test("affinity round trips unchanged, while literal and encoded private identities fail closed", async () => {
+  const { env } = await environment();
+  for (const value of [target, JSON.stringify({ value: target }), encodeURIComponent(JSON.stringify({ value: target })), Buffer.from(JSON.stringify({ value: target })).toString("base64url"), `synthetic.${Buffer.from(JSON.stringify({ model: "synthetic-other" })).toString("base64url")}.signature`]) {
+    await withFetch(() => jsonResponse({}, { "x-codex-turn-state": value }), async () => { const result = await run(request(), env); assert.equal(result.status, 502); assertContained(await result.text()); });
+    await withFetch(() => assert.fail("Unsafe affinity reached upstream"), async () => { assert.equal((await run(request(undefined, { headers: { "x-codex-turn-state": value } }), env)).status, 400); });
+  }
+  const state = Buffer.from(JSON.stringify({ affinity: "synthetic-cell", turn: "synthetic-turn" })).toString("base64url");
+  await withFetch((_, init) => { assert.equal(init.headers.get("x-codex-turn-state"), state); return jsonResponse({}, { "x-codex-turn-state": state }); }, async () => {
+    const result = await run(request(undefined, { headers: { "x-codex-turn-state": state } }), env); assert.equal(result.status, 200); assert.equal(result.headers.get("x-codex-turn-state"), state);
+  });
+});
+
+test("source-shaped SSE metadata preserves moderation, verification, safety and sparse Lite event identities", async () => {
+  const { env } = await environment();
+  const events = [
+    { type: "codex.rate_limits", metered_limit_name: target, rate_limits: { primary: { used_percent: 1 } } },
+    { type: "responsesapi.websocket_timing", synthetic_timing_ms: 1 },
+    { type: "response.created", response: { id: "synthetic-response", headers: { "OpenAI-Model": [target], "x-codex-primary-used-percent": "1" } } },
+    { type: "response.metadata", headers: { "openai-model": target, "x-codex-turn-state": "synthetic-affinity" }, metadata: { openai_verification_recommendation: ["synthetic-verification"], openai_chatgpt_moderation_metadata: { synthetic_moderation: true } }, safety_buffering: { use_cases: ["synthetic-case"], reasons: ["synthetic-reason"], retry_model: null } },
+    { type: "response.reasoning_summary_text.delta", summary_index: 0, delta: "Safe summary" },
+    { type: "response.reasoning_summary_text.done", item_id: "synthetic-reasoning", summary_index: 0, text: "Safe summary" },
+    { type: "response.output_text.delta", delta: "Safe native text" },
+    { type: "response.custom_tool_call_input.delta", item_id: "synthetic-custom", call_id: "synthetic-call", delta: "synthetic " },
+    { type: "response.custom_tool_call_input.delta", item_id: "synthetic-custom", call_id: "synthetic-call", delta: "tool input" },
+    { type: "response.output_item.done", item: { id: "synthetic-custom", type: "custom_tool_call", call_id: "synthetic-call", name: "synthetic_tool", input: "synthetic tool input" } },
+    { type: "response.custom_tool_call_input.delta", call_id: "synthetic-call-only", delta: "synthetic " },
+    { type: "response.custom_tool_call_input.delta", call_id: "synthetic-call-only", item_id: "synthetic-later-item", delta: "input" },
+    { type: "response.output_item.done", item: { id: "synthetic-later-item", type: "custom_tool_call", call_id: "synthetic-call-only", name: "synthetic_tool", input: "synthetic input" } },
+    { type: "response.function_call_arguments.done", item_id: "synthetic-function", arguments: '{"value":"safe"}' },
+    { type: "codex.response.metadata", metadata: { synthetic_metadata: true } },
+    { type: "response.completed", response: { id: "synthetic-response", end_turn: true, usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 } } },
+  ];
+  await withFetch(() => sse(events, 1), async () => {
+    const result = await run(request(undefined, { body: nativeBody() }), env);
+    const text = await result.text(); assertContained(text); assert.doesNotMatch(text, /private_upstream_error/);
+    const actual = [...text.matchAll(/^data: (.+)$/gm)].filter((match) => match[1] !== "[DONE]").map((match) => JSON.parse(match[1]));
+    const expected = JSON.parse(JSON.stringify(events.slice(2)).replaceAll(target, alias)); delete expected[0].response.headers["x-codex-primary-used-percent"];
+    assert.deepEqual(actual, expected);
+  });
+});
+
+test("new SSE protocol cannot leak via model headers, safety reroutes or sparse/custom deltas", async () => {
+  const { env } = await environment();
+  const custom = { type: "response.custom_tool_call_input.delta", item_id: "synthetic-custom" };
+  const cases = [
+    [{ type: "response.metadata", headers: { "openai-model": "synthetic-reroute" } }],
+    [{ type: "response.unknown_safety_protocol", synthetic_required: true }],
+    [{ type: "response.created", response: { headers: { "X-OpenAI-Model": "synthetic-reroute" } } }],
+    [{ type: "response.metadata", metadata: { type: "safety_buffering", use_cases: [], reasons: [], retry_model: "synthetic-reroute" } }],
+    [{ type: "response.metadata", headers: { "x-codex-turn-state": Buffer.from(target).toString("base64url") } }],
+    [{ type: "response.output_text.delta", delta: target.slice(0, 9) }, { type: "response.output_text.delta", delta: target.slice(9) }],
+    [textDelta(target.slice(0, 9)), textDelta(target.slice(9), { item_id: "synthetic-second", output_index: 1 })],
+    [{ ...custom, delta: target.slice(0, 9) }, { ...custom, delta: target.slice(9) }],
+    [{ ...custom, delta: target.slice(0, 9) }, { ...custom, item_id: undefined, call_id: "synthetic-call", delta: target.slice(9) }],
+    [{ ...custom, call_id: "synthetic-call", delta: target.slice(0, 9) }, { ...custom, call_id: "synthetic-call", item_id: "synthetic-spoof", delta: target.slice(9) }],
+  ];
+  for (const events of cases) await withFetch(() => sse([...events, completed()]), async () => {
+    const result = await run(request(undefined, { body: nativeBody() }), env); const text = await result.text(); assertContained(text); assert.match(text, /private_upstream_error/); assert.doesNotMatch(text, /response.completed/);
+  });
+});
+
+test("native SSE policy denials keep recognized failure semantics without leaking provider messages", async () => {
+  const { env } = await environment();
+  for (const code of ["cyber_policy", "misalignment_policy_violation", "bio_policy", "invalid_prompt", "context_length_exceeded", "insufficient_quota", "usage_not_included", "rate_limit_exceeded"]) {
+    await withFetch(() => sse([textDelta("safe text"), { type: "response.failed", response: { id: target, error: { code, message: target, misalignment: { private_detail: accessToken } } } }], 19, false), async () => {
+      const result = await run(request(undefined, { body: nativeBody() }), env);
+      const text = await result.text(); assertContained(text); assert.match(text, /event: response.failed/); assert.doesNotMatch(text, /response.completed|private_detail/);
+      const failed = [...text.matchAll(/^data: (.+)$/gm)].map((match) => JSON.parse(match[1])).at(-1);
+      assert.equal(failed.response.error.code, code); assert.equal(failed.response.status, "failed");
+    });
+  }
+});

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -64,6 +64,9 @@ export interface CompiledModel { id: string; upstream: string; capabilities: str
 export interface CompiledEndpoint { id: string; method: string; methods: string[]; path: string; native_proxy: boolean; auth: string | null; headers: Record<string, string>; request_headers: string[]; response_headers: string[]; query: Record<string, string>; path_params: string[]; path_param_styles: Record<string, string>; request_format: string; response_format: string; streaming: string | null; timeout_ms: number | null }
 
 export interface Env {
+  // Object bindings, never generic provider environment strings or grant-pool entries.
+  PRIVATE_CODEX_POLICY?: { get(): Promise<string> };
+  PRIVATE_CODEX_UPSTREAM?: { get(): Promise<string> };
   POLICY_KV: KVNamespace;
   BUDGET_LEDGER: DurableObjectNamespace;
   USAGE_LEDGER: DurableObjectNamespace;


### PR DESCRIPTION
## Summary

Add an opt-in private Responses facade for a separately isolated, owner-only workload. Clients discover and request only `codex-latest`, displayed as **Codex (Latest)**; the upstream model identifier, subscription account and OAuth credential remain in broker-owned secret bindings. The public catalog, generic grants, admin API, billing and content-retention paths do not acquire this binding.

Authentication is either a dedicated opaque workload credential or a verified Access assertion with an exact GitHub account/IdP policy. A workload credential is not a human identity, and hiding a model row is not access control. The documented deployment boundary must independently isolate ingress, execution, administration, browser profiles and tool/node capabilities.

The facade validates the native request contract and projects typed JSON/SSE identity fields, with bounded buffering and cancellation. It preserves supported safety, attestation, refusal and reroute semantics rather than disguising a different model or altering successful tool data. Unsupported protocol and unrepresentable known-value leaks fail closed.

## Verification

- Reviewed landing head: `ab34b99361f532f22aadf733f1a7ed5447408f5c`, rebased onto `40b07f432c9fce0109890be97ede5ae676647c06`. Only the changelog was reconciled; all 16 runtime, test and documentation files are byte-identical to the previously reviewed feature.
- `pnpm check` passed: 236 Worker, 29 admin and 79 script tests (344 total; the earlier base had 330). `pnpm build`, strict `pnpm provider:smoke-plan`, local `pnpm worker:e2e`, Wrangler package `--dry-run`, and all 8 Playwright browser tests passed. These checks used local fixtures without service credentials or live provider calls.
- Independent isolated Codex branch autoreview against `origin/main` exited 0 with no accepted/actionable P0 findings. The review bundle passed credential scanning; review did not claim live identity or production-isolation proof.
- Earlier isolated local acceptance exercised the actual subscription upstream through native Codex and direct OpenClaw: tool use, continuation, native cold resume, both manual compaction paths and post-compaction tools. Native compaction used the default v2 streaming path in CLI `0.150.0-alpha.13`, not the unsupported legacy unary endpoint.
- Local adversarial tests covered unauthenticated and sibling-client denial, conflicting credentials, revocation, output projection, safety envelopes, split deltas and bounded streams. Separate container acceptance checked the isolated ingress/network/process boundary.
- The complete repository tree, task diff (including removed/context lines), outgoing commit messages and this PR text are checked against known private identifiers. Credential scanning runs before review/publication. No raw agent transcripts, private model metadata, credentials or live configuration are included.

## Deployment status and remaining limits

**Code only: not deployed or enabled.** No secret binding is provisioned and no Codex/OpenClaw client configuration is changed. The feature fails closed without valid private bindings. Production setup remains a separate operator decision.

Real token-specific Cloudflare/GitHub identity proof and the production isolation boundary are still required before activation; synthetic identity tests are not that proof. Automatic OAuth refresh, continuous reauthorization of an admitted stream, auxiliary endpoint parity and full-context capacity are not claimed. Known-value containment does not guarantee secrecy against arbitrary encodings, semantic self-identification or a malicious upstream. `max_output_tokens` is explicitly disclosed as ignored by this subscription adapter, not advertised as an enforced limit.

AI-assisted implementation and review. Maintainer-requested feature; no release or package publication.
