### PR TITLE
feat(private): support explicitly configured API transport

### DIFF
--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -4,14 +4,14 @@ This opt-in, bounded Responses facade is for a **separately isolated, owner-only
 OpenClaw Gateway or Codex runtime**. It is not per-user security for a shared
 Gateway. Production Team must not receive these bindings or credentials. Shared
 agents must have no access to the private ingress credential, process, workspace,
-session namespace, or upstream subscription. Use a separate deployment and
+session namespace, or upstream credentials. Use a separate deployment and
 administrative trust boundary; a deployment operator can change its code or
 bindings and is necessarily trusted. Include owner-authenticated browser profiles
 and remote-node/tool capabilities in that boundary: shared agents must not be able
 to drive a browser carrying the owner's session or administer the private cell.
 
 Nothing in this implementation provisions that isolation. Local synthetic tests
-do not prove live subscription entitlement, client compatibility, owner-only
+do not prove live upstream entitlement, client compatibility, owner-only
 ingress, or OS/process isolation. In particular, `/responses` support does not
 establish native Codex integration.
 
@@ -159,7 +159,8 @@ proxy or account-selection endpoint. Caller `ChatGPT-Account-ID` and custom
 account headers are rejected in both modes. Only the broker constructs the
 upstream account header from its fixed authenticated binding.
 
-`PRIVATE_CODEX_UPSTREAM` has these required fields and one optional fallback:
+`PRIVATE_CODEX_UPSTREAM` explicitly selects one credential and transport. The
+original subscription shape remains supported when `transport` is absent:
 
 | Field | Contract |
 | --- | --- |
@@ -170,21 +171,32 @@ upstream account header from its fixed authenticated binding.
 | `accessToken` | Separately held subscription access token; 16–8192 ASCII letters/digits/`.`/`_`/`~`/`-` |
 | `expiresAt` | Integer Unix **milliseconds**, at least 30 seconds in the future |
 
+For OpenAI API access, the document has exactly `version: 1`,
+`transport: "openai-api"`, `target`, and `apiKey`, plus an optional
+`fallbackTarget`. Target syntax is unchanged. The API key is 16–8192 ASCII
+letters/digits/`.`/`_`/`~`/`-`; subscription account, token, and expiry fields
+are rejected in this mode. The destination is fixed to
+`https://api.openai.com/v1/responses`, with no subscription account header.
+The API transport preserves `max_output_tokens` and genuine native client,
+Lite, review, and safety facts. Verify API entitlement and native compatibility
+before provisioning it. API usage is billed normally by the provider; this
+private facade does not write the shared usage ledger.
+
 The alias ID is 3–64 lowercase ASCII letters/digits/hyphens, beginning with a
 letter. Its display name is 1–80 printable ASCII characters. Use the safe values
-shown above. Neither may contain the target, account ID, or upstream token.
+shown above. Neither may contain the target, account ID, or upstream credential.
 Both binding documents are limited to 16 KiB of text. Missing, disabled, malformed,
 expired, inaccessible, or mid-request changed configuration fails closed.
 
 The upstream binding is read **only after authentication**, including on private
-discovery. The adapter sends exactly that account and token to the fixed
-subscription Responses URL already declared by the OpenAI provider manifest.
+discovery. The adapter sends exactly the configured credential to the selected
+transport's fixed Responses URL. Subscription mode also sends its fixed account.
 No caller can change the provider, account, origin, or configured targets. There
-are no redirects, alternate accounts, API-key fallbacks, generic grant lookups,
+are no redirects, alternate accounts, cross-transport fallbacks, generic grant lookups,
 Fusion paths, or arbitrary-model/native routing inside this facade.
 
 When `fallbackTarget` is configured, the broker may make one additional call on
-the same fixed subscription after an explicit HTTP availability failure:
+the same fixed transport and credential after an explicit HTTP availability failure:
 `404 model_not_found`, `429 rate_limit_exceeded`, or a 502/503/504 carrying
 `server_error`, `service_unavailable`, `overloaded_error`, or `timeout`. Unknown
 errors, authentication, safety, entitlement and exhausted-quota denials are
@@ -194,7 +206,7 @@ on the target that issued their state and cannot fail over again.
 
 With fallback configured, typed response IDs and turn-state headers carry an
 opaque broker route envelope. An authenticated encrypted slot binds them to the
-current policy, target mapping, account, and upstream credential. It contains no
+current policy, target mapping, transport, account, and upstream credential. It contains no
 model name. The broker restores the original upstream values on the next call;
 it does not manufacture upstream signatures or attestations. Unwrapped legacy
 state remains primary-only, conflicting origins and tampering fail closed, and
@@ -211,7 +223,7 @@ target. Provisioning must verify entitlement and compatible native capabilities
 for both targets. The fallback does not invent compatibility or bypass upstream
 requirements.
 
-Automatic OAuth refresh is intentionally absent. The existing shared refresh
+For subscription mode, automatic OAuth refresh is intentionally absent. The existing shared refresh
 helper writes shared grant state and does not provide this boundary's required
 revocation/rotation transaction. The parent must provide an owner-only lifecycle
 that atomically replaces this private token/account/expiry document, or accept
@@ -224,7 +236,8 @@ already transmitted requests/streams.
 Broker token rotation does not require changing the independent client workload
 credential or exposing the new token to clients. Changes during a request's
 upload still fail closed. Binding expiry must reflect the real token lifetime;
-provider expiry/revocation denials remain denials.
+provider expiry/revocation denials remain denials. API keys have no locally
+invented expiry; their provider revocation and authorization denials are terminal.
 
 ## Endpoints and client contract
 

--- a/worker/private-codex-config.ts
+++ b/worker/private-codex-config.ts
@@ -13,13 +13,32 @@ export interface PrivatePolicy {
 
 const reasoningEfforts: readonly ProviderReasoningEffort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
 
-export interface PrivateUpstream {
+interface PrivateRoute {
   version: 1;
   target: string;
   fallbackTarget?: string;
+}
+
+export type PrivateUpstream = PrivateRoute & ({
+  transport?: undefined;
   accountId: string;
   accessToken: string;
   expiresAt: number;
+} | {
+  transport: "openai-api";
+  apiKey: string;
+});
+
+export function privateCredential(upstream: PrivateUpstream): string {
+  return upstream.transport === "openai-api" ? upstream.apiKey : upstream.accessToken;
+}
+
+export function privateSensitive(upstream: PrivateUpstream): string[] {
+  return [upstream.target, privateCredential(upstream), ...(upstream.transport === "openai-api" ? [] : [upstream.accountId]), ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])];
+}
+
+export function privateUpstreamActive(upstream: PrivateUpstream): boolean {
+  return upstream.transport === "openai-api" || upstream.expiresAt > Date.now() + 30_000;
 }
 
 export function record(value: unknown): value is Record<string, unknown> {
@@ -132,16 +151,20 @@ export async function privateAuthorizationCurrent(authorization: PrivateAuthoriz
 export async function privateUpstream(env: Env, policy: PrivatePolicy): Promise<PrivateUpstream | null> {
   const value = await bindingJson(env.PRIVATE_CODEX_UPSTREAM);
   if (!record(value)) return null;
-  const keys = ["version", "target", "accountId", "accessToken", "expiresAt"];
+  const api = value.transport === "openai-api";
+  const keys = api ? ["version", "target", "transport", "apiKey"] : ["version", "target", "accountId", "accessToken", "expiresAt"];
   if (Object.hasOwn(value, "fallbackTarget")) keys.push("fallbackTarget");
   if (!exactKeys(value, keys) || value.version !== 1
-    || typeof value.target !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.target)
-    || typeof value.accountId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(value.accountId)
+    || typeof value.target !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.target)) return null;
+  if (api) {
+    if (typeof value.apiKey !== "string" || !/^[A-Za-z0-9._~-]{16,8192}$/.test(value.apiKey)) return null;
+  } else if (typeof value.accountId !== "string" || !/^[A-Za-z0-9_-]{8,128}$/.test(value.accountId)
     || typeof value.accessToken !== "string" || !/^[A-Za-z0-9._~-]{16,8192}$/.test(value.accessToken)
     || typeof value.expiresAt !== "number" || !Number.isSafeInteger(value.expiresAt) || value.expiresAt <= Date.now() + 30_000) return null;
   if (Object.hasOwn(value, "fallbackTarget") && (typeof value.fallbackTarget !== "string"
     || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.fallbackTarget) || value.fallbackTarget === value.target)) return null;
-  const sensitive = [value.target, value.accountId, value.accessToken, ...(typeof value.fallbackTarget === "string" ? [value.fallbackTarget] : [])];
+  const upstream = value as unknown as PrivateUpstream;
+  const sensitive = privateSensitive(upstream);
   if (sensitive.some((secret) => policy.alias.id.includes(secret) || policy.alias.name.includes(secret))) return null;
-  return value as unknown as PrivateUpstream;
+  return upstream;
 }

--- a/worker/private-codex-continuation.ts
+++ b/worker/private-codex-continuation.ts
@@ -1,4 +1,4 @@
-import type { PrivatePolicy, PrivateUpstream } from "./private-codex-config";
+import { privateCredential, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
 
 const prefix = "cr1.";
 const encoder = new TextEncoder();
@@ -9,8 +9,9 @@ export interface PrivateContinuationProjection { wrap(value: unknown): Promise<s
 // Bind original upstream state to its route without revealing the target. This
 // envelope never replaces upstream verification of its own restored state.
 export async function privateContinuations(policy: PrivatePolicy, upstream: PrivateUpstream) {
-  const key = await crypto.subtle.importKey("raw", await crypto.subtle.digest("SHA-256", encoder.encode("clawrouter:continuation:v1\0" + upstream.accessToken)), "AES-GCM", false, ["encrypt", "decrypt"]);
-  const additionalData = encoder.encode(JSON.stringify([policy, upstream.target, upstream.fallbackTarget, upstream.accountId]));
+  const key = await crypto.subtle.importKey("raw", await crypto.subtle.digest("SHA-256", encoder.encode("clawrouter:continuation:v1\0" + privateCredential(upstream))), "AES-GCM", false, ["encrypt", "decrypt"]);
+  const identity = upstream.transport === "openai-api" ? [upstream.transport] : upstream.accountId;
+  const additionalData = encoder.encode(JSON.stringify([policy, upstream.target, upstream.fallbackTarget, identity]));
 
   async function unwrap(value: string): Promise<{ slot: number; value: string }> {
     if (!value.startsWith(prefix)) return { slot: 0, value };

--- a/worker/private-codex-response.ts
+++ b/worker/private-codex-response.ts
@@ -1,4 +1,4 @@
-import { record, type PrivateUpstream } from "./private-codex-config";
+import { privateSensitive, record, type PrivateUpstream } from "./private-codex-config";
 import { privateResponseHeaders } from "./private-codex-protocol";
 import type { PrivateContinuationProjection } from "./private-codex-continuation";
 
@@ -37,7 +37,7 @@ export class PrivateResponseProjection {
     this.alias = alias;
     this.continuation = continuation;
     this.target = upstream.target;
-    this.sensitive = [upstream.target, upstream.accessToken, upstream.accountId, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])];
+    this.sensitive = privateSensitive(upstream);
   }
 
   get sensitiveValues(): readonly string[] { return this.sensitive; }

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -1,11 +1,12 @@
 import { boundedJson } from "./private-codex-io";
-import { privateAuthorizationCurrent, privateAuthorized, privatePolicy, privateUpstream, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
+import { privateAuthorizationCurrent, privateAuthorized, privateCredential, privatePolicy, privateSensitive, privateUpstream, privateUpstreamActive, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
 import { containResponse, privateError, privateJson } from "./private-codex-output";
 import { forwardPrivateHeaders, inspectPrivateOpaque, validPrivateHeaders, validPrivateProtocolBody } from "./private-codex-protocol";
 import { privateContinuations } from "./private-codex-continuation";
 import type { Env } from "./types";
 
 const upstreamUrl = "https://chatgpt.com/backend-api/codex/responses";
+const apiUrl = "https://api.openai.com/v1/responses";
 const requestFields = new Set([
   "model", "input", "instructions", "stream", "store", "tools", "tool_choice", "parallel_tool_calls", "reasoning", "text",
   "include", "max_output_tokens", "temperature", "top_p", "truncation", "metadata", "previous_response_id",
@@ -39,7 +40,7 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
 
     // Target/account/credential resolution happens only inside this authenticated boundary.
     const upstream = await privateUpstream(env, policy);
-    if (!upstream || !await privateAuthorizationCurrent(authorization, policy, env) || upstream.expiresAt <= Date.now() + 30_000) return privateError(404);
+    if (!upstream || !await privateAuthorizationCurrent(authorization, policy, env) || !privateUpstreamActive(upstream)) return privateError(404);
     const { id, name } = policy.alias;
     if (discovery) {
       if (request.body) return privateError(400);
@@ -64,14 +65,14 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
     try {
       if (continuations) routed = await continuations.request(body, request.headers);
       const affinity = routed.headers.get("x-codex-turn-state");
-      if (affinity !== null) inspectPrivateOpaque(affinity, id, [upstream.target, upstream.accessToken, upstream.accountId, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])]);
+      if (affinity !== null) inspectPrivateOpaque(affinity, id, privateSensitive(upstream));
     } catch { return privateError(400); }
 
     // Re-read both bindings after a potentially slow upload; never cache authorization.
     if (!await upstreamCurrent(request, env, policy, upstream)) return privateError(404);
-    const ignoredMaxOutputTokens = body.max_output_tokens !== undefined;
+    const ignoredMaxOutputTokens = upstream.transport !== "openai-api" && body.max_output_tokens !== undefined;
     // A fixed disclosure must not echo a runtime identity, including on transport failure.
-    if (ignoredMaxOutputTokens && [upstream.target, upstream.accountId, upstream.accessToken, ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])].some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
+    if (ignoredMaxOutputTokens && privateSensitive(upstream).some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
     // Do not manufacture originator, client metadata, review, or attestation evidence.
     const abort = new AbortController();
     const signal = AbortSignal.any([request.signal, abort.signal, AbortSignal.timeout(600_000)]);
@@ -84,10 +85,12 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
       for (let attempt = 0; attempt < 2; attempt++) {
         const headers = new Headers({ "content-type": "application/json", accept: body.stream === true ? "text/event-stream" : "application/json", "accept-encoding": "identity" });
         forwardPrivateHeaders(routed.headers, headers, id, selected.target);
-        headers.set("authorization", `Bearer ${selected.accessToken}`);
-        headers.set("chatgpt-account-id", selected.accountId);
-        const response = await fetch(upstreamUrl, {
-          method: "POST", headers, body: JSON.stringify(privateSubscriptionBody(routed.body, selected.target)), redirect: "manual", signal,
+        headers.set("authorization", `Bearer ${privateCredential(selected)}`);
+        const api = selected.transport === "openai-api";
+        if (selected.transport !== "openai-api") headers.set("chatgpt-account-id", selected.accountId);
+        const outgoing = api ? { ...routed.body, model: selected.target } : privateSubscriptionBody(routed.body, selected.target);
+        const response = await fetch(api ? apiUrl : upstreamUrl, {
+          method: "POST", headers, body: JSON.stringify(outgoing), redirect: "manual", signal,
         });
         if (attempt === 0 && fallback && await availabilityFailure(response, signal)) {
           if (!await upstreamCurrent(request, env, policy, upstream) || signal.aborted) {
@@ -118,7 +121,7 @@ async function upstreamCurrent(request: Request, env: Env, policy: PrivatePolicy
   if (!refreshed || !await privateAuthorizationCurrent(refreshed, current, env)) return false;
   const fresh = await privateUpstream(env, current);
   return !!fresh && JSON.stringify(fresh) === JSON.stringify(upstream)
-    && await privateAuthorizationCurrent(refreshed, current, env) && fresh.expiresAt > Date.now() + 30_000;
+    && await privateAuthorizationCurrent(refreshed, current, env) && privateUpstreamActive(fresh);
 }
 
 async function availabilityFailure(response: Response, signal: AbortSignal): Promise<boolean> {

--- a/worker/test/private-codex-api.test.mjs
+++ b/worker/test/private-codex-api.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { default: worker } = await import("../private-entry.ts");
+const { sha256Hex } = await import("../utils.ts");
+const target = "SYNTHETIC_PRIVATE_TARGET", fallbackTarget = "SYNTHETIC_FALLBACK_TARGET", apiKey = "SYNTHETIC_PRIVATE_API_CREDENTIAL";
+const credential = "private-workload-SYNTHETIC_API_WORKLOAD_123456789";
+
+async function fixture() {
+  const policy = { version: 1, enabled: true, alias: { id: "internal", name: "Codex" }, auth: { mode: "workload", credentialSha256: await sha256Hex(credential) } };
+  const upstream = { version: 1, transport: "openai-api", target, apiKey };
+  const env = { PRIVATE_CODEX_POLICY: { get: async () => JSON.stringify(policy) }, PRIVATE_CODEX_UPSTREAM: { get: async () => JSON.stringify(upstream) } };
+  const run = (body = {}, headers = {}) => worker.fetch(new Request("https://private.invalid/private/v1/responses", {
+    method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json", ...headers },
+    body: JSON.stringify({ model: "internal", store: false, input: "synthetic input", ...body }),
+  }), env);
+  return { policy, upstream, run };
+}
+const completed = (model, output = []) => Response.json({ id: "resp-synthetic", object: "response", status: "completed", model, output });
+
+test("private API transport pins the endpoint and preserves native facts and output limits", async (t) => {
+  const { run } = await fixture(); let calls = 0;
+  t.mock.method(globalThis, "fetch", async (url, options) => {
+    calls++; assert.equal(url, "https://api.openai.com/v1/responses"); assert.equal(options.redirect, "manual");
+    assert.equal(options.headers.get("authorization"), `Bearer ${apiKey}`);
+    assert.equal(options.headers.has("chatgpt-account-id"), false);
+    assert.equal(options.headers.get("originator"), "codex_cli_rs");
+    assert.equal(options.headers.get("x-openai-internal-codex-responses-lite"), "true");
+    const body = JSON.parse(options.body);
+    assert.equal(body.model, target); assert.equal(body.max_output_tokens, 512); assert.equal(body.store, false);
+    assert.deepEqual(body.reasoning, { effort: "high" });
+    return completed(target);
+  });
+  const response = await run({ max_output_tokens: 512, reasoning: { effort: "high" } }, { originator: "codex_cli_rs", "x-openai-internal-codex-responses-lite": "true" });
+  assert.equal(response.status, 200); assert.equal(response.headers.has("x-clawrouter-ignored-parameters"), false);
+  assert.equal((await response.json()).model, "internal"); assert.equal(calls, 1);
+});
+
+test("private API credentials are contained and rejected transports cannot mix credential kinds", async (t) => {
+  const state = await fixture(); let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => { calls++; return completed(target, [{ type: "message", content: [{ type: "output_text", text: apiKey }] }]); });
+  const response = await state.run(); assert.equal(response.status, 502); assert.doesNotMatch(await response.text(), /SYNTHETIC/);
+  for (const extra of [{ transport: "arbitrary" }, { accountId: "SYNTHETIC_ACCOUNT" }, { accessToken: "SYNTHETIC_TOKEN" }, { expiresAt: Date.now() + 3600_000 }, { apiKey: "" }, { apiKey: "invalid\ncredential" }, { url: "https://elsewhere.invalid" }]) {
+    const other = await fixture(); Object.assign(other.upstream, extra);
+    assert.equal((await other.run()).status, 404);
+  }
+  assert.equal(calls, 1);
+});
+
+test("private API fallback retains its credential and continuation while revocation and rotation stop reuse", async (t) => {
+  const state = await fixture(); state.upstream.fallbackTarget = fallbackTarget; const calls = [];
+  t.mock.method(globalThis, "fetch", async (url, options) => {
+    assert.equal(url, "https://api.openai.com/v1/responses"); assert.equal(options.headers.get("authorization"), `Bearer ${apiKey}`);
+    const body = JSON.parse(options.body); calls.push(body);
+    return calls.length === 1 ? Response.json({ error: { code: "server_error" } }, { status: 503 }) : completed(fallbackTarget);
+  });
+  const first = await state.run(); const id = (await first.json()).id;
+  const next = await state.run({ previous_response_id: id }); assert.equal(next.status, 200); await next.text();
+  assert.deepEqual(calls.map(x => x.model), [target, fallbackTarget, fallbackTarget]); assert.equal(calls[2].previous_response_id, "resp-synthetic");
+  state.upstream.apiKey = "SYNTHETIC_ROTATED_API_CREDENTIAL";
+  assert.equal((await state.run({ previous_response_id: id })).status, 400); assert.equal(calls.length, 3);
+  state.policy.enabled = false;
+  assert.equal((await state.run()).status, 404); assert.equal(calls.length, 3);
+});
+
+test("private API transport never falls through an auth denial to another model or credential kind", async (t) => {
+  for (const status of [401, 403]) {
+    const state = await fixture(); state.upstream.fallbackTarget = fallbackTarget; let calls = 0;
+    t.mock.method(globalThis, "fetch", async url => {
+      calls++; assert.equal(url, "https://api.openai.com/v1/responses");
+      return Response.json({ error: { code: "unauthorized", message: apiKey } }, { status });
+    });
+    const result = await state.run(); assert.equal(result.status, status); assert.doesNotMatch(await result.text(), /SYNTHETIC/); assert.equal(calls, 1);
+    t.mock.restoreAll();
+  }
+});


### PR DESCRIPTION
The private facade can now explicitly use owner-provisioned OpenAI API credentials. This supports API-entitled workloads without relying on the subscription transport or a short-lived subscription access token.

An `openai-api` binding pins requests to the Responses API, omits the subscription account header, and preserves output limits and genuine native client/safety facts. It cannot mix subscription fields or switch credential kinds after a denial. Both transports share authorization revalidation, alias projection, secret containment, and bounded model fallback. Encrypted continuations are bound to the selected transport and credential. The existing subscription configuration and continuation format remain supported.

Validation: TypeScript and 279 Worker tests pass; dedicated cases cover endpoint pinning, native facts, parameters, malformed/mixed configuration, secret leakage, fallback, continuation, rotation, revocation, and terminal authorization denials. Real Worker-runtime E2E passes with Secrets Store bindings. The native client completed a real API-backed shell-tool exchange through the implemented private facade, with alias-only client output. Independent autoreview is clean.

Deployment: explicit opt-in for an isolated private Worker. No shared production credentials or routing are changed by the source change. Provider API billing still applies; private calls do not populate shared usage ledgers.
