### PR TITLE
fix(private): honor workload revocation during binding reads

### DIFF
--- a/worker/private-codex-config.ts
+++ b/worker/private-codex-config.ts
@@ -122,10 +122,9 @@ export async function privateAuthorized(request: Request, policy: PrivatePolicy)
 }
 
 export async function privateAuthorizationCurrent(authorization: PrivateAuthorization, policy: PrivatePolicy, env: Env): Promise<boolean> {
-  if (policy.auth.mode === "access") {
-    const current = await privatePolicy(env);
-    if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return false;
-  }
+  // Workload revocation must also win while an upstream binding read is pending.
+  const current = await privatePolicy(env);
+  if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return false;
   return authorization.current();
 }
 

--- a/worker/test/private-codex-adversarial.test.mjs
+++ b/worker/test/private-codex-adversarial.test.mjs
@@ -254,7 +254,7 @@ test("adversarial paused uploads fail closed across policy, credential, binding 
     const body = new ReadableStream({ start(c) { controller = c; }, pull() { waiting.resolve(); } }, { highWaterMark: 0 });
     const req = new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" }, body, duplex: "half" });
     const pending = run(req, env); await waiting.promise;
-    assert.equal(state.policies, 1); assert.equal(state.secrets, 1);
+    assert.equal(state.secrets, 1);
     change(state);
     controller.enqueue(enc.encode(JSON.stringify({ model: alias, store: false }))); controller.close();
     const result = await pending; assert.equal(result.status, 404);

--- a/worker/test/private-codex.test.mjs
+++ b/worker/test/private-codex.test.mjs
@@ -675,6 +675,24 @@ test("no private failures or request metadata enter application logs", async (co
   assert.deepEqual(logs, []);
 });
 
+test("workload revocation during the final upstream binding read prevents egress", async () => {
+  for (const revoke of [
+    (state) => { state.policy.enabled = false; },
+    (state) => { state.policy.auth.credentialSha256 = "0".repeat(64); },
+  ]) {
+    const { env, state } = await environment();
+    env.PRIVATE_CODEX_UPSTREAM.get = async () => {
+      if (++state.secretReads === 2) revoke(state);
+      return JSON.stringify(state.upstream);
+    };
+    await withFetch(() => assert.fail("Revoked workload must not reach upstream"), async () => {
+      const result = await run(request(), env);
+      assert.equal(result.status, 404);
+      assert.equal(state.secretReads, 2);
+    });
+  }
+});
+
 test("holdback disambiguates overlapping prefixes and safely ends incomplete Responses", async () => {
   const { env, state } = await environment();
   state.upstream.target = "SYNTHETIC_ABABABAC";


### PR DESCRIPTION
Workload credentials are now revalidated against the current private policy after awaited upstream-binding reads. Previously, disabling the policy or rotating a workload credential during the final binding read could still allow one upstream request; Access authentication already performed this recheck.

The regression reproduces both revocation cases and now fails closed before egress. Validation: all 77 private endpoint tests pass; the baseline Worker, admin, and script suites also pass. Independent autoreview found no actionable issues. Deployment is unchanged.
