### PR TITLE
fix: abort hung session avatar, Access certs, and local login fetches

### DIFF
--- a/admin/src/dashboard-fetch.ts
+++ b/admin/src/dashboard-fetch.ts
@@ -1,6 +1,20 @@
 import { DASHBOARD_FETCH_TIMEOUT_MS, fetchTimeoutSignal, PLAYGROUND_FETCH_TIMEOUT_MS } from "../../shared/fetch-timeout";
 import type { PlaygroundHttpResponse } from "./ui-types";
 
+export async function localLogin(baseUrl: string, token: string): Promise<string | null> {
+  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/session/login`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token }),
+    signal: fetchTimeoutSignal(undefined, DASHBOARD_FETCH_TIMEOUT_MS),
+  });
+  if (response.ok) return null;
+  if (response.status === 401) return "invalid admin token";
+  if (response.status === 429) return "too many sign-in attempts; wait a minute and retry";
+  return `sign-in failed with status ${response.status}`;
+}
+
 export async function request<T>(baseUrl: string, path: string, init: RequestInit = {}): Promise<T> {
   const headers = new Headers(init.headers);
   const response = await fetch(`${baseUrl.replace(/\/$/, "")}${path}`, { ...init, credentials: "same-origin", headers, signal: fetchTimeoutSignal(init.signal, DASHBOARD_FETCH_TIMEOUT_MS) });

--- a/admin/src/ui-helpers.ts
+++ b/admin/src/ui-helpers.ts
@@ -36,20 +36,7 @@ export async function localLoginAvailable(baseUrl: string): Promise<boolean> {
   }
 }
 
-export async function localLogin(baseUrl: string, token: string): Promise<string | null> {
-  const response = await fetch(`${baseUrl.replace(/\/$/, "")}/v1/session/login`, {
-    method: "POST",
-    credentials: "same-origin",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ token }),
-  });
-  if (response.ok) return null;
-  if (response.status === 401) return "invalid admin token";
-  if (response.status === 429) return "too many sign-in attempts; wait a minute and retry";
-  return `sign-in failed with status ${response.status}`;
-}
-
-export { isTextualResponse, playgroundRequest, request } from "./dashboard-fetch";
+export { isTextualResponse, localLogin, playgroundRequest, request } from "./dashboard-fetch";
 
 export function createPlaygroundTurn(input: Omit<PlaygroundTurn, "id" | "response" | "rawResponse"> & { raw: string }): PlaygroundTurn {
   return {

--- a/admin/test/dashboard-fetch.test.mjs
+++ b/admin/test/dashboard-fetch.test.mjs
@@ -12,7 +12,7 @@ registerHooks({
   },
 });
 
-const { playgroundRequest, request } = await import("../src/dashboard-fetch.ts");
+const { localLogin, playgroundRequest, request } = await import("../src/dashboard-fetch.ts");
 
 test("dashboard JSON request leaves headroom for a typed 30s Worker timeout and keeps a caller signal", async (context) => {
   const timeouts = [];
@@ -61,6 +61,29 @@ test("playground request uses the 600s endpoint budget instead of the bounded da
   assert.equal(result.status, 200);
   assert.ok(init.signal instanceof AbortSignal);
   assert.deepEqual(timeouts, [600_000]);
+});
+
+test("local console login attaches the dashboard AbortSignal", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let loginInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), "https://console.example/v1/session/login");
+    loginInit = init;
+    return Response.json({ ok: true });
+  });
+
+  assert.equal(await localLogin("https://console.example", "admin-token"), null);
+  assert.equal(loginInit.method, "POST");
+  assert.equal(loginInit.credentials, "same-origin");
+  assert.equal(loginInit.body, JSON.stringify({ token: "admin-token" }));
+  assert.ok(loginInit.signal instanceof AbortSignal);
+  assert.equal(loginInit.signal.aborted, false);
+  assert.deepEqual(timeouts, [60_000]);
 });
 
 test("playground request honors an explicit endpoint timeout", async (context) => {

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -1,3 +1,4 @@
+import { fetchTimeoutSignal } from "../shared/fetch-timeout.ts";
 import { authorityCall, resolveBindings, resolvePolicies, resolveUsers } from "./authority";
 import { assignmentEvidenceFromAccessIdentity } from "./assignment-evaluator";
 import { listAssignmentRules, reconcileUserAssignments } from "./assignments";
@@ -27,7 +28,7 @@ async function cloudflareAccessSession(request: Request, env: Env): Promise<Acce
   const headers = request.headers;
   const assertion = headers.get("cf-access-jwt-assertion");
   if (!assertion || !env.CLAWROUTER_ACCESS_TEAM_DOMAIN || !env.CLAWROUTER_ACCESS_AUD) return null;
-  const payload = await verifyAccessJwt(assertion, env.CLAWROUTER_ACCESS_TEAM_DOMAIN, env.CLAWROUTER_ACCESS_AUD);
+  const payload = await verifyAccessJwt(assertion, env.CLAWROUTER_ACCESS_TEAM_DOMAIN, env.CLAWROUTER_ACCESS_AUD, fetchTimeoutSignal(request.signal));
   const email = payload?.email ? normalizeEmail(payload.email) : null;
   if (!payload || !email) return null;
   const role = adminRole(email, env) ? "admin" : "user";
@@ -123,7 +124,7 @@ async function verifiedGithubEvidence(request: Request, email: string) {
   if (!cookie) return undefined;
   const url = new URL("/cdn-cgi/access/get-identity", request.url);
   try {
-    const response = await fetch(url, { headers: { accept: "application/json", cookie }, redirect: "manual" });
+    const response = await fetch(url, { headers: { accept: "application/json", cookie }, redirect: "manual", signal: fetchTimeoutSignal(request.signal) });
     if (!response.ok) return undefined;
     const body = await response.text();
     if (body.length > 64 * 1024) return undefined;

--- a/worker/discovery.ts
+++ b/worker/discovery.ts
@@ -1,3 +1,4 @@
+import { fetchTimeoutSignal } from "../shared/fetch-timeout.ts";
 import { publicSession, sessionPolicies, verifiedAccessSession } from "./access";
 import { contentRetentionDefault } from "./content-retention.ts";
 import { loadFusionConfig } from "./fusion-config";
@@ -27,7 +28,7 @@ export async function avatarResponse(request: Request, env: Env): Promise<Respon
   const session = await verifiedAccessSession(request, env);
   if (!session) return errorResponse("access_session_required", "avatar access requires a verified Cloudflare Access session", 401);
   const hash = await sha256Hex(session.email.trim().toLowerCase());
-  const upstream = await fetch(`https://www.gravatar.com/avatar/${hash}?s=60&d=identicon&r=g`);
+  const upstream = await fetch(`https://www.gravatar.com/avatar/${hash}?s=60&d=identicon&r=g`, { signal: fetchTimeoutSignal(request.signal) });
   if (!upstream.ok) return new Response(null, { status: 404, headers: { "cache-control": "private, no-store" } });
   const type = upstream.headers.get("content-type")?.split(";")[0] ?? "";
   if (!["image/gif", "image/jpeg", "image/png", "image/webp"].includes(type)) return new Response(null, { status: 502 });

--- a/worker/test/access-fetch-timeout.test.mjs
+++ b/worker/test/access-fetch-timeout.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname)) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { verifiedAccessSession } = await import("../access.ts");
+
+const teamDomain = "team.cloudflareaccess.com";
+const audience = "aud-1";
+const email = "member@example.com";
+const certsUrl = `https://${teamDomain}/cdn-cgi/access/certs`;
+const identityUrl = "https://console.example/cdn-cgi/access/get-identity";
+
+function encode(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function unsignedJwt(kid = "test-kid") {
+  return `${encode({ alg: "RS256", kid })}.${encode({
+    aud: audience,
+    iss: `https://${teamDomain}`,
+    email,
+    exp: Math.floor(Date.now() / 1000) + 300,
+  })}.c2ln`;
+}
+
+async function signedJwt(privateKey, kid) {
+  const unsigned = `${encode({ alg: "RS256", kid })}.${encode({
+    aud: audience,
+    iss: `https://${teamDomain}`,
+    email,
+    sub: "access-subject",
+    exp: Math.floor(Date.now() / 1000) + 300,
+  })}`;
+  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", privateKey, new TextEncoder().encode(unsigned));
+  return `${unsigned}.${Buffer.from(signature).toString("base64url")}`;
+}
+
+function accessEnv(kv = new Map(), users = new Map()) {
+  return {
+    CLAWROUTER_ACCESS_TEAM_DOMAIN: teamDomain,
+    CLAWROUTER_ACCESS_AUD: audience,
+    POLICY_KV: {
+      async list({ prefix }) {
+        const keys = [...kv.keys()].filter((key) => key.startsWith(prefix)).map((name) => ({ name }));
+        return { keys, list_complete: true };
+      },
+      async get(key, type) {
+        const value = kv.get(key);
+        return value === undefined ? null : type === "json" ? structuredClone(value) : value;
+      },
+    },
+    ACCESS_CONTROL: {
+      idFromName: (name) => name,
+      get: () => ({
+        fetch: async (url, init) => {
+          const path = new URL(url).pathname;
+          const body = init?.body ? JSON.parse(init.body) : {};
+          if (path === "/users/resolve") {
+            const found = (body.emails ?? []).filter((item) => users.has(item)).map((item) => ({ email: item, record: users.get(item) }));
+            return Response.json({ initialized: true, users: found, missingEmails: (body.emails ?? []).filter((item) => !users.has(item)) });
+          }
+          if (path === "/users/put") {
+            users.set(body.email, body.record);
+            return new Response("updated");
+          }
+          return Response.json({ error: { code: "route_not_found" } }, { status: 404 });
+        },
+      }),
+    },
+  };
+}
+
+function sessionRequest(assertion, extraHeaders = {}) {
+  return new Request("https://console.example/v1/session", {
+    headers: { "cf-access-jwt-assertion": assertion, ...extraHeaders },
+  });
+}
+
+test("public Access certs fetch attaches a 30s AbortSignal", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let certsInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), certsUrl);
+    certsInit = init;
+    return Response.json({ keys: [] });
+  });
+
+  const session = await verifiedAccessSession(sessionRequest(unsignedJwt()), accessEnv());
+  assert.equal(session, null);
+  assert.ok(certsInit.signal instanceof AbortSignal);
+  assert.equal(certsInit.signal.aborted, false);
+  assert.deepEqual(timeouts, [30_000]);
+});
+
+test("public Access certs fetch aborts a hung certs endpoint", { timeout: 2_000 }, async (context) => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  const timeouts = [];
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(40);
+  });
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), certsUrl);
+    return nativeFetch(`http://127.0.0.1:${port}/hung`, { signal: init?.signal });
+  });
+
+  context.after(() => {
+    server.closeAllConnections();
+    server.close();
+  });
+  await assert.rejects(
+    verifiedAccessSession(sessionRequest(unsignedJwt()), accessEnv()),
+    (error) => error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError"),
+  );
+  assert.deepEqual(timeouts, [30_000]);
+});
+
+test("GitHub identity fetch attaches a 30s AbortSignal and fails open on timeout", async (context) => {
+  const keys = await crypto.subtle.generateKey({ name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" }, true, ["sign", "verify"]);
+  const kid = "github-binding-key";
+  const jwk = { ...await crypto.subtle.exportKey("jwk", keys.publicKey), kid, kty: "RSA" };
+  const assertion = await signedJwt(keys.privateKey, kid);
+  const kv = new Map([
+    ["access/assignment-rules/org", {
+      version: 1,
+      enabled: true,
+      kind: "github_org",
+      subject: "openclaw",
+      groups: ["maintainers"],
+      policyIds: ["policy"],
+      priority: 10,
+      revokeOnLoss: true,
+      provenance: "cloudflare_access",
+    }],
+  ]);
+  const users = new Map([
+    [email, { role: "user", tenantId: "default", enabled: true, groups: [], contentRetentionDisabled: false }],
+  ]);
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let identityInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    if (String(input) === certsUrl) return Response.json({ keys: [jwk] });
+    assert.equal(String(input), identityUrl);
+    identityInit = init;
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  });
+
+  const session = await verifiedAccessSession(sessionRequest(assertion, { cookie: "CF_Authorization=present" }), accessEnv(kv, users));
+  assert.equal(session?.email, email);
+  assert.ok(identityInit.signal instanceof AbortSignal);
+  assert.deepEqual(timeouts, [30_000, 30_000]);
+});

--- a/worker/test/avatar-fetch.mocks.mjs
+++ b/worker/test/avatar-fetch.mocks.mjs
@@ -1,0 +1,20 @@
+export async function verifiedAccessSession() {
+  return {
+    authenticated: true,
+    auth: "local",
+    role: "admin",
+    email: "admin@example.com",
+    subject: null,
+    tenantId: "default",
+    groups: [],
+    contentRetentionDisabled: false,
+  };
+}
+
+export function publicSession(session) {
+  return session;
+}
+
+export async function sessionPolicies() {
+  return [];
+}

--- a/worker/test/avatar-fetch.test.mjs
+++ b/worker/test/avatar-fetch.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { extname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (context.parentURL === pathToFileURL(new URL("../discovery.ts", import.meta.url).pathname).href) {
+      if (specifier === "./access") {
+        return { shortCircuit: true, url: new URL("./avatar-fetch.mocks.mjs", import.meta.url).href };
+      }
+    }
+    if (specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname)) {
+      return nextResolve(`${specifier}.ts`, context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { avatarResponse } = await import("../discovery.ts");
+
+const gravatarHash = createHash("sha256").update("admin@example.com").digest("hex");
+const gravatarUrl = `https://www.gravatar.com/avatar/${gravatarHash}?s=60&d=identicon&r=g`;
+
+function avatarRequest() {
+  return new Request("https://console.example/v1/session/avatar");
+}
+
+test("session avatar Gravatar fetch attaches a 30s AbortSignal", async (context) => {
+  const timeouts = [];
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(ms);
+  });
+  let avatarInit;
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), gravatarUrl);
+    avatarInit = init;
+    return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), { headers: { "content-type": "image/png" } });
+  });
+
+  const response = await avatarResponse(avatarRequest(), {});
+  assert.equal(response.status, 200);
+  assert.ok(avatarInit?.signal instanceof AbortSignal);
+  assert.equal(avatarInit.signal.aborted, false);
+  assert.deepEqual(timeouts, [30_000]);
+});
+
+test("session avatar fetch aborts a hung Gravatar instead of stalling the Worker", { timeout: 2_000 }, async (context) => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
+  const timeouts = [];
+  context.mock.method(AbortSignal, "timeout", (ms) => {
+    timeouts.push(ms);
+    return nativeTimeout(40);
+  });
+  context.mock.method(globalThis, "fetch", async (input, init) => {
+    assert.equal(String(input), gravatarUrl);
+    return nativeFetch(`http://127.0.0.1:${port}/hung`, { signal: init?.signal });
+  });
+
+  context.after(() => {
+    server.closeAllConnections();
+    server.close();
+  });
+  await assert.rejects(
+    avatarResponse(avatarRequest(), {}),
+    (error) => error instanceof DOMException && (error.name === "TimeoutError" || error.name === "AbortError"),
+  );
+  assert.deepEqual(timeouts, [30_000]);
+});


### PR DESCRIPTION
## What Problem This Solves

Three leftover public fetches still call `fetch` with no `AbortSignal` after #111 and #112 bounded dashboard JSON, OAuth callback, and grant-refresh token POSTs.

1. `GET /v1/session/avatar` proxies Gravatar. A stalled `www.gravatar.com` leaves the dashboard `<img>` and the Worker request pending until the isolate wall-clock limit.
2. Public Cloudflare Access session verification fetches `/cdn-cgi/access/certs` without a timeout. `verifyAccessJwt` already accepts an optional `signal` (used by private Codex at 10s). The public caller (`cloudflareAccessSession` on `/dashboard/*`, `/v1/session`, `/v1/session/avatar`, `/v1/entitlements`, `/v1/me`) still omits it. The same file's GitHub identity lookup (`/cdn-cgi/access/get-identity`) also has no signal.
3. Self-host console `localLogin` POSTs `/v1/session/login` with raw `fetch`. Sibling `request()` already uses `fetchTimeoutSignal(..., DASHBOARD_FETCH_TIMEOUT_MS)`. A stalled Worker leaves the sign-in button pending.

## Evidence

Live Node against a TCP server that accepts the connection and never writes an HTTP response. The shared helper aborts in 81ms on an 80ms budget. Production `localLogin` records the 60s dashboard budget and aborts. Public Access certs and session avatar record the 30s worker default and abort.

```console
$ node --version && uname -srm
v26.7.0
Darwin 25.6.0 arm64

$ node /tmp/oc-clawrouter-session-timeout-proof.mjs
hung_server=http://127.0.0.1:57620/hung
default_timeout_ms=30000
dashboard_timeout_ms=60000
helper_abort name=TimeoutError elapsed_ms=81
local_login name=TimeoutError elapsed_ms=81 timeout_ms=[60000]
access_certs name=TimeoutError elapsed_ms=80 timeout_ms=[30000]
session_avatar name=TimeoutError elapsed_ms=82 timeout_ms=[30000]
proof_ok hung session login fetches aborted
```

Patched call sites on this branch:

```console
$ rg -n "fetchTimeoutSignal" worker/discovery.ts worker/access.ts admin/src/dashboard-fetch.ts
worker/discovery.ts: avatarResponse -> fetchTimeoutSignal(request.signal)
worker/access.ts: cloudflareAccessSession -> verifyAccessJwt(..., fetchTimeoutSignal(request.signal))
worker/access.ts: verifiedGithubEvidence -> fetchTimeoutSignal(request.signal)
admin/src/dashboard-fetch.ts: localLogin -> fetchTimeoutSignal(undefined, DASHBOARD_FETCH_TIMEOUT_MS)
```

## Real behavior proof

- **Behavior or issue addressed:** Session avatar Gravatar GET, public Access certs and GitHub identity lookups, and console local login POST now carry `fetchTimeoutSignal`. A hung peer finishes with `TimeoutError` instead of leaving the Worker or sign-in button pending.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, clawrouter checkout `/tmp/oc-pr-clawrouter-F004` on `fix/session-login-fetch-timeouts`. Live `node` against a local hanging HTTP server (accept, no response body).
- **Exact steps or command run after this patch:** Started a `node:http` server that never writes a response. Called `fetchTimeoutSignal(undefined, 80)` on that URL. Then called production `localLogin`, `verifiedAccessSession` (certs path), and `avatarResponse` with `AbortSignal.timeout` shortened to 80ms so the compiled default budgets (60s dashboard, 30s worker) are the ones recorded.
- **Evidence after fix:** terminal output copied below.

  ```console
  hung_server=http://127.0.0.1:57620/hung
  default_timeout_ms=30000
  dashboard_timeout_ms=60000
  helper_abort name=TimeoutError elapsed_ms=81
  local_login name=TimeoutError elapsed_ms=81 timeout_ms=[60000]
  access_certs name=TimeoutError elapsed_ms=80 timeout_ms=[30000]
  session_avatar name=TimeoutError elapsed_ms=82 timeout_ms=[30000]
  proof_ok hung session login fetches aborted
  ```

- **Observed result after fix:** The 80ms helper path aborted with `TimeoutError` at 81ms. Production `localLogin` recorded `AbortSignal.timeout(60000)` and aborted at 81ms. Public Access certs and session avatar recorded `AbortSignal.timeout(30000)` and aborted at 80ms and 82ms. None of the four calls stayed pending.
- **What was not tested:** Live Cloudflare Access against a real hung `cdn-cgi/access/certs` or Gravatar host. Browser screenshot of the self-host sign-in button. Private Codex still uses its own 10s signal and was not changed.

## Summary

- Reuse `fetchTimeoutSignal` from `shared/fetch-timeout.ts` (30s worker default, 60s dashboard login)
- `avatarResponse` Gravatar GET combines the inbound request signal with a 30s timeout
- Public `cloudflareAccessSession` now passes that signal into `verifyAccessJwt`; GitHub identity lookup uses the same helper and still fails open
- Console `localLogin` moved next to `request()` in `dashboard-fetch.ts` and uses the 60s dashboard budget
- Same hang class as [openclaw/clawrouter#111](https://github.com/openclaw/clawrouter/pull/111), [openclaw/clawrouter#112](https://github.com/openclaw/clawrouter/pull/112), and [openclaw/clickclack#168](https://github.com/openclaw/clickclack/pull/168)
- Avatar fetch landed in [openclaw/clawrouter#55](https://github.com/openclaw/clawrouter/pull/55) (`61cba08`, 2026-06-22, 68 days). GitHub identity fetch landed in [openclaw/clawrouter#68](https://github.com/openclaw/clawrouter/pull/68). `verifyAccessJwt` gained an optional signal in [openclaw/clawrouter#118](https://github.com/openclaw/clawrouter/pull/118) for private Codex only. `localLogin` landed without a timeout in [openclaw/clawrouter#113](https://github.com/openclaw/clawrouter/pull/113) (2026-08-16)
