### PR TITLE
refactor(proxy): unify response inspection and delivery lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,13 @@ provider and model drift.
 9. Settle budget and enqueue the single final usage event independently. Either failure is
    retried without masking the provider response or suppressing the other task.
 
+`proxy-response.ts` owns shared response normalization and usage inspection. One
+observer follows client consumption for JSON, SSE, and binary responses, without
+cloning or draining ahead of the client. It inspects at most 2 MiB for usage;
+oversized, canceled, or broken bodies retain the conservative reservation.
+Settlement starts when delivery completes, fails, or is canceled. Private alias
+inference keeps its separate containment and continuation protocol.
+
 Usage events are queued into a Durable Object shard named by tenant and policy.
 Session/admin reads aggregate only their relevant shards. A bounded legacy read
 bridge includes the former global ledger through 2026-07-23; it performs one

--- a/worker/proxy-response.ts
+++ b/worker/proxy-response.ts
@@ -1,0 +1,221 @@
+import { extractSseUsageTokens, extractUsageTokens, type UsageTokens } from "./token-usage.ts";
+
+// Accounting observes the delivered stream; a tee would drain upstream ahead of
+// the client and buffer arbitrary output. Inspection alone is capped at 2 MiB.
+export function observeUsage(response: Response): { response: Response; tokens: Promise<UsageTokens | null> } {
+  if (!response.body) return { response, tokens: Promise.resolve(null) };
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  let inspect = contentType.includes("json") || contentType.includes("text/event-stream");
+  const decoder = new TextDecoder();
+  const reader = response.body.getReader();
+  let text = "", bytes = 0, finished = false;
+  let resolve!: (tokens: UsageTokens | null) => void;
+  const tokens = new Promise<UsageTokens | null>(done => { resolve = done; });
+  function finish(complete: boolean) {
+    if (finished) return;
+    finished = true;
+    let measured: UsageTokens | null = null;
+    if (complete && inspect) {
+      try {
+        text += decoder.decode();
+        measured = contentType.includes("json") ? extractUsageTokens(JSON.parse(text)) : extractSseUsageTokens(text);
+      } catch { /* Incomplete usage keeps the conservative reservation. */ }
+    }
+    text = "";
+    reader.releaseLock();
+    resolve(measured);
+  }
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const next = await reader.read();
+        if (next.done) { finish(true); controller.close(); return; }
+        if (inspect) {
+          bytes += next.value.byteLength;
+          if (bytes > 2 * 1024 * 1024) { inspect = false; text = ""; }
+          else text += decoder.decode(next.value, { stream: true });
+        }
+        controller.enqueue(next.value);
+      } catch (error) { finish(false); controller.error(error); }
+    },
+    cancel(reason) {
+      const canceled = reader.cancel(reason);
+      finish(false);
+      return canceled;
+    },
+  }, { highWaterMark: 0 });
+  return { response: new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers }), tokens };
+}
+
+export async function normalizePreStreamError(response: Response, streamingRequested: boolean): Promise<Response> {
+  if (!streamingRequested) return response;
+  const eventStream = response.headers.get("content-type")?.toLowerCase().includes("text/event-stream") === true;
+  if (response.status >= 400) {
+    if (eventStream && response.body) return normalizeFirstSseEvent(response, response.status);
+    const body = await readLimited(response, 64 * 1024).catch(() => "");
+    return mappedUpstreamError(response, upstreamError(body), response.status);
+  }
+  if (!response.ok || !eventStream || !response.body) return response;
+  return normalizeFirstSseEvent(response, null);
+}
+
+const FIRST_SSE_EVENT_LIMIT = 8 * 1024;
+
+async function normalizeFirstSseEvent(response: Response, errorStatus: number | null): Promise<Response> {
+  const reader = response.body!.getReader();
+  const chunks: Uint8Array[] = [];
+  const sniffed = new Uint8Array(FIRST_SSE_EVENT_LIMIT);
+  let sniffedLength = 0;
+  let eventStart = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (value?.byteLength) {
+      chunks.push(value);
+      const copyLength = Math.min(value.byteLength, FIRST_SSE_EVENT_LIMIT - sniffedLength);
+      if (copyLength > 0) {
+        sniffed.set(value.subarray(0, copyLength), sniffedLength);
+        sniffedLength += copyLength;
+      }
+    }
+    while (eventStart < sniffedLength) {
+      const boundary = sseEventBoundary(sniffed, eventStart, sniffedLength);
+      if (!boundary) break;
+      const event = classifySseEvent(sniffed.subarray(eventStart, boundary.start));
+      eventStart = boundary.end;
+      if (event.kind === "empty") continue;
+      if (errorStatus !== null || event.kind === "error") {
+        await reader.cancel().catch(() => undefined);
+        const upstream = event.upstream;
+        const status = errorStatus ?? (typeof upstream.code === "number" && Number.isInteger(upstream.code) && upstream.code >= 400 && upstream.code <= 599 ? upstream.code : 502);
+        return mappedUpstreamError(response, upstream, status);
+      }
+      return replayResponse(response, reader, chunks, done);
+    }
+    if (done || sniffedLength === FIRST_SSE_EVENT_LIMIT) {
+      if (errorStatus === null) return replayResponse(response, reader, chunks, done);
+      if (!done) await reader.cancel().catch(() => undefined);
+      return mappedUpstreamError(response, {}, errorStatus);
+    }
+  }
+}
+
+function replayResponse(response: Response, reader: ReadableStreamDefaultReader<Uint8Array>, chunks: Uint8Array[], readerDone: boolean): Response {
+  let chunkIndex = 0;
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (chunkIndex < chunks.length) {
+        controller.enqueue(chunks[chunkIndex++]);
+        return;
+      }
+      if (readerDone) {
+        controller.close();
+        return;
+      }
+      try {
+        const { done, value } = await reader.read();
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch (error) { controller.error(error); }
+    },
+    cancel(reason) { return reader.cancel(reason); },
+  }, { highWaterMark: 0 });
+  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
+}
+
+function sseEventBoundary(bytes: Uint8Array, start: number, length: number): { start: number; end: number } | null {
+  let lineStart = start;
+  for (let index = start; index < length; index += 1) {
+    if (bytes[index] !== 10 && bytes[index] !== 13) continue;
+    const next = bytes[index] === 13 && index + 1 < length && bytes[index + 1] === 10 ? index + 2 : index + 1;
+    if (index === lineStart) return { start: lineStart, end: next };
+    lineStart = next;
+    index = next - 1;
+  }
+  return null;
+}
+
+function classifySseEvent(bytes: Uint8Array): { kind: "empty" } | { kind: "healthy" | "error"; upstream: ReturnType<typeof upstreamError> } {
+  let eventType = "";
+  const dataLines: string[] = [];
+  for (const line of new TextDecoder().decode(bytes).split(/\r\n|\r|\n/)) {
+    if (!line || line.startsWith(":")) continue;
+    const colon = line.indexOf(":");
+    const field = colon < 0 ? line : line.slice(0, colon);
+    let value = colon < 0 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    if (field === "event") eventType = value;
+    else if (field === "data") dataLines.push(value);
+  }
+  const data = dataLines.join("\n");
+  if (dataLines.length === 0) return { kind: "empty" };
+  const upstream = upstreamError(data);
+  return eventType === "error" || hasTopLevelError(data) ? { kind: "error", upstream } : { kind: "healthy", upstream };
+}
+
+function hasTopLevelError(data: string): boolean {
+  try {
+    const value: unknown = JSON.parse(data);
+    return !!value && typeof value === "object" && !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, "error");
+  } catch { return false; }
+}
+
+function mappedUpstreamError(response: Response, upstream: ReturnType<typeof upstreamError>, status: number): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  headers.set("content-type", "application/json; charset=utf-8");
+  return Response.json({ error: {
+    message: upstream.message ?? (response.ok ? "upstream request failed" : response.statusText || "upstream request failed"),
+    type: upstream.type ?? "upstream_error",
+    code: upstream.code ?? status,
+  } }, { status, statusText: status === response.status ? response.statusText : "", headers });
+}
+
+function upstreamError(body: string): { message?: string; type?: string; code?: string | number } {
+  let value: unknown;
+  try {
+    const eventData = firstSseData(body);
+    value = JSON.parse(eventData || body);
+  } catch { return {}; }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const error = "error" in value && value.error && typeof value.error === "object" && !Array.isArray(value.error) ? value.error as Record<string, unknown> : value as Record<string, unknown>;
+  return {
+    message: typeof error.message === "string" ? error.message : undefined,
+    type: typeof error.type === "string" ? error.type : undefined,
+    code: typeof error.code === "string" || typeof error.code === "number" ? error.code : undefined,
+  };
+}
+
+function firstSseData(body: string): string | null {
+  const dataLines: string[] = [];
+  for (const line of body.split(/\r\n|\r|\n/)) {
+    if (!line) {
+      if (dataLines.some((value) => value !== "")) break;
+      dataLines.length = 0;
+      continue;
+    }
+    if (line.startsWith(":")) continue;
+    const colon = line.indexOf(":");
+    const field = colon < 0 ? line : line.slice(0, colon);
+    if (field !== "data") continue;
+    let value = colon < 0 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    dataLines.push(value);
+  }
+  return dataLines.length > 0 ? dataLines.join("\n") : null;
+}
+
+async function readLimited(response: Response, limit: number): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader(), decoder = new TextDecoder();
+  let size = 0, text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) throw new Error("usage payload exceeds inspection limit");
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally { if (size > limit) await reader.cancel(); }
+}

--- a/worker/proxy.ts
+++ b/worker/proxy.ts
@@ -16,7 +16,8 @@ import {
 } from "./providers";
 import { applyTransportHeaders, transformTransportBody } from "./provider-auth.ts";
 import { actualModelCost, estimateModelCost } from "./pricing";
-import { extractSseUsageTokens, extractUsageTokens, type UsageTokens } from "./token-usage";
+import type { UsageTokens } from "./token-usage";
+import { normalizePreStreamError, observeUsage } from "./proxy-response";
 import type { AuthorizedIdentity, CompiledEndpoint, CompiledModel, CompiledProvider, CompiledQuotaConfig, Env, ProviderConnection, UsageEvent } from "./types";
 import {
   errorResponse, HttpError, parseProxyKey, randomId, readJson, safeEqual, sha256Hex,
@@ -387,18 +388,9 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
     return errorResponse("provider_unavailable", `upstream request to provider ${selection.provider.id} failed`, 502, undefined);
   }
   clearTimeout(timeout);
-  const contentType = response.headers.get("content-type") ?? "";
-  if (contentType.includes("json") || contentType.includes("text/event-stream")) {
-    context.waitUntil(finalizeResponse(response.clone(), env, auth, selection, request, requestId, started, cost, reservation, content, compound));
-  } else {
-    // Draining a tee for accounting buffers the entire binary transfer behind a
-    // slow client. Observe its completion without creating a second consumer.
-    const upstreamResponse = response;
-    let completed!: () => void;
-    const completion = new Promise<void>(resolve => { completed = resolve; });
-    response = observeResponseBody(response, completed);
-    context.waitUntil(completion.then(() => finalizeResponse(upstreamResponse, env, auth, selection, request, requestId, started, cost, reservation, content, compound)));
-  }
+  const observed = observeUsage(response);
+  context.waitUntil(observed.tokens.then(tokens => finalizeResponse(response, tokens, env, auth, selection, request, requestId, started, cost, reservation, content, compound)));
+  response = observed.response;
   const outputHeaders = new Headers(response.headers);
   for (const name of ["connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "set-cookie", "trailer", "transfer-encoding", "upgrade"]) outputHeaders.delete(name);
   outputHeaders.set("x-clawrouter-upstream-provider", selection.provider.id);
@@ -406,163 +398,6 @@ async function proxySelected(request: Request, env: Env, context: ExecutionConte
   if (grantFailover) outputHeaders.set("x-clawrouter-grant-failover", "1");
   outputHeaders.set("x-clawrouter-content-retention", auth.policy.retainRequestContent !== false && !auth.contentRetentionDisabled ? "on; retention-days=30" : "off");
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers: outputHeaders });
-}
-
-export async function normalizePreStreamError(response: Response, streamingRequested: boolean): Promise<Response> {
-  if (!streamingRequested) return response;
-  const eventStream = response.headers.get("content-type")?.toLowerCase().includes("text/event-stream") === true;
-  if (response.status >= 400) {
-    if (eventStream && response.body) return normalizeFirstSseEvent(response, response.status);
-    const body = await readLimited(response, 64 * 1024).catch(() => "");
-    return mappedUpstreamError(response, upstreamError(body), response.status);
-  }
-  if (!response.ok || !eventStream || !response.body) return response;
-  return normalizeFirstSseEvent(response, null);
-}
-
-const FIRST_SSE_EVENT_LIMIT = 8 * 1024;
-
-async function normalizeFirstSseEvent(response: Response, errorStatus: number | null): Promise<Response> {
-  const reader = response.body!.getReader();
-  const chunks: Uint8Array[] = [];
-  const sniffed = new Uint8Array(FIRST_SSE_EVENT_LIMIT);
-  let sniffedLength = 0;
-  let eventStart = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (value?.byteLength) {
-      chunks.push(value);
-      const copyLength = Math.min(value.byteLength, FIRST_SSE_EVENT_LIMIT - sniffedLength);
-      if (copyLength > 0) {
-        sniffed.set(value.subarray(0, copyLength), sniffedLength);
-        sniffedLength += copyLength;
-      }
-    }
-    while (eventStart < sniffedLength) {
-      const boundary = sseEventBoundary(sniffed, eventStart, sniffedLength);
-      if (!boundary) break;
-      const event = classifySseEvent(sniffed.subarray(eventStart, boundary.start));
-      eventStart = boundary.end;
-      if (event.kind === "empty") continue;
-      if (errorStatus !== null || event.kind === "error") {
-        await reader.cancel().catch(() => undefined);
-        const upstream = event.upstream;
-        const status = errorStatus ?? (typeof upstream.code === "number" && Number.isInteger(upstream.code) && upstream.code >= 400 && upstream.code <= 599 ? upstream.code : 502);
-        return mappedUpstreamError(response, upstream, status);
-      }
-      return replayResponse(response, reader, chunks, done);
-    }
-    if (done || sniffedLength === FIRST_SSE_EVENT_LIMIT) {
-      if (errorStatus === null) return replayResponse(response, reader, chunks, done);
-      if (!done) await reader.cancel().catch(() => undefined);
-      return mappedUpstreamError(response, {}, errorStatus);
-    }
-  }
-}
-
-function replayResponse(response: Response, reader: ReadableStreamDefaultReader<Uint8Array>, chunks: Uint8Array[], readerDone: boolean): Response {
-  let chunkIndex = 0;
-  const body = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      if (chunkIndex < chunks.length) {
-        controller.enqueue(chunks[chunkIndex++]);
-        return;
-      }
-      if (readerDone) {
-        controller.close();
-        return;
-      }
-      try {
-        const { done, value } = await reader.read();
-        if (done) controller.close();
-        else controller.enqueue(value);
-      } catch (error) { controller.error(error); }
-    },
-    cancel(reason) { return reader.cancel(reason); },
-  });
-  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
-}
-
-function sseEventBoundary(bytes: Uint8Array, start: number, length: number): { start: number; end: number } | null {
-  let lineStart = start;
-  for (let index = start; index < length; index += 1) {
-    if (bytes[index] !== 10 && bytes[index] !== 13) continue;
-    const next = bytes[index] === 13 && index + 1 < length && bytes[index + 1] === 10 ? index + 2 : index + 1;
-    if (index === lineStart) return { start: lineStart, end: next };
-    lineStart = next;
-    index = next - 1;
-  }
-  return null;
-}
-
-function classifySseEvent(bytes: Uint8Array): { kind: "empty" } | { kind: "healthy" | "error"; upstream: ReturnType<typeof upstreamError> } {
-  let eventType = "";
-  const dataLines: string[] = [];
-  for (const line of new TextDecoder().decode(bytes).split(/\r\n|\r|\n/)) {
-    if (!line || line.startsWith(":")) continue;
-    const colon = line.indexOf(":");
-    const field = colon < 0 ? line : line.slice(0, colon);
-    let value = colon < 0 ? "" : line.slice(colon + 1);
-    if (value.startsWith(" ")) value = value.slice(1);
-    if (field === "event") eventType = value;
-    else if (field === "data") dataLines.push(value);
-  }
-  const data = dataLines.join("\n");
-  if (dataLines.length === 0) return { kind: "empty" };
-  const upstream = upstreamError(data);
-  return eventType === "error" || hasTopLevelError(data) ? { kind: "error", upstream } : { kind: "healthy", upstream };
-}
-
-function hasTopLevelError(data: string): boolean {
-  try {
-    const value: unknown = JSON.parse(data);
-    return !!value && typeof value === "object" && !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, "error");
-  } catch { return false; }
-}
-
-function mappedUpstreamError(response: Response, upstream: ReturnType<typeof upstreamError>, status: number): Response {
-  const headers = new Headers(response.headers);
-  headers.delete("content-length");
-  headers.set("content-type", "application/json; charset=utf-8");
-  return Response.json({ error: {
-    message: upstream.message ?? (response.ok ? "upstream request failed" : response.statusText || "upstream request failed"),
-    type: upstream.type ?? "upstream_error",
-    code: upstream.code ?? status,
-  } }, { status, statusText: status === response.status ? response.statusText : "", headers });
-}
-
-function upstreamError(body: string): { message?: string; type?: string; code?: string | number } {
-  let value: unknown;
-  try {
-    const eventData = firstSseData(body);
-    value = JSON.parse(eventData || body);
-  } catch { return {}; }
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const error = "error" in value && value.error && typeof value.error === "object" && !Array.isArray(value.error) ? value.error as Record<string, unknown> : value as Record<string, unknown>;
-  return {
-    message: typeof error.message === "string" ? error.message : undefined,
-    type: typeof error.type === "string" ? error.type : undefined,
-    code: typeof error.code === "string" || typeof error.code === "number" ? error.code : undefined,
-  };
-}
-
-function firstSseData(body: string): string | null {
-  const dataLines: string[] = [];
-  for (const line of body.split(/\r\n|\r|\n/)) {
-    if (!line) {
-      if (dataLines.some((value) => value !== "")) break;
-      dataLines.length = 0;
-      continue;
-    }
-    if (line.startsWith(":")) continue;
-    const colon = line.indexOf(":");
-    const field = colon < 0 ? line : line.slice(0, colon);
-    if (field !== "data") continue;
-    let value = colon < 0 ? "" : line.slice(colon + 1);
-    if (value.startsWith(" ")) value = value.slice(1);
-    dataLines.push(value);
-  }
-  return dataLines.length > 0 ? dataLines.join("\n") : null;
 }
 
 async function reserveSelected(request: Request, env: Env, context: ExecutionContext, mode: AuthMode, selection: ProxySelection, preauthenticated: AuthorizedIdentity | null, compound?: CompoundRequestContext): Promise<ReservedProxyBudget | Response> {
@@ -657,13 +492,7 @@ async function preauthenticate(request: Request, env: Env, mode: AuthMode, provi
   return providerId ? accessIdentity(request, env, providerId) : null;
 }
 
-async function finalizeResponse(response: Response, env: Env, auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, estimated: Cost, reservation: BudgetReservation, content: string | null, compound?: CompoundRequestContext): Promise<void> {
-  let tokens: Tokens | null = null;
-  try {
-    const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.includes("json")) tokens = extractUsageTokens(JSON.parse(await readLimited(response, 2 * 1024 * 1024)));
-    else if (contentType.includes("text/event-stream")) tokens = extractSseUsageTokens(await readLimited(response, 2 * 1024 * 1024));
-  } catch { /* usage is best-effort; reservation stays conservative */ }
+async function finalizeResponse(response: Response, tokens: Tokens | null, env: Env, auth: AuthorizedIdentity, selection: ProxySelection, request: Request, requestId: string, started: number, estimated: Cost, reservation: BudgetReservation, content: string | null, compound?: CompoundRequestContext): Promise<void> {
   const measured = tokens ? actualCost(selection.model, tokens, auth.policy.requestCostMicros) : null;
   const actual = response.ok && measured != null ? measured : response.ok ? estimated.reserveMicros : 0;
   await finalizeAccounting(env, auth, reservation, actual, usageEvent(auth, selection, request, requestId, started, response.status, tokens, estimated, reservation, content, response.ok ? "success" : response.status < 500 ? "client_error" : "provider_error", actual, compound));
@@ -707,40 +536,6 @@ function usageEvent(auth: AuthorizedIdentity, selection: ProxySelection, request
     pricing_effective_at: selection.model?.pricing?.effectiveAt ?? null, cost_basis: cost.basis, status_code: statusCode,
     duration_ms: Date.now() - started, content_retained: !!contentRef, content_ref: contentRef, status,
   };
-}
-
-async function readLimited(response: Response, limit: number): Promise<string> {
-  if (!response.body) return "";
-  const reader = response.body.getReader(), decoder = new TextDecoder();
-  let size = 0, text = "";
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      size += value.byteLength;
-      if (size > limit) throw new Error("usage payload exceeds inspection limit");
-      text += decoder.decode(value, { stream: true });
-    }
-    return text + decoder.decode();
-  } finally { if (size > limit) await reader.cancel(); }
-}
-
-function observeResponseBody(response: Response, complete: () => void): Response {
-  if (!response.body) { complete(); return response; }
-  const reader = response.body.getReader();
-  let finished = false;
-  const finish = () => { if (!finished) { finished = true; reader.releaseLock(); complete(); } };
-  const body = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const next = await reader.read();
-        if (next.done) { finish(); controller.close(); }
-        else controller.enqueue(next.value);
-      } catch (error) { finish(); controller.error(error); }
-    },
-    async cancel(reason) { try { await reader.cancel(reason); } finally { finish(); } },
-  }, { highWaterMark: 0 });
-  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers });
 }
 
 function searchParamsRecord(params: URLSearchParams): Record<string, string> { const result: Record<string, string> = {}; params.forEach((value, key) => { result[key] = value; }); return result; }

--- a/worker/test/proxy-response.test.mjs
+++ b/worker/test/proxy-response.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { observeUsage, normalizePreStreamError } from "../proxy-response.ts";
+
+const encoder = new TextEncoder();
+const usage = { input_tokens: 12, output_tokens: 3 };
+
+test("usage inspection preserves split UTF-8 bytes and mixed-case media types", async () => {
+  const bytes = encoder.encode(JSON.stringify({ text: "🦞", usage }));
+  let offset = 0;
+  const upstream = new Response(new ReadableStream({
+    pull(controller) {
+      if (offset < bytes.length) controller.enqueue(bytes.slice(offset, ++offset));
+      else controller.close();
+    },
+  }), { headers: { "content-type": "Application/JSON" } });
+  const observed = observeUsage(upstream);
+  assert.deepEqual(new Uint8Array(await observed.response.arrayBuffer()), bytes);
+  assert.equal((await observed.tokens).total, 15);
+});
+
+test("oversized inspection falls back without truncating the client response", async () => {
+  const text = JSON.stringify({ text: "a".repeat(2 * 1024 * 1024), usage });
+  const observed = observeUsage(new Response(text, { headers: { "content-type": "application/json" } }));
+  assert.equal(await observed.response.text(), text);
+  assert.equal(await observed.tokens, null);
+});
+
+test("canceling a pending read never treats cancellation as a complete usage report", async () => {
+  let pulls = 0;
+  let entered;
+  const pending = new Promise(resolve => { entered = resolve; });
+  const observed = observeUsage(new Response(new ReadableStream({
+    pull(controller) {
+      if (pulls++ === 0) controller.enqueue(encoder.encode(JSON.stringify({ usage })));
+      else entered();
+    },
+  }, { highWaterMark: 0 }), { headers: { "content-type": "application/json" } }));
+  const reader = observed.response.body.getReader();
+  await reader.read();
+  const read = reader.read();
+  await pending;
+  await reader.cancel();
+  assert.equal((await read).done, true);
+  assert.equal(await observed.tokens, null);
+});
+
+test("first-event normalization and accounting do not prefetch later SSE chunks", async () => {
+  let pulls = 0;
+  const first = 'data: {"type":"response.created"}\n\n';
+  const last = `data: ${JSON.stringify({ type: "response.completed", response: { usage } })}\n\n`;
+  const response = new Response(new ReadableStream({
+    pull(controller) {
+      if (pulls === 0) controller.enqueue(encoder.encode(first));
+      else if (pulls === 1) controller.enqueue(encoder.encode(last));
+      else controller.close();
+      pulls++;
+    },
+  }, { highWaterMark: 0 }), { headers: { "content-type": "text/event-stream" } });
+  const observed = observeUsage(await normalizePreStreamError(response, true));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(pulls, 1);
+  assert.equal(await observed.response.text(), first + last);
+  assert.equal((await observed.tokens).total, 15);
+});

--- a/worker/test/stream-errors.test.mjs
+++ b/worker/test/stream-errors.test.mjs
@@ -10,7 +10,7 @@ registerHooks({
   },
 });
 
-const { normalizePreStreamError } = await import("../proxy.ts");
+const { normalizePreStreamError } = await import("../proxy-response.ts");
 const encoder = new TextEncoder();
 
 function chunkedSse(chunks, headers = {}) {

--- a/worker/test/usage-budget.test.mjs
+++ b/worker/test/usage-budget.test.mjs
@@ -58,7 +58,8 @@ function usageEnv(objectNames, { provider = "openai", limit = 100, fixedCost = 1
 
 function proxyKey() { return ["clawrouter", "live", `maintainer_key-${keyMaterial}`].join("-"); }
 
-test("binary proxy accounting preserves backpressure and settles on completion, error, or cancellation", async (t) => {
+for (const contentType of ["application/vnd.amazon.eventstream", "application/json", "text/event-stream"]) {
+test(`${contentType} accounting preserves backpressure and settles on completion, error, or cancellation`, async (t) => {
   for (const outcome of ["complete", "error", "cancel"]) {
     const env = usageEnv([], { provider: "local-openai", limit: null, retainContent: false });
     env.LOCAL_OPENAI_BASE_URL = "https://upstream.example.invalid";
@@ -73,7 +74,7 @@ test("binary proxy accounting preserves backpressure and settles on completion, 
       },
       cancel() { canceled = true; },
     }, { highWaterMark: 0 });
-    t.mock.method(globalThis, "fetch", async () => new Response(source, { headers: { "content-type": "application/vnd.amazon.eventstream" } }));
+    t.mock.method(globalThis, "fetch", async () => new Response(source, { headers: { "content-type": contentType } }));
     const pending = [];
     const response = await handler.fetch(new Request("https://clawrouter.example/v1/chat/completions", {
       method: "POST", headers: { authorization: `Bearer ${proxyKey()}`, "content-type": "application/json" },
@@ -82,7 +83,7 @@ test("binary proxy accounting preserves backpressure and settles on completion, 
     try {
       assert.equal(response.status, 200);
       await new Promise(resolve => setImmediate(resolve));
-      assert.equal(pulls, 0, "accounting must not drain a stalled client's binary stream");
+      assert.equal(pulls, 0, "accounting must not drain a stalled client's stream");
       assert.equal(events.length, 0);
       if (outcome === "cancel") await response.body.cancel();
       else if (outcome === "error") await assert.rejects(response.arrayBuffer(), /synthetic upstream failure/);
@@ -95,6 +96,7 @@ test("binary proxy accounting preserves backpressure and settles on completion, 
     }
   }
 });
+}
 
 async function sha256(value) {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));


### PR DESCRIPTION
JSON and SSE accounting drained a cloned upstream response even when the client stopped reading. Use one response observer for JSON, SSE, and binary delivery, with a 2 MiB inspection cap and settlement on completion, failure, or cancellation. Keep conservative charging when complete usage is unavailable. First-event SSE normalization also respects backpressure after its bounded sniff.

Move shared response normalization and inspection into `proxy-response.ts`, leaving routing orchestration in `proxy.ts`. Private inference retains its independent containment boundary.

Validation: the new gateway backpressure tests failed for JSON and SSE before the change and pass afterward. Added coverage includes pending-read cancellation, split UTF-8, oversized bodies, and SSE replay. Full `pnpm check` passed (288 Worker, 30 admin, 82 script tests), local Worker E2E passed, and independent Codex review found no actionable issues.
