### PR TITLE
fix(proxy): preserve binary response backpressure

### DIFF
--- a/scripts/smoke-local-worker.mjs
+++ b/scripts/smoke-local-worker.mjs
@@ -59,6 +59,11 @@ const upstreamServer = createHttpServer(async (request, response) => {
   const body = JSON.parse(raw);
   upstreamCalls.push(body);
   const authorization = request.headers.authorization ?? "";
+  if (body.messages?.[0]?.content === "synthetic binary response") {
+    response.writeHead(200, { "content-type": "application/octet-stream" });
+    response.end(Buffer.from(Array.from({ length: 65536 }, (_, index) => index % 256)));
+    return;
+  }
   if (body.model === "default" && authorization === "Bearer rate-limited") {
     failoverCalls.push(authorization);
     response.writeHead(429, { "content-type": "application/json", "retry-after": "120", "x-ratelimit-limit-requests": "100", "x-ratelimit-remaining-requests": "0", "x-ratelimit-reset-requests": "120" });
@@ -767,6 +772,13 @@ try {
   assert.deepEqual(await unmeteredConnection.json(), { providerId: "local-openai", enabled: true, label: null, monthlyBudgetMicros: null });
   assert.equal((await rotationRequest()).status, 200, "clearing the provider budget restores requests");
   assert.doesNotMatch(output, /private prompt sentinel|private tool sentinel|invalid trace private sentinel|secret_1234|rotation123/i, "Worker logs remain metadata-only");
+  const binary = await fetch(`${base}/v1/chat/completions`, {
+    method: "POST", headers: { authorization: `Bearer ${rotationKey}`, "content-type": "application/json" },
+    body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "synthetic binary response" }] }),
+  });
+  assert.equal(binary.status, 200);
+  assert.equal(binary.headers.get("content-type"), "application/octet-stream");
+  assert.deepEqual(new Uint8Array(await binary.arrayBuffer()), Uint8Array.from({ length: 65536 }, (_, index) => index % 256));
   console.log(`local Worker smoke passed on ${base}`);
   if (process.env.CLAWROUTER_E2E_HOLD_FILE) {
     writeFileSync(process.env.CLAWROUTER_E2E_HOLD_FILE, `${JSON.stringify({ base, adminToken, rotationKey, noFailoverKey })}\n`, { mode: 0o600 });

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -387,8 +387,18 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     return errorResponse("provider_unavailable", `upstream request to provider ${selection.provider.id} failed`, 502, undefined);
   }
   clearTimeout(timeout);
-  const clone = response.clone();
-  context.waitUntil(finalizeResponse(clone, env, auth, selection, request, requestId, started, cost, reservation, content, compound));
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("json") || contentType.includes("text/event-stream")) {
+    context.waitUntil(finalizeResponse(response.clone(), env, auth, selection, request, requestId, started, cost, reservation, content, compound));
+  } else {
+    // Draining a tee for accounting buffers the entire binary transfer behind a
+    // slow client. Observe its completion without creating a second consumer.
+    const upstreamResponse = response;
+    let completed!: () => void;
+    const completion = new Promise<void>(resolve => { completed = resolve; });
+    response = observeResponseBody(response, completed);
+    context.waitUntil(completion.then(() => finalizeResponse(upstreamResponse, env, auth, selection, request, requestId, started, cost, reservation, content, compound)));
+  }
   const outputHeaders = new Headers(response.headers);
   for (const name of ["connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "set-cookie", "trailer", "transfer-encoding", "upgrade"]) outputHeaders.delete(name);
   outputHeaders.set("x-clawrouter-upstream-provider", selection.provider.id);
@@ -653,7 +663,6 @@ async function finalizeResponse(response: Response, env: Env, auth: AuthorizedId
     const contentType = response.headers.get("content-type") ?? "";
     if (contentType.includes("json")) tokens = extractUsageTokens(JSON.parse(await readLimited(response, 2 * 1024 * 1024)));
     else if (contentType.includes("text/event-stream")) tokens = extractSseUsageTokens(await readLimited(response, 2 * 1024 * 1024));
-    else await drainResponseBody(response.body);
   } catch { /* usage is best-effort; reservation stays conservative */ }
   const measured = tokens ? actualCost(selection.model, tokens, auth.policy.requestCostMicros) : null;
   const actual = response.ok && measured != null ? measured : response.ok ? estimated.reserveMicros : 0;
@@ -716,17 +725,22 @@ async function readLimited(response: Response, limit: number): Promise<string> {
   } finally { if (size > limit) await reader.cancel(); }
 }
 
-export async function drainResponseBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
-  if (!body) return;
-  const reader = body.getReader();
-  try {
-    while (!(await reader.read()).done) { /* discard without buffering the cloned stream */ }
-  } catch (error) {
-    await reader.cancel().catch(() => undefined);
-    throw error;
-  } finally {
-    reader.releaseLock();
-  }
+function observeResponseBody(response: Response, complete: () => void): Response {
+  if (!response.body) { complete(); return response; }
+  const reader = response.body.getReader();
+  let finished = false;
+  const finish = () => { if (!finished) { finished = true; reader.releaseLock(); complete(); } };
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const next = await reader.read();
+        if (next.done) { finish(); controller.close(); }
+        else controller.enqueue(next.value);
+      } catch (error) { finish(); controller.error(error); }
+    },
+    async cancel(reason) { try { await reader.cancel(reason); } finally { finish(); } },
+  }, { highWaterMark: 0 });
+  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
 }
 
 function searchParamsRecord(params: URLSearchParams): Record<string, string> { const result: Record<string, string> = {}; params.forEach((value, key) => { result[key] = value; }); return result; }

--- a/worker/test/aws-bedrock.test.mjs
+++ b/worker/test/aws-bedrock.test.mjs
@@ -23,7 +23,7 @@ registerHooks({
     return nextResolve(specifier, context);
   },
 });
-const { drainResponseBody, prepareManifestRequest } = await import("../proxy.ts");
+const { prepareManifestRequest } = await import("../proxy.ts");
 
 const provider = providerById("aws-bedrock");
 assert.ok(provider);
@@ -220,22 +220,4 @@ test("AWS Bedrock SigV4 does not fill an incomplete selected grant from global s
       error?.code === "provider_not_configured" &&
       /selected AWS grant must contain accessKeyId and secretAccessKey/.test(error.message),
   );
-});
-
-test("binary Bedrock response clones are drained without buffering", async () => {
-  let pulls = 0;
-  const body = new ReadableStream(
-    {
-      pull(controller) {
-        pulls += 1;
-        if (pulls <= 2) controller.enqueue(Uint8Array.of(pulls));
-        else controller.close();
-      },
-    },
-    { highWaterMark: 0 },
-  );
-
-  await drainResponseBody(body);
-  assert.equal(pulls, 3);
-  await drainResponseBody(null);
 });

--- a/worker/test/usage-budget.test.mjs
+++ b/worker/test/usage-budget.test.mjs
@@ -58,6 +58,44 @@ function usageEnv(objectNames, { provider = "openai", limit = 100, fixedCost = 1
 
 function proxyKey() { return ["clawrouter", "live", `maintainer_key-${keyMaterial}`].join("-"); }
 
+test("binary proxy accounting preserves backpressure and settles on completion, error, or cancellation", async (t) => {
+  for (const outcome of ["complete", "error", "cancel"]) {
+    const env = usageEnv([], { provider: "local-openai", limit: null, retainContent: false });
+    env.LOCAL_OPENAI_BASE_URL = "https://upstream.example.invalid";
+    const events = []; env.USAGE_QUEUE = { send: async event => { events.push(event); } };
+    let pulls = 0, canceled = false;
+    const bytes = Uint8Array.from({ length: 32 }, (_, i) => i);
+    const source = new ReadableStream({
+      pull(controller) {
+        if (outcome === "error" && pulls === 1) controller.error(new Error("synthetic upstream failure"));
+        else if (pulls < bytes.length) controller.enqueue(bytes.slice(pulls, ++pulls));
+        else controller.close();
+      },
+      cancel() { canceled = true; },
+    }, { highWaterMark: 0 });
+    t.mock.method(globalThis, "fetch", async () => new Response(source, { headers: { "content-type": "application/vnd.amazon.eventstream" } }));
+    const pending = [];
+    const response = await handler.fetch(new Request("https://clawrouter.example/v1/chat/completions", {
+      method: "POST", headers: { authorization: `Bearer ${proxyKey()}`, "content-type": "application/json" },
+      body: JSON.stringify({ model: "local/default", messages: [{ role: "user", content: "synthetic input" }] }),
+    }), env, { waitUntil: promise => pending.push(promise) });
+    try {
+      assert.equal(response.status, 200);
+      await new Promise(resolve => setImmediate(resolve));
+      assert.equal(pulls, 0, "accounting must not drain a stalled client's binary stream");
+      assert.equal(events.length, 0);
+      if (outcome === "cancel") await response.body.cancel();
+      else if (outcome === "error") await assert.rejects(response.arrayBuffer(), /synthetic upstream failure/);
+      else assert.deepEqual(new Uint8Array(await response.arrayBuffer()), bytes);
+      await Promise.all(pending);
+      assert.equal(canceled, outcome === "cancel"); assert.equal(events.length, 1); assert.equal(events[0].actual_cost_micros, 1);
+    } finally {
+      if (!response.body.locked) await response.body.cancel().catch(() => {});
+      t.mock.restoreAll();
+    }
+  }
+});
+
 async function sha256(value) {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");


### PR DESCRIPTION
Binary proxy responses previously created a second stream consumer for accounting. That consumer drained the upstream independently of the client, allowing the tee to buffer the entire response behind a slow reader.

Observe the client-facing stream instead. It preserves backpressure and records conservative accounting once the transfer finishes, errors, or is canceled. JSON and SSE usage extraction retain their existing path. The obsolete drain helper and its misleading helper-only test are removed.

Validation: Worker TypeScript and all Worker tests pass. The regression exercises the actual proxy handler with a stalled client, byte-for-byte completion, upstream failure, and cancellation. The real local Worker E2E also passes with a binary transfer, and independent autoreview has no actionable findings.

Deployment: code change only; no configuration or provider catalog change. Binary usage remains conservatively estimated because the gateway does not parse provider-specific binary usage frames.
