### PR TITLE
refactor(usage): use one canonical shard aggregation path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,9 +54,10 @@ provider and model drift.
    retried without masking the provider response or suppressing the other task.
 
 Usage events are queued into a Durable Object shard named by tenant and policy.
-Session/admin reads aggregate only their relevant shards. A bounded legacy read
-bridge includes the former global ledger through 2026-07-23; it performs one
-filtered global read per aggregate and can then be removed.
+Session/admin reads aggregate each relevant tenant/policy shard once, even when
+the input policy list repeats a scope. The former global ledger's migration
+window ended on 2026-07-23; it is no longer queried. Stored data and Durable
+Object bindings are unchanged.
 
 ## Failure boundaries
 

--- a/worker/ledgers.ts
+++ b/worker/ledgers.ts
@@ -1,13 +1,12 @@
 import type { BudgetReserveRequest, BudgetSettleRequest, Env, QueueMessage, UsageEvent } from "./types";
 import { budgetLedgerAddress, providerBudgetLedgerAddress } from "./budget-scope.ts";
-import { emptyUsageSnapshot, mergeUsageSnapshots, usageCutoffs, usageDayMs, usageShardName, type UsageSnapshot } from "./usage-sharding.ts";
+import { mergeUsageSnapshots, usageCutoffs, usageDayMs, usageShardName, type UsageSnapshot } from "./usage-sharding.ts";
 import { errorResponse, json } from "./utils.ts";
 
 const reservationLeaseMs = 15 * 60 * 1_000;
 const chargeRetentionMs = 45 * 86_400_000;
 const usageWindowDays = 30;
 const usageRetentionMs = usageWindowDays * usageDayMs;
-const legacyUsageReadUntilMs = Date.parse("2026-07-23T00:00:00.000Z");
 
 export class BudgetLedgerObject implements DurableObject {
   private sql: SqlStorage;
@@ -176,16 +175,9 @@ export async function usageSnapshot(env: Env, tenantId: string, policyId: string
 }
 
 export async function usageSnapshots(env: Env, policies: Array<{ policyId: string; tenantId: string }>, limit = 100): Promise<UsageSnapshot> {
-  if (!policies.length) return emptyUsageSnapshot();
-  const current = await Promise.all(policies.map((policy) => currentUsageSnapshot(env, policy.tenantId, policy.policyId, limit)));
-  if (Date.now() >= legacyUsageReadUntilMs) return mergeUsageSnapshots(current, limit);
-  const url = new URL("https://clawrouter.internal/snapshot");
-  for (const policyId of [...new Set(policies.map((policy) => policy.policyId))]) url.searchParams.append("policy_id", policyId);
-  url.searchParams.set("limit", String(limit));
-  const legacyResponse = await legacyUsageStub(env).fetch(url);
-  if (!legacyResponse.ok) return mergeUsageSnapshots(current, limit);
-  const legacy = await legacyResponse.json<UsageSnapshot>();
-  return mergeUsageSnapshots([legacy, ...current], limit);
+  const shards = new Map(policies.map(policy => [usageShardName(policy.tenantId, policy.policyId), policy]));
+  const snapshots = await Promise.all([...shards.values()].map(policy => currentUsageSnapshot(env, policy.tenantId, policy.policyId, limit)));
+  return mergeUsageSnapshots(snapshots, limit);
 }
 
 async function currentUsageSnapshot(env: Env, tenantId: string, policyId: string, limit: number): Promise<UsageSnapshot> {
@@ -233,7 +225,6 @@ export async function providerBudgetStatus(env: Env, providerId: string, limitMi
 }
 
 export function usageStub(env: Env, tenantId: string, policyId: string): DurableObjectStub { return env.USAGE_LEDGER.get(env.USAGE_LEDGER.idFromName(usageShardName(tenantId, policyId))); }
-function legacyUsageStub(env: Env): DurableObjectStub { return env.USAGE_LEDGER.get(env.USAGE_LEDGER.idFromName("global")); }
 
 function numberParam(url: URL, name: string): number | null { const value = Number(url.searchParams.get(name)); return Number.isSafeInteger(value) && value >= 0 ? value : null; }
 function rows<T>(cursor: Iterable<T>): T[] { return [...cursor]; }

--- a/worker/test/usage-snapshots.test.mjs
+++ b/worker/test/usage-snapshots.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { usageSnapshots } from "../ledgers.ts";
+import { emptyUsageSnapshot } from "../usage-sharding.ts";
+
+test("aggregation reads each tenant/policy shard once and never the retired global ledger", async () => {
+  const calls = [];
+  const env = { USAGE_LEDGER: {
+    idFromName: name => name,
+    get: name => ({ fetch: async url => {
+      calls.push({ name, policy: new URL(url).searchParams.get("policy_id") });
+      const snapshot = emptyUsageSnapshot();
+      snapshot.summary.requestCount = 1;
+      return Response.json(snapshot);
+    } }),
+  } };
+  const summary = await usageSnapshots(env, [
+    { tenantId: "one", policyId: "same" },
+    { tenantId: "one", policyId: "same" },
+    { tenantId: "two", policyId: "same" },
+  ]);
+  assert.deepEqual(calls, [
+    { name: "policy:one:same", policy: "same" },
+    { name: "policy:two:same", policy: "same" },
+  ]);
+  assert.equal(summary.summary.requestCount, 2);
+  calls.length = 0;
+  assert.deepEqual(await usageSnapshots(env, []), emptyUsageSnapshot());
+  assert.deepEqual(calls, []);
+});
+
+test("a current shard failure fails the aggregate instead of returning partial totals", async () => {
+  const env = { USAGE_LEDGER: {
+    idFromName: name => name,
+    get: () => ({ fetch: async () => new Response(null, { status: 503 }) }),
+  } };
+  await assert.rejects(usageSnapshots(env, [{ tenantId: "one", policyId: "policy" }]), /503/);
+});


### PR DESCRIPTION
Usage aggregation now has one read path: the tenant/policy shards that also receive usage events. Remove the global-ledger migration bridge whose window ended on July 23, and deduplicate shard addresses so repeated policy inputs cannot repeat requests or inflate totals. Durable Object bindings and stored data remain unchanged.

Validation: focused aggregation/sharding tests cover tenant separation, duplicates, empty input, and fail-closed shard errors. Independent Codex review found no actionable issues. Full router checks and the Worker, dashboard/browser, and self-host CI jobs validate the final commit.
