### PR TITLE
feat(private): add bounded fallback with continuation affinity

### DIFF
--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -152,12 +152,13 @@ proxy or account-selection endpoint. Caller `ChatGPT-Account-ID` and custom
 account headers are rejected in both modes. Only the broker constructs the
 upstream account header from its fixed authenticated binding.
 
-`PRIVATE_CODEX_UPSTREAM` has exactly these fields:
+`PRIVATE_CODEX_UPSTREAM` has these required fields and one optional fallback:
 
 | Field | Contract |
 | --- | --- |
 | `version` | Number `1` |
 | `target` | Runtime-only upstream binding; 8–128 ASCII letters/digits/`.`/`_`/`-`, beginning with a letter/digit |
+| `fallbackTarget` | Optional, distinct target with the same syntax; at most one alternative, never exposed in discovery |
 | `accountId` | Exact subscription account; 8–128 ASCII letters/digits/`_`/`-` |
 | `accessToken` | Separately held subscription access token; 16–8192 ASCII letters/digits/`.`/`_`/`~`/`-` |
 | `expiresAt` | Integer Unix **milliseconds**, at least 30 seconds in the future |
@@ -171,9 +172,37 @@ expired, inaccessible, or mid-request changed configuration fails closed.
 The upstream binding is read **only after authentication**, including on private
 discovery. The adapter sends exactly that account and token to the fixed
 subscription Responses URL already declared by the OpenAI provider manifest.
-No caller can change the provider, account, origin, or target. There are no
-redirects, retries, alternate accounts, API-key fallbacks, generic grant lookups,
+No caller can change the provider, account, origin, or configured targets. There
+are no redirects, alternate accounts, API-key fallbacks, generic grant lookups,
 Fusion paths, or arbitrary-model/native routing inside this facade.
+
+When `fallbackTarget` is configured, the broker may make one additional call on
+the same fixed subscription after an explicit HTTP availability failure:
+`404 model_not_found`, `429 rate_limit_exceeded`, or a 502/503/504 carrying
+`server_error`, `service_unavailable`, `overloaded_error`, or `timeout`. Unknown
+errors, authentication, safety, entitlement and exhausted-quota denials are
+terminal. Transport exceptions and any response stream that has begun are
+terminal too. Requests with `previous_response_id` or `x-codex-turn-state` stay
+on the target that issued their state and cannot fail over again.
+
+With fallback configured, typed response IDs and turn-state headers carry an
+opaque broker route envelope. An authenticated encrypted slot binds them to the
+current policy, target mapping, account, and upstream credential. It contains no
+model name. The broker restores the original upstream values on the next call;
+it does not manufacture upstream signatures or attestations. Unwrapped legacy
+state remains primary-only, conflicting origins and tampering fail closed, and
+credential or routing rotation invalidates wrapped state. Clients must restart
+from full input after such a rotation. Without fallback, the existing opaque
+values remain unchanged.
+
+Before the second call, the broker revalidates the caller and both complete
+bindings. Revocation or rotation stops the request. Both attempts share the
+existing deadline, preserve the request's genuine client and safety facts, and
+return only the same alias. Both configured identities remain sensitive on
+either attempt; model headers and safety selectors must match the selected
+target. Provisioning must verify entitlement and compatible native capabilities
+for both targets. The fallback does not invent compatibility or bypass upstream
+requirements.
 
 Automatic OAuth refresh is intentionally absent. The existing shared refresh
 helper writes shared grant state and does not provide this boundary's required
@@ -295,8 +324,9 @@ rate_limits.rs,safety_buffering.rs}`. Additional protocol requires source review
 
 Queries, encoded route spellings, trailing slashes, alternate methods,
 compression, non-UTF-8 content, the legacy unary `/responses/compact` endpoint,
-websocket, upload, usage, and every other endpoint are unsupported. Upstream redirects and errors do not trigger another
-provider call. At ingress, enforce rejection of raw dot segments/backslashes
+websocket, upload, usage, and every other endpoint are unsupported. Upstream
+redirects and errors outside the bounded availability fallback do not trigger
+another provider call. At ingress, enforce rejection of raw dot segments/backslashes
 before URL normalization: the Worker cannot recover path spellings already
 normalized by the HTTP runtime. Normalized routes never select an alternative
 private endpoint/provider/target.

--- a/worker/private-codex-config.ts
+++ b/worker/private-codex-config.ts
@@ -16,6 +16,7 @@ const reasoningEfforts: readonly ProviderReasoningEffort[] = ["none", "minimal",
 export interface PrivateUpstream {
   version: 1;
   target: string;
+  fallbackTarget?: string;
   accountId: string;
   accessToken: string;
   expiresAt: number;
@@ -130,11 +131,17 @@ export async function privateAuthorizationCurrent(authorization: PrivateAuthoriz
 
 export async function privateUpstream(env: Env, policy: PrivatePolicy): Promise<PrivateUpstream | null> {
   const value = await bindingJson(env.PRIVATE_CODEX_UPSTREAM);
-  if (!record(value) || !exactKeys(value, ["version", "target", "accountId", "accessToken", "expiresAt"]) || value.version !== 1
+  if (!record(value)) return null;
+  const keys = ["version", "target", "accountId", "accessToken", "expiresAt"];
+  if (Object.hasOwn(value, "fallbackTarget")) keys.push("fallbackTarget");
+  if (!exactKeys(value, keys) || value.version !== 1
     || typeof value.target !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.target)
     || typeof value.accountId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(value.accountId)
     || typeof value.accessToken !== "string" || !/^[A-Za-z0-9._~-]{16,8192}$/.test(value.accessToken)
     || typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt <= Date.now() + 30_000) return null;
-  if ([value.target, value.accountId, value.accessToken].some((secret) => policy.alias.id.includes(secret) || policy.alias.name.includes(secret))) return null;
+  if (Object.hasOwn(value, "fallbackTarget") && (typeof value.fallbackTarget !== "string"
+    || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.fallbackTarget) || value.fallbackTarget === value.target)) return null;
+  const sensitive = [value.target, value.accountId, value.accessToken, ...(typeof value.fallbackTarget === "string" ? [value.fallbackTarget] : [])];
+  if (sensitive.some((secret) => policy.alias.id.includes(secret) || policy.alias.name.includes(secret))) return null;
   return value as unknown as PrivateUpstream;
 }

--- a/worker/private-codex-continuation.ts
+++ b/worker/private-codex-continuation.ts
@@ -1,0 +1,75 @@
+import type { PrivatePolicy, PrivateUpstream } from "./private-codex-config";
+
+const prefix = "cr1.";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+export interface PrivateContinuationProjection { wrap(value: unknown): Promise<string> }
+
+// Bind original upstream state to its route without revealing the target. This
+// envelope never replaces upstream verification of its own restored state.
+export async function privateContinuations(policy: PrivatePolicy, upstream: PrivateUpstream) {
+  const key = await crypto.subtle.importKey("raw", await crypto.subtle.digest("SHA-256", encoder.encode("clawrouter:continuation:v1\0" + upstream.accessToken)), "AES-GCM", false, ["encrypt", "decrypt"]);
+  const additionalData = encoder.encode(JSON.stringify([policy, upstream.target, upstream.fallbackTarget, upstream.accountId]));
+
+  async function unwrap(value: string): Promise<{ slot: number; value: string }> {
+    if (!value.startsWith(prefix)) return { slot: 0, value };
+    if (value.length > 8192) throw new Error("private continuation limit");
+    const sealed = decode(value.slice(prefix.length));
+    if (sealed.length < 30) throw new Error("private continuation invalid");
+    const plain = new Uint8Array(await crypto.subtle.decrypt({ name: "AES-GCM", iv: sealed.slice(0, 12), additionalData }, key, sealed.slice(12)));
+    if (plain.length < 2 || plain[0] > 1) throw new Error("private continuation invalid");
+    return { slot: plain[0], value: decoder.decode(plain.slice(1)) };
+  }
+
+  return {
+    async request(body: Record<string, unknown>, headers: Headers) {
+      const previous = body.previous_response_id;
+      const affinity = headers.get("x-codex-turn-state");
+      if (previous != null && typeof previous !== "string") throw new Error("private continuation invalid");
+      const responseState = typeof previous === "string" && previous ? await unwrap(previous) : null;
+      const turnState = affinity !== null ? await unwrap(affinity) : null;
+      if (responseState && turnState && responseState.slot !== turnState.slot) throw new Error("private continuation mismatch");
+      const outgoing = new Headers(headers);
+      if (turnState) outgoing.set("x-codex-turn-state", turnState.value);
+      return {
+        slot: responseState?.slot ?? turnState?.slot ?? 0,
+        body: responseState ? { ...body, previous_response_id: responseState.value } : body,
+        headers: outgoing,
+        continuing: !!responseState || !!turnState,
+      };
+    },
+    async projection(slot: number): Promise<PrivateContinuationProjection> {
+      const cache = new Map<string, Promise<string>>();
+      async function seal(value: string): Promise<string> {
+        const raw = encoder.encode(value);
+        const plain = new Uint8Array(1 + raw.length); plain[0] = slot; plain.set(raw, 1);
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const sealed = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-GCM", iv, additionalData }, key, plain));
+        const token = new Uint8Array(iv.length + sealed.length); token.set(iv); token.set(sealed, iv.length);
+        const wrapped = prefix + encode(token);
+        if (wrapped.length > 8192) throw new Error("private continuation limit");
+        return wrapped;
+      }
+      return { async wrap(value: unknown): Promise<string> {
+        if (typeof value !== "string" || !value || value.length > 8192) throw new Error("private continuation invalid");
+        const existing = cache.get(value);
+        if (existing) return existing;
+        if (cache.size >= 128) throw new Error("private continuation count");
+        const wrapped = seal(value); cache.set(value, wrapped);
+        return wrapped;
+      } };
+    },
+  };
+}
+
+function encode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function decode(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error("private continuation invalid");
+  const bytes = Uint8Array.from(atob(value.replaceAll("-", "+").replaceAll("_", "/")), c => c.charCodeAt(0));
+  if (encode(bytes) !== value) throw new Error("private continuation invalid");
+  return bytes;
+}

--- a/worker/private-codex-output.ts
+++ b/worker/private-codex-output.ts
@@ -1,6 +1,7 @@
 import { boundedJson, cancel, read } from "./private-codex-io";
 import { record, type PrivateUpstream } from "./private-codex-config";
 import { PrivateResponseProjection } from "./private-codex-response";
+import type { PrivateContinuationProjection } from "./private-codex-continuation";
 
 const encoder = new TextEncoder();
 const frameLimit = 256 * 1024;
@@ -35,7 +36,7 @@ export function privateError(status: number, ignoredMaxOutputTokens = false): Re
   return privateJson({ error }, status, ignoredMaxOutputTokens);
 }
 
-export async function containResponse(response: Response, alias: string, upstream: PrivateUpstream, streaming: boolean, signal: AbortSignal, abort: () => void, ignoredMaxOutputTokens = false): Promise<Response> {
+export async function containResponse(response: Response, alias: string, upstream: PrivateUpstream, streaming: boolean, signal: AbortSignal, abort: () => void, ignoredMaxOutputTokens = false, continuation?: PrivateContinuationProjection): Promise<Response> {
   const discard = () => { void response.body?.cancel().catch(() => {}); abort(); };
   if (!response.ok) {
     discard();
@@ -45,10 +46,10 @@ export async function containResponse(response: Response, alias: string, upstrea
   const encoding = response.headers.get("content-encoding");
   const contentType = response.headers.get("content-type") ?? "";
   if ((encoding && encoding !== "identity") || response.status !== 200) { discard(); return privateError(502, ignoredMaxOutputTokens); }
-  const projection = new PrivateResponseProjection(alias, upstream);
-  const outputHeaders = () => {
+  const projection = new PrivateResponseProjection(alias, upstream, continuation);
+  const outputHeaders = async () => {
     const result = new Headers(headers(streaming ? "text/event-stream; charset=utf-8" : "application/json; charset=utf-8", ignoredMaxOutputTokens));
-    for (const [key, value] of Object.entries(projection.headers(response.headers))) result.set(key, value as string);
+    for (const [key, value] of Object.entries(await projection.headers(response.headers))) result.set(key, value as string);
     projection.inspect([...result]);
     return result;
   };
@@ -57,7 +58,7 @@ export async function containResponse(response: Response, alias: string, upstrea
     try { projection.inspect(errorBody); projection.inspect([...result.headers]); return result; }
     catch { return new Response(null, { status: 502 }); }
   };
-  try { outputHeaders(); } catch { discard(); return failure(); }
+  try { await outputHeaders(); } catch { discard(); return failure(); }
   if (streaming) {
     // Native subscription SSE can omit Content-Type; the frame parser still validates every byte.
     if ((contentType && !/^text\/event-stream(?:;\s*charset=utf-8)?$/i.test(contentType)) || !response.body) { discard(); return privateError(502, ignoredMaxOutputTokens); }
@@ -66,7 +67,7 @@ export async function containResponse(response: Response, alias: string, upstrea
       // Learn the initial reporting identity before releasing opaque HTTP affinity headers.
       // Priming uses the same bounded parser/queue and cancellation as subsequent reads.
       let first: ReadableStreamReadResult<Uint8Array> | undefined = await reader.read();
-      const projectedHeaders = outputHeaders();
+      const projectedHeaders = await outputHeaders();
       projection.seal();
       const body = new ReadableStream<Uint8Array>({
         async pull(controller) {
@@ -83,8 +84,8 @@ export async function containResponse(response: Response, alias: string, upstrea
   try {
     const value = await boundedJson(response.body, 4 * 1024 * 1024, signal);
     if (!record(value) || value.object !== "response" || !["completed", "incomplete"].includes(String(value.status))) throw new Error("private response invalid");
-    const projected = projection.response(value);
-    return new Response(JSON.stringify(projected), { headers: outputHeaders() });
+    const projected = await projection.response(value);
+    return new Response(JSON.stringify(projected), { headers: await outputHeaders() });
   } catch { return failure(); } finally { abort(); }
 }
 
@@ -229,7 +230,7 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
     state.arguments = ""; state.done = true; state.holdFrom = Infinity; state.matches.fill(0);
   }
 
-  function eventFrame(frame: string, controller: ReadableStreamDefaultController<Uint8Array>): boolean {
+  async function eventFrame(frame: string, controller: ReadableStreamDefaultController<Uint8Array>): Promise<boolean> {
     if (encoder.encode(frame).byteLength > frameLimit || frame.includes("\r") && !frame.includes("\r\n")) throw new Error("private SSE frame");
     let eventName = "", data: string[] = [];
     for (const line of frame.split(/\r?\n/)) {
@@ -252,7 +253,7 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
     if (!record(event) || typeof event.type !== "string" || !eventTypes.has(event.type) || eventName && eventName !== event.type) throw new Error("private SSE event type");
     if (["codex.rate_limits", "responsesapi.websocket_timing"].includes(event.type)) {
       // Codex consumes common model/safety envelopes before dispatching by event type.
-      const protocol = projection.event({ type: event.type, response: event.response, headers: event.headers, safety_buffering: event.safety_buffering });
+      const protocol = await projection.event({ type: event.type, response: event.response, headers: event.headers, safety_buffering: event.safety_buffering });
       if (event.response != null || event.safety_buffering !== undefined || record(protocol.headers) && Object.keys(protocol.headers).length) throw new Error("private observation protocol unsupported");
       return false;
     }
@@ -261,10 +262,10 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
       if (error && typeof error.code === "string" && denialCodes.has(error.code)) {
         failure = `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: { status: "failed", error: { code: error.code, message: errorBody.error.message } } })}\n\n`;
       }
-      projection.event(event);
+      await projection.event(event);
       throw new Error("private upstream failed");
     }
-    const safe = projection.event(event);
+    const safe = await projection.event(event);
     if (tables.length !== secrets.length) {
       // Learning is sealed before any delta state or output exists; no prefix is discarded.
       tables = secrets.map(prefixTable);
@@ -294,7 +295,7 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
           if (separator) {
             const frame = buffer.slice(0, separator.index);
             buffer = buffer.slice(separator.index + separator[0].length);
-            if (eventFrame(frame, controller)) {
+            if (await eventFrame(frame, controller)) {
               if (ended) { cancel(reader); abort(); controller.close(); }
               return;
             }

--- a/worker/private-codex-response.ts
+++ b/worker/private-codex-response.ts
@@ -1,5 +1,6 @@
 import { record, type PrivateUpstream } from "./private-codex-config";
 import { privateResponseHeaders } from "./private-codex-protocol";
+import type { PrivateContinuationProjection } from "./private-codex-continuation";
 
 // Inspect data without assigning protocol meaning to its keys or rewriting ciphertext/tool JSON.
 export function inspectPrivateContent(value: unknown, sensitive: readonly string[], depth = 0, budget = { nodes: 0 }): void {
@@ -30,11 +31,13 @@ export class PrivateResponseProjection {
   private reported: string | undefined;
   private sealed = false;
   private rejected = false;
+  private readonly continuation: PrivateContinuationProjection | undefined;
 
-  constructor(alias: string, upstream: PrivateUpstream) {
+  constructor(alias: string, upstream: PrivateUpstream, continuation?: PrivateContinuationProjection) {
     this.alias = alias;
+    this.continuation = continuation;
     this.target = upstream.target;
-    this.sensitive = [upstream.target, upstream.accessToken, upstream.accountId];
+    this.sensitive = [upstream.target, upstream.accessToken, upstream.accountId, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])];
   }
 
   get sensitiveValues(): readonly string[] { return this.sensitive; }
@@ -44,44 +47,53 @@ export class PrivateResponseProjection {
 
   inspect(value: unknown): void { inspectPrivateContent(value, this.sensitive); }
 
-  headers(entries: Iterable<[string, unknown]>): Record<string, unknown> {
+  async headers(entries: Iterable<[string, unknown]>): Promise<Record<string, unknown>> {
     const projected = privateResponseHeaders(entries, this.alias, this.target, this.sensitive);
     this.inspect(projected);
+    if (this.continuation && projected["x-codex-turn-state"] !== undefined) projected["x-codex-turn-state"] = await this.continuation.wrap(projected["x-codex-turn-state"]);
     return projected;
   }
 
-  response(value: Record<string, unknown>): Record<string, unknown> {
+  async response(value: Record<string, unknown>): Promise<Record<string, unknown>> {
     if (this.rejected) throw new Error("private reporting identity rejected");
-    const projected = this.responseEnvelope(value);
+    const projected = await this.responseEnvelope(value);
     this.inspect(projected);
     return projected;
   }
 
-  event(value: Record<string, unknown>): Record<string, unknown> {
+  async event(value: Record<string, unknown>): Promise<Record<string, unknown>> {
     if (this.rejected) throw new Error("private reporting identity rejected");
     const projected = { ...value };
     // Register before inspecting any sibling, irrespective of JSON property order.
     if (value.response != null) {
       if (!record(value.response)) throw new Error("private response envelope invalid");
-      projected.response = this.responseEnvelope(value.response);
+      projected.response = await this.responseEnvelope(value.response);
     }
-    if (value.headers !== undefined) projected.headers = this.headerEnvelope(value.headers);
+    if (value.headers !== undefined) projected.headers = await this.headerEnvelope(value.headers);
     if (value.safety_buffering !== undefined) projected.safety_buffering = this.safety(value.safety_buffering);
     if (value.type === "response.metadata" && record(value.metadata) && value.metadata.type === "safety_buffering") {
       projected.metadata = this.safety(value.metadata);
     }
     this.inspect(projected);
+    if (this.continuation && value.response_id !== undefined) projected.response_id = await this.continuation.wrap(value.response_id);
     return projected;
   }
 
-  private responseEnvelope(value: Record<string, unknown>): Record<string, unknown> {
+  private async responseEnvelope(value: Record<string, unknown>): Promise<Record<string, unknown>> {
     const projected = { ...value };
     if (value.model !== undefined) {
       this.learn(value.model);
       projected.model = this.alias;
     }
     if (value.error != null) throw new Error("private upstream error");
-    if (value.headers !== undefined) projected.headers = this.headerEnvelope(value.headers);
+    if (value.headers !== undefined) projected.headers = await this.headerEnvelope(value.headers);
+    if (this.continuation) {
+      for (const key of ["id", "previous_response_id"]) {
+        if (value[key] == null) continue;
+        this.inspect(value[key]);
+        projected[key] = await this.continuation.wrap(value[key]);
+      }
+    }
     return projected;
   }
 
@@ -98,7 +110,7 @@ export class PrivateResponseProjection {
     this.reported = value;
   }
 
-  private headerEnvelope(value: unknown): Record<string, unknown> {
+  private async headerEnvelope(value: unknown): Promise<Record<string, unknown>> {
     if (!record(value)) throw new Error("private protocol headers invalid");
     return this.headers(Object.entries(value));
   }

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -1,7 +1,8 @@
 import { boundedJson } from "./private-codex-io";
-import { privateAuthorizationCurrent, privateAuthorized, privatePolicy, privateUpstream, record } from "./private-codex-config";
+import { privateAuthorizationCurrent, privateAuthorized, privatePolicy, privateUpstream, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
 import { containResponse, privateError, privateJson } from "./private-codex-output";
 import { forwardPrivateHeaders, inspectPrivateOpaque, validPrivateHeaders, validPrivateProtocolBody } from "./private-codex-protocol";
+import { privateContinuations } from "./private-codex-continuation";
 import type { Env } from "./types";
 
 const upstreamUrl = "https://chatgpt.com/backend-api/codex/responses";
@@ -58,34 +59,48 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
       || (body.stream !== undefined && typeof body.stream !== "boolean") || !validPrivateProtocolBody(body)
       || (body.max_output_tokens !== undefined && (typeof body.max_output_tokens !== "number" || !Number.isSafeInteger(body.max_output_tokens) || body.max_output_tokens <= 0))
       || !validPrivateHeaders(request.headers, id, body)) return privateError(400);
+    const continuations = upstream.fallbackTarget ? await privateContinuations(policy, upstream) : undefined;
+    let routed = { body, headers: request.headers, slot: 0, continuing: !!body.previous_response_id || request.headers.has("x-codex-turn-state") };
     try {
-      const affinity = request.headers.get("x-codex-turn-state");
-      if (affinity !== null) inspectPrivateOpaque(affinity, id, [upstream.target, upstream.accessToken, upstream.accountId]);
+      if (continuations) routed = await continuations.request(body, request.headers);
+      const affinity = routed.headers.get("x-codex-turn-state");
+      if (affinity !== null) inspectPrivateOpaque(affinity, id, [upstream.target, upstream.accessToken, upstream.accountId, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])]);
     } catch { return privateError(400); }
 
-    // Re-read both bindings after a potentially slow upload; no authorization/secret cache or retry.
-    const current = await privatePolicy(env);
-    if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return privateError(404);
-    const refreshed = await privateAuthorized(request, current);
-    if (!refreshed || !await privateAuthorizationCurrent(refreshed, current, env)) return privateError(404);
-    const freshUpstream = await privateUpstream(env, current);
-    if (!freshUpstream || JSON.stringify(freshUpstream) !== JSON.stringify(upstream)
-      || !await privateAuthorizationCurrent(refreshed, current, env) || freshUpstream.expiresAt <= Date.now() + 30_000) return privateError(404);
+    // Re-read both bindings after a potentially slow upload; never cache authorization.
+    if (!await upstreamCurrent(request, env, policy, upstream)) return privateError(404);
     const ignoredMaxOutputTokens = body.max_output_tokens !== undefined;
     // A fixed disclosure must not echo a runtime identity, including on transport failure.
-    if (ignoredMaxOutputTokens && [upstream.target, upstream.accountId, upstream.accessToken].some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
-    const headers = new Headers({ "content-type": "application/json", accept: body.stream === true ? "text/event-stream" : "application/json", "accept-encoding": "identity" });
-    forwardPrivateHeaders(request.headers, headers, id, upstream.target);
-    headers.set("authorization", `Bearer ${upstream.accessToken}`);
-    headers.set("chatgpt-account-id", upstream.accountId);
+    if (ignoredMaxOutputTokens && [upstream.target, upstream.accountId, upstream.accessToken, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])].some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
     // Do not manufacture originator, client metadata, review, or attestation evidence.
     const abort = new AbortController();
     const signal = AbortSignal.any([request.signal, abort.signal, AbortSignal.timeout(600_000)]);
     try {
-      const response = await fetch(upstreamUrl, {
-        method: "POST", headers, body: JSON.stringify(privateSubscriptionBody(body, upstream.target)), redirect: "manual", signal,
-      });
-      return await containResponse(response, id, upstream, body.stream === true, signal, () => abort.abort(), ignoredMaxOutputTokens);
+      const alternate = upstream.fallbackTarget
+        ? { ...upstream, target: upstream.fallbackTarget, fallbackTarget: upstream.target } : null;
+      // A continuation stays with the target that issued its opaque state.
+      const fallback = !routed.continuing ? alternate : null;
+      let selected = routed.slot === 1 && alternate ? alternate : upstream;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const headers = new Headers({ "content-type": "application/json", accept: body.stream === true ? "text/event-stream" : "application/json", "accept-encoding": "identity" });
+        forwardPrivateHeaders(routed.headers, headers, id, selected.target);
+        headers.set("authorization", `Bearer ${selected.accessToken}`);
+        headers.set("chatgpt-account-id", selected.accountId);
+        const response = await fetch(upstreamUrl, {
+          method: "POST", headers, body: JSON.stringify(privateSubscriptionBody(routed.body, selected.target)), redirect: "manual", signal,
+        });
+        if (attempt === 0 && fallback && await availabilityFailure(response, signal)) {
+          if (!await upstreamCurrent(request, env, policy, upstream) || signal.aborted) {
+            abort.abort();
+            return privateError(404);
+          }
+          selected = fallback;
+          continue;
+        }
+        const continuation = await continuations?.projection(selected === upstream ? 0 : 1);
+        return await containResponse(response, id, selected, body.stream === true, signal, () => abort.abort(), ignoredMaxOutputTokens, continuation);
+      }
+      throw new Error("private attempts exhausted");
     } catch {
       abort.abort();
       return privateError(502, ignoredMaxOutputTokens);
@@ -94,4 +109,28 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
     // Never pass private exceptions through the public logger or error formatter.
     return privateError(404);
   }
+}
+
+async function upstreamCurrent(request: Request, env: Env, policy: PrivatePolicy, upstream: PrivateUpstream): Promise<boolean> {
+  const current = await privatePolicy(env);
+  if (!current || JSON.stringify(current) !== JSON.stringify(policy)) return false;
+  const refreshed = await privateAuthorized(request, current);
+  if (!refreshed || !await privateAuthorizationCurrent(refreshed, current, env)) return false;
+  const fresh = await privateUpstream(env, current);
+  return !!fresh && JSON.stringify(fresh) === JSON.stringify(upstream)
+    && await privateAuthorizationCurrent(refreshed, current, env) && fresh.expiresAt > Date.now() + 30_000;
+}
+
+async function availabilityFailure(response: Response, signal: AbortSignal): Promise<boolean> {
+  if (![404, 429, 502, 503, 504].includes(response.status)) return false;
+  // Only explicit availability failures authorize another model. Never retry an
+  // auth, safety, entitlement, or quota denial, or a stream that has begun.
+  try {
+    const value = await boundedJson(response.body, 64 * 1024, signal);
+    if (!record(value) || !record(value.error)) return false;
+    const code = value.error.code ?? value.error.type;
+    if (response.status === 404) return code === "model_not_found";
+    if (response.status === 429) return code === "rate_limit_exceeded";
+    return ["server_error", "service_unavailable", "overloaded_error", "timeout"].includes(String(code));
+  } catch { return false; }
 }

--- a/worker/test/private-codex-fallback.test.mjs
+++ b/worker/test/private-codex-fallback.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { default: worker } = await import("../index.ts");
+const { sha256Hex } = await import("../utils.ts");
+const target = "SYNTHETIC_PRIMARY_TARGET", fallbackTarget = "SYNTHETIC_FALLBACK_TARGET";
+const credential = "private-workload-SYNTHETIC_ISOLATED_CREDENTIAL_123456789";
+const alias = "internal";
+
+async function fixture() {
+  const policy = { version: 1, enabled: true, alias: { id: alias, name: "Codex" }, auth: { mode: "workload", credentialSha256: await sha256Hex(credential) } };
+  const upstream = { version: 1, target, fallbackTarget, accountId: "SYNTHETIC_ACCOUNT", accessToken: "SYNTHETIC_SUBSCRIPTION_TOKEN", expiresAt: Date.now() + 3600_000 };
+  const env = { PRIVATE_CODEX_POLICY: { get: async () => JSON.stringify(policy) }, PRIVATE_CODEX_UPSTREAM: { get: async () => JSON.stringify(upstream) } };
+  const run = (body = {}, headers = {}) => worker.fetch(new Request("https://private.invalid/private/v1/responses", {
+    method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json", ...headers },
+    body: JSON.stringify({ model: alias, store: false, input: "Synthetic input", ...body }),
+  }), env, { waitUntil() { assert.fail("Private calls do not enqueue generic accounting"); } });
+  return { policy, upstream, env, run };
+}
+
+const failed = (status, code) => Response.json({ error: { code, message: `${target} ${fallbackTarget}` } }, { status });
+const completed = (model, output = []) => Response.json({ id: "synthetic-response", object: "response", model, status: "completed", output }, { headers: { "OpenAI-Model": model, "x-codex-turn-state": "synthetic-upstream-affinity" } });
+function contained(value) { for (const secret of [target, fallbackTarget, "SYNTHETIC_ACCOUNT", "SYNTHETIC_SUBSCRIPTION_TOKEN"]) assert.equal(value.includes(secret), false); }
+
+test("private fallback stays on the fixed account, rewrites hints, and returns one alias", async (context) => {
+  for (const [status, code] of [[404, "model_not_found"], [429, "rate_limit_exceeded"], [503, "overloaded_error"]]) {
+    const { run } = await fixture(); const calls = [];
+    context.mock.method(globalThis, "fetch", async (url, options) => {
+      assert.equal(url, "https://chatgpt.com/backend-api/codex/responses");
+      const body = JSON.parse(options.body); calls.push(body);
+      assert.equal(options.headers.get("x-codex-routing-hint"), `model=${body.model};tier=priority`);
+      assert.equal(options.headers.get("authorization"), "Bearer SYNTHETIC_SUBSCRIPTION_TOKEN");
+      return calls.length === 1 ? failed(status, code) : completed(fallbackTarget);
+    });
+    const result = await run({ service_tier: "priority" }, { "x-codex-routing-hint": `model=${alias};tier=priority` });
+    assert.equal(result.status, 200); assert.equal(result.headers.get("openai-model"), alias);
+    const body = await result.text(); contained(body); assert.equal(JSON.parse(body).model, alias);
+    assert.deepEqual(calls.map(x => x.model), [target, fallbackTarget]);
+    assert.deepEqual({ ...calls[0], model: alias }, { ...calls[1], model: alias });
+    context.mock.restoreAll();
+  }
+});
+
+test("private fallback never retries auth, policy, quota, transport, or successful streaming responses", async (context) => {
+  for (const makeResponse of [
+    () => failed(401, "unauthorized"), () => failed(403, "misalignment_policy_violation"),
+    () => failed(429, "insufficient_quota"), () => failed(503, "cyber_policy"),
+    () => { throw new Error(target); },
+    () => new Response('data: {"type":"error","message":"synthetic failure"}\n\n', { headers: { "content-type": "text/event-stream" } }),
+  ]) {
+    const { run } = await fixture(); let calls = 0;
+    context.mock.method(globalThis, "fetch", async () => { calls++; return makeResponse(); });
+    const result = await run({ stream: true }); contained(await result.text()); assert.equal(calls, 1);
+    context.mock.restoreAll();
+  }
+});
+
+test("private fallback is bounded and refuses server-side continuation or affinity", async (context) => {
+  for (const [body, headers, expected] of [[{}, {}, 2], [{ previous_response_id: "synthetic-response" }, {}, 1], [{}, { "x-codex-turn-state": "synthetic-affinity" }, 1]]) {
+    const { run } = await fixture(); let calls = 0;
+    context.mock.method(globalThis, "fetch", async () => { calls++; return failed(429, "rate_limit_exceeded"); });
+    const result = await run(body, headers); assert.equal(result.status, 429); contained(await result.text()); assert.equal(calls, expected);
+    context.mock.restoreAll();
+  }
+});
+
+test("private fallback revalidates revocation and configuration before a second call", async (context) => {
+  for (const change of [x => { x.policy.enabled = false; }, x => { x.upstream.fallbackTarget = "SYNTHETIC_ROTATED_TARGET"; }, x => { x.upstream.expiresAt = 1; }]) {
+    const state = await fixture(); let calls = 0;
+    context.mock.method(globalThis, "fetch", async () => { calls++; change(state); return failed(503, "server_error"); });
+    const result = await state.run(); assert.equal(result.status, 404); contained(await result.text()); assert.equal(calls, 1);
+    context.mock.restoreAll();
+  }
+});
+
+test("both configured identities stay sensitive on either successful target", async (context) => {
+  for (const fallback of [false, true]) {
+    const { run } = await fixture(); let calls = 0;
+    context.mock.method(globalThis, "fetch", async () => {
+      if (++calls === 1 && fallback) return failed(503, "server_error");
+      return completed(fallback ? fallbackTarget : target, [{ type: "message", content: [{ type: "output_text", text: fallback ? target : fallbackTarget }] }]);
+    });
+    const result = await run(); assert.equal(result.status, 502); contained(await result.text());
+    context.mock.restoreAll();
+  }
+});
+
+test("invalid private fallback configuration fails before upstream", async (context) => {
+  for (const invalid of [null, "", target, [], "invalid/model"]) {
+    const { run, upstream } = await fixture(); upstream.fallbackTarget = invalid;
+    let calls = 0; context.mock.method(globalThis, "fetch", async () => { calls++; return completed(target); });
+    assert.equal((await run()).status, 404); assert.equal(calls, 0);
+    context.mock.restoreAll();
+  }
+});
+
+test("fallback response IDs and affinity keep subsequent tool turns on their originating target", async (context) => {
+  const { run } = await fixture(); const calls = [];
+  context.mock.method(globalThis, "fetch", async (_, options) => {
+    const body = JSON.parse(options.body); calls.push({ body, affinity: options.headers.get("x-codex-turn-state") });
+    return calls.length === 1 ? failed(503, "server_error") : completed(fallbackTarget);
+  });
+  const first = await run(); const affinity = first.headers.get("x-codex-turn-state");
+  const previous = (await first.json()).id;
+  assert.match(previous, /^cr1\./); assert.match(affinity, /^cr1\./);
+  contained(previous + affinity);
+  const second = await run({ previous_response_id: previous }, { "x-codex-turn-state": affinity });
+  assert.equal(second.status, 200); contained(await second.text());
+  assert.deepEqual(calls.map(x => x.body.model), [target, fallbackTarget, fallbackTarget]);
+  assert.equal(calls[2].body.previous_response_id, "synthetic-response");
+  assert.equal(calls[2].affinity, "synthetic-upstream-affinity");
+});
+
+test("private continuation tampering, rotation, and conflicting origins fail before upstream", async (context) => {
+  const state = await fixture(); let calls = 0;
+  context.mock.method(globalThis, "fetch", async () => { calls++; return completed(target); });
+  const first = await state.run(); const primary = (await first.json()).id;
+  const { privateContinuations } = await import("../private-codex-continuation.ts");
+  const codec = await privateContinuations(state.policy, state.upstream);
+  const fallback = await (await codec.projection(1)).wrap("synthetic-affinity");
+  assert.equal((await state.run({ previous_response_id: primary }, { "x-codex-turn-state": fallback })).status, 400);
+  const parts = primary.split("."); parts[1] = (parts[1][0] === "A" ? "B" : "A") + parts[1].slice(1);
+  assert.equal((await state.run({ previous_response_id: parts.join(".") })).status, 400);
+  assert.equal((await state.run({ previous_response_id: fallback + "." + Buffer.from("synthetic-response").toString("base64url") })).status, 400);
+  const payload = Buffer.from(fallback.slice(4), "base64url"); payload[payload.length - 1] ^= 1;
+  assert.equal((await state.run({ previous_response_id: "cr1." + payload.toString("base64url") })).status, 400);
+  state.upstream.accessToken = "SYNTHETIC_ROTATED_SUBSCRIPTION_TOKEN";
+  assert.equal((await state.run({ previous_response_id: primary })).status, 400);
+  assert.equal(calls, 1);
+});
+
+test("streaming fallback wraps typed response state consistently without touching tool identities", async (context) => {
+  const { run } = await fixture(); const calls = [];
+  context.mock.method(globalThis, "fetch", async (_, options) => {
+    calls.push(JSON.parse(options.body));
+    if (calls.length === 1) return failed(503, "server_error");
+    const response = { id: "resp-synthetic", model: fallbackTarget, status: "completed", previous_response_id: "resp-before", output: [] };
+    const events = [
+      { type: "response.created", response: { ...response, status: "in_progress" } },
+      { type: "response.output_item.done", response_id: "resp-synthetic", item: { type: "function_call", id: "tool-synthetic", call_id: "call-synthetic", name: "synthetic_tool", arguments: "{}" }, output_index: 0 },
+      { type: "response.completed", response },
+    ];
+    return new Response(events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(""), { headers: { "content-type": "text/event-stream", "x-codex-turn-state": "affinity-synthetic" } });
+  });
+  const result = await run({ stream: true });
+  const raw = await result.text(); contained(raw);
+  const events = raw.trim().split("\n\n").map(frame => JSON.parse(frame.split("data: ")[1]));
+  assert.equal(events.length, 3);
+  const id = events[0].response.id;
+  assert.match(id, /^cr1\./); assert.equal(events[1].response_id, id); assert.equal(events[2].response.id, id);
+  assert.match(events[2].response.previous_response_id, /^cr1\./);
+  assert.equal(events[1].item.call_id, "call-synthetic"); assert.equal(events[1].item.id, "tool-synthetic");
+  const next = await run({ stream: true, previous_response_id: id }, { "x-codex-turn-state": result.headers.get("x-codex-turn-state") });
+  assert.equal(next.status, 200); await next.text();
+  assert.equal(calls[2].model, fallbackTarget); assert.equal(calls[2].previous_response_id, "resp-synthetic");
+});


### PR DESCRIPTION
The isolated private inference facade can now try one owner-configured alternative after a recognized availability failure. Authentication, policy, quota, transport, and started-stream failures remain terminal. Both attempts use the same fixed subscription account and deadline, revalidate both bindings before retrying, and expose only the configured alias.

Response IDs and turn-state headers use authenticated encrypted continuation envelopes when fallback is enabled. Later tool turns return to the target that issued that state. The envelope binds the original state and route to the current policy, account, credential, and target mapping; tampering, conflicting state, or rotation fails closed. Both configured target identities remain covered by output containment. Existing single-target deployments preserve their current wire behavior.

Validation: 273 Worker tests and TypeScript checks pass, including synthetic fallback, denial, revocation, rotation, tampering, streaming, and continuation cases. A separate E2E run against the actual Worker runtime with native Secrets Store bindings passes fallback, SSE containment, continuation, and revocation. Independent autoreview is clean after correcting continuation handling. A pinned native client completed an actual upstream shell-tool exchange with a synthetic initial availability failure and confirmed the next turn stayed on the alternate route without leaking configured identities or upstream credentials.

Deployment: optional and not enabled by this PR. Owners must verify entitlement and compatible native capabilities for both configured targets. The isolated broker still requires an owner-managed upstream credential lifecycle; credential or routing rotation invalidates wrapped continuation state.
