### PR TITLE
fix(private): contain identity disclosures across ASCII capitalization

### DIFF
--- a/worker/private-codex-config.ts
+++ b/worker/private-codex-config.ts
@@ -37,6 +37,16 @@ export function privateSensitive(upstream: PrivateUpstream): string[] {
   return [upstream.target, privateCredential(upstream), ...(upstream.transport === "openai-api" ? [] : [upstream.accountId]), ...(upstream.fallbackTarget ? [upstream.fallbackTarget] : [])];
 }
 
+// ASCII folding preserves string lengths, including stream holdback offsets.
+export function privateFold(value: string): string {
+  return value.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+}
+
+export function containsPrivate(value: string, sensitive: readonly string[]): boolean {
+  const folded = privateFold(value);
+  return sensitive.some((secret) => folded.includes(privateFold(secret)));
+}
+
 export function privateUpstreamActive(upstream: PrivateUpstream): boolean {
   return upstream.transport === "openai-api" || upstream.expiresAt > Date.now() + 30_000;
 }
@@ -165,6 +175,6 @@ export async function privateUpstream(env: Env, policy: PrivatePolicy): Promise<
     || !/^[A-Za-z0-9][A-Za-z0-9._-]{7,127}$/.test(value.fallbackTarget) || value.fallbackTarget === value.target)) return null;
   const upstream = value as unknown as PrivateUpstream;
   const sensitive = privateSensitive(upstream);
-  if (sensitive.some((secret) => policy.alias.id.includes(secret) || policy.alias.name.includes(secret))) return null;
+  if (containsPrivate(policy.alias.id, sensitive) || containsPrivate(policy.alias.name, sensitive)) return null;
   return upstream;
 }

--- a/worker/private-codex-output.ts
+++ b/worker/private-codex-output.ts
@@ -1,5 +1,5 @@
 import { boundedJson, cancel, read } from "./private-codex-io";
-import { record, type PrivateUpstream } from "./private-codex-config";
+import { privateFold, record, type PrivateUpstream } from "./private-codex-config";
 import { PrivateResponseProjection } from "./private-codex-response";
 import type { PrivateContinuationProjection } from "./private-codex-continuation";
 
@@ -114,7 +114,7 @@ function matchDelta(text: string, pattern: string, table: number[], length: numb
 function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResponseProjection, signal: AbortSignal, abort: () => void): ReadableStream<Uint8Array> {
   const reader = body.getReader(), decoder = new TextDecoder("utf-8", { fatal: true });
   const secrets = projection.sensitiveValues;
-  let tables = secrets.map(prefixTable);
+  let patterns = secrets.map(privateFold), tables = patterns.map(prefixTable);
   const states = new Map<string, DeltaState>(), items = new Map<number, string>(), itemIndexes = new Map<string, number>();
   const identityModes = new Map<string, "identified" | "anonymous">();
   const calls = new Map<string, string>(), callOwners = new Map<string, string>(), customItems = new Map<string, string>();
@@ -190,13 +190,13 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
       state.holdFrom = Infinity;
     } else {
       if (typeof event.delta !== "string") throw new Error("private delta invalid");
-      const text = event.delta;
+      const text = privateFold(event.delta);
       if (family === "response.output_text") {
-        outputText.matches = secrets.map((secret, index) => matchDelta(text, secret, tables[index], outputText.matches[index]));
+        outputText.matches = patterns.map((secret, index) => matchDelta(text, secret, tables[index], outputText.matches[index]));
         const suffix = Math.max(...outputText.matches);
         outputText.holdFrom = suffix ? suffix > text.length ? outputText.holdFrom : sequence : Infinity;
       }
-      state.matches = secrets.map((secret, index) => matchDelta(text, secret, tables[index], state.matches[index]));
+      state.matches = patterns.map((secret, index) => matchDelta(text, secret, tables[index], state.matches[index]));
       const suffix = Math.max(...state.matches);
       state.holdFrom = suffix ? suffix > event.delta.length ? state.holdFrom : sequence : Infinity;
       if (state.tool) {
@@ -268,7 +268,8 @@ function containStream(body: ReadableStream<Uint8Array>, projection: PrivateResp
     const safe = await projection.event(event);
     if (tables.length !== secrets.length) {
       // Learning is sealed before any delta state or output exists; no prefix is discarded.
-      tables = secrets.map(prefixTable);
+      patterns = secrets.map(privateFold);
+      tables = patterns.map(prefixTable);
       outputText.matches = secrets.map(() => 0);
     }
     const serialized = `${eventName ? `event: ${eventName}\n` : ""}data: ${JSON.stringify(safe)}\n\n`;

--- a/worker/private-codex-protocol.ts
+++ b/worker/private-codex-protocol.ts
@@ -1,4 +1,4 @@
-import { record } from "./private-codex-config";
+import { containsPrivate, record } from "./private-codex-config";
 
 // Wire contracts: codex core/client.rs, core/responses_metadata.rs and codex-api.
 const forwardedHeaders = new Set([
@@ -85,7 +85,7 @@ export function forwardPrivateHeaders(incoming: Headers, outgoing: Headers, alia
 export function inspectPrivateOpaque(value: unknown, alias: string, secrets: readonly string[], depth = 0, budget = { nodes: 0 }): void {
   if (++budget.nodes > 10_000 || depth > 12) throw new Error("private opaque limit");
   if (typeof value === "string") {
-    if (secrets.some((secret) => value.includes(secret))) throw new Error("private opaque identity");
+    if (containsPrivate(value, secrets)) throw new Error("private opaque identity");
     if (value.length > 8192) throw new Error("private opaque size");
     for (const match of value.matchAll(/(?:^|[;,&\s])(?:model|retry_model|faster_model)=([^;,&\s]+)/g)) {
       if (match[1] !== alias) throw new Error("private opaque selector");
@@ -102,7 +102,7 @@ export function inspectPrivateOpaque(value: unknown, alias: string, secrets: rea
         if (!/^[A-Za-z0-9+/_-]{8,}={0,2}$/.test(part)) continue;
         let decoded: string;
         try { decoded = atob(part.replaceAll("-", "+").replaceAll("_", "/")); } catch { continue; }
-        if (secrets.some((secret) => decoded.includes(secret))) throw new Error("private opaque encoded identity");
+        if (containsPrivate(decoded, secrets)) throw new Error("private opaque encoded identity");
         if (/^[\x20-\x7e\r\n\t]+$/.test(decoded) && decoded !== value) inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
       }
     }

--- a/worker/private-codex-response.ts
+++ b/worker/private-codex-response.ts
@@ -1,4 +1,4 @@
-import { privateSensitive, record, type PrivateUpstream } from "./private-codex-config";
+import { containsPrivate, privateSensitive, record, type PrivateUpstream } from "./private-codex-config";
 import { privateResponseHeaders } from "./private-codex-protocol";
 import type { PrivateContinuationProjection } from "./private-codex-continuation";
 
@@ -6,7 +6,7 @@ import type { PrivateContinuationProjection } from "./private-codex-continuation
 export function inspectPrivateContent(value: unknown, sensitive: readonly string[], depth = 0, budget = { nodes: 0 }): void {
   if (++budget.nodes > 50_000 || depth > 48) throw new Error("private structure limit");
   if (typeof value === "string") {
-    if (sensitive.some((secret) => value.includes(secret))) throw new Error("private content rejected");
+    if (containsPrivate(value, sensitive)) throw new Error("private content rejected");
     if (/^\s*[\[{]/.test(value)) {
       let nested: unknown;
       try { nested = JSON.parse(value); } catch { return; }

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -1,5 +1,5 @@
 import { boundedJson } from "./private-codex-io";
-import { privateAuthorizationCurrent, privateAuthorized, privateCredential, privatePolicy, privateSensitive, privateUpstream, privateUpstreamActive, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
+import { containsPrivate, privateAuthorizationCurrent, privateAuthorized, privateCredential, privatePolicy, privateSensitive, privateUpstream, privateUpstreamActive, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
 import { containResponse, privateError, privateJson } from "./private-codex-output";
 import { forwardPrivateHeaders, inspectPrivateOpaque, validPrivateHeaders, validPrivateProtocolBody } from "./private-codex-protocol";
 import { privateContinuations } from "./private-codex-continuation";
@@ -72,7 +72,7 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
     if (!await upstreamCurrent(request, env, policy, upstream)) return privateError(404);
     const ignoredMaxOutputTokens = upstream.transport !== "openai-api" && body.max_output_tokens !== undefined;
     // A fixed disclosure must not echo a runtime identity, including on transport failure.
-    if (ignoredMaxOutputTokens && privateSensitive(upstream).some((secret) => "x-clawrouter-ignored-parameters: max_output_tokens".includes(secret))) return new Response(null, { status: 502 });
+    if (ignoredMaxOutputTokens && containsPrivate("x-clawrouter-ignored-parameters: max_output_tokens", privateSensitive(upstream))) return new Response(null, { status: 502 });
     // Do not manufacture originator, client metadata, review, or attestation evidence.
     const abort = new AbortController();
     const signal = AbortSignal.any([request.signal, abort.signal, AbortSignal.timeout(600_000)]);

--- a/worker/test/private-codex-projection.test.mjs
+++ b/worker/test/private-codex-projection.test.mjs
@@ -27,6 +27,35 @@ function sse(events, headers = {}, chunkSize = 17) {
 }
 const contain = (response, stream = false) => containResponse(response, alias, upstream, stream, new AbortController().signal, () => {});
 const parseEvents = (text) => [...text.matchAll(/^data: (.+)$/gm)].filter((match) => match[1] !== "[DONE]").map((match) => JSON.parse(match[1]));
+
+test("private identities are contained irrespective of ASCII capitalization", async () => {
+  for (const identity of [target, reported, upstream.accessToken, upstream.accountId]) {
+    const text = identity.toLowerCase();
+    const result = await contain(Response.json(responseBody({ model: reported, output: [{ text }] })));
+    assert.equal(result.status, 502); assert.equal((await result.text()).includes(text), false);
+  }
+});
+
+test("case-folded identities remain held across logical deltas without changing safe text", async () => {
+  for (const identity of [target, reported]) {
+    const text = identity.toLowerCase(), first = text.slice(0, 12), last = text.slice(12);
+    const result = await contain(sse([created({ model: reported }), delta(first), delta(last), completed({ model: reported })], {}, 1), true);
+    const wire = await result.text();
+    assert.match(wire, /private_upstream_error/); assert.equal(wire.includes(first), false); assert.equal(wire.includes(last), false);
+  }
+  const text = "İ Mixed CASE stays intact.";
+  const result = await contain(sse([created(), delta(text), completed()]), true);
+  assert.equal(parseEvents(await result.text())[1].delta, text);
+});
+
+test("case-folded private identities cannot escape through encoded opaque headers", async () => {
+  const text = reported.toLowerCase();
+  for (const value of [text, encodeURIComponent(JSON.stringify({ affinity: text })), Buffer.from(JSON.stringify({ affinity: text })).toString("base64url")]) {
+    const result = await contain(Response.json(responseBody({ model: reported }), { headers: { "x-codex-turn-state": value } }));
+    assert.equal(result.status, 502); assert.equal(result.headers.get("x-codex-turn-state"), null);
+  }
+});
+
 function assertPrivate(text, extras = [reported]) {
   for (const value of [target, upstream.accountId, upstream.accessToken, ...extras]) assert.equal(text.includes(value), false);
 }


### PR DESCRIPTION
## Summary

The private response filter matched configured and reported identities case-sensitively. A differently capitalized identity could therefore pass through JSON, split streaming deltas, or encoded affinity headers.

Use length-preserving ASCII folding for inspection and streaming prefix matching, including fixed disclosures and alias validation. Protocol routing, credentials, and returned safe content retain their original bytes. Existing bounded holdback and fail-closed behavior remain in place.

## Validation

- Three added regressions failed before the fix and pass afterward, covering JSON, split logical deltas, encoded opaque headers, and unchanged safe Unicode text.
- Full workspace checks pass: 282 Worker tests, 30 admin tests, and 82 script tests, plus TypeScript checks.
- A real Worker-runtime E2E using native Secrets Store bindings passed fallback, continuation, revocation, and case-folded split-delta containment.
- Independent Codex review found no actionable issues.
- Exact-head CI passed before landing. The isolated private Worker was deployed from merged main and passed a real native shell-tool probe; the shared public deployment is unaffected.

This closes a concrete capitalization bypass; it does not claim detection of arbitrary paraphrases or every possible encoding.
