### PR TITLE
refactor: let reservations own budget settlement routing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,10 @@ Object bindings are unchanged.
 - Required request retention fails closed before upstream traffic.
 - Provider failures release a reservation to zero and emit audit metadata.
 - Settlement and usage delivery retry independently through `USAGE_QUEUE`.
+- Each reservation keeps only its reservation ID and exact ledger address.
+  Immediate settlement and queued retries use that same address; neither
+  reconstructs it from authentication or policy state. The queue consumer still
+  accepts scope-addressed jobs left by earlier deployments.
 - Non-2xx Durable Object queue writes are retried and eventually reach the
   configured dead-letter queue.
 - Raw requests live only in the retention archive; usage ledgers contain metadata

--- a/worker/accounting.ts
+++ b/worker/accounting.ts
@@ -1,4 +1,4 @@
-import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, ProviderConnection, QueueMessage, UsageEvent } from "./types";
+import type { AuthorizedIdentity, BudgetReserveRequest, BudgetSettleRequest, Env, ProviderConnection, UsageEvent } from "./types";
 import { budgetLedgerAddress, budgetPrincipal, providerBudgetLedgerAddress } from "./budget-scope.ts";
 import { logCorrelationError } from "./correlation.ts";
 import { HttpError, randomId } from "./utils.ts";
@@ -11,10 +11,6 @@ export interface BudgetReservation {
 interface LedgerBudgetReservation {
   reservationId: string;
   objectName: string;
-  tenant: string;
-  policyId: string;
-  principalId: string | null;
-  ledger: "policy" | "provider";
 }
 
 export interface EstimatedCost {
@@ -32,22 +28,22 @@ export async function reserveBudget(env: Env, auth: AuthorizedIdentity, capabili
   if (policyLimit === 0) throw new HttpError(402, "budget_exhausted", "proxy key budget is exhausted");
   if (providerLimit === 0) throw new HttpError(402, "provider_budget_exhausted", `provider ${connection?.providerId ?? "unknown"} monthly budget is exhausted`);
   if (cost.basis === "flat_fallback") throw new HttpError(400, "pricing_required", "budgeted requests require versioned manifest pricing or a fixed policy request price");
-  const reservations: LedgerBudgetReservation[] = [];
+  const reservation: BudgetReservation = { reservations: [], reservedMicros: cost.reserveMicros };
   if (policyLimit != null) {
     const principal = budgetPrincipal(auth);
     const address = budgetLedgerAddress(auth.policyId, auth.policy, principal);
-    reservations.push(await reserveLedger(env, address, policyLimit, cost, capability, "policy", principal, "budget_exhausted", "proxy key budget is exhausted"));
+    reservation.reservations.push(await reserveLedger(env, address, policyLimit, cost, capability, "budget_exhausted", "proxy key budget is exhausted"));
   }
   if (providerLimit != null && connection) {
     const address = providerBudgetLedgerAddress(connection.providerId);
     try {
-      reservations.push(await reserveLedger(env, address, providerLimit, cost, capability, "provider", null, "provider_budget_exhausted", `provider ${connection.providerId} monthly budget is exhausted`));
+      reservation.reservations.push(await reserveLedger(env, address, providerLimit, cost, capability, "provider_budget_exhausted", `provider ${connection.providerId} monthly budget is exhausted`));
     } catch (error) {
-      await settleReservations(env, auth, reservations, 0).catch(() => undefined);
+      await settleBudget(env, reservation, 0).catch(() => undefined);
       throw error;
     }
   }
-  return { reservations, reservedMicros: cost.reserveMicros };
+  return reservation;
 }
 
 async function reserveLedger(
@@ -56,8 +52,6 @@ async function reserveLedger(
   limitMicros: number,
   cost: EstimatedCost,
   capability: string,
-  ledger: LedgerBudgetReservation["ledger"],
-  principalId: string | null,
   exhaustedCode: string,
   exhaustedMessage: string,
 ): Promise<LedgerBudgetReservation> {
@@ -75,34 +69,27 @@ async function reserveLedger(
   if (!response.ok) throw new Error(`budget reserve returned ${response.status}`);
   const result = await response.json<{ allowed: boolean; chargedMicros: number }>();
   if (!result.allowed) throw new HttpError(402, exhaustedCode, exhaustedMessage);
-  return { reservationId, objectName: address.objectName, tenant: address.tenant, policyId: address.policyId, principalId, ledger };
+  return { reservationId, objectName: address.objectName };
 }
 
-export async function finalizeAccounting(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number, event: UsageEvent): Promise<void> {
+export async function finalizeAccounting(env: Env, reservation: BudgetReservation, actualCostMicros: number, event: UsageEvent): Promise<void> {
   const results = await Promise.allSettled([
-    settleBudget(env, auth, reservation, actualCostMicros),
-    enqueueUsage(env, event),
+    settleBudget(env, reservation, actualCostMicros),
+    env.USAGE_QUEUE.send(event),
   ]);
   for (const result of results) {
     if (result.status === "rejected") logCorrelationError("accounting finalization failed", event.request_id);
   }
 }
 
-export async function settleBudget(env: Env, auth: AuthorizedIdentity, reservation: BudgetReservation, actualCostMicros: number): Promise<void> {
-  await settleReservations(env, auth, reservation.reservations, actualCostMicros);
-}
-
-async function settleReservations(env: Env, auth: AuthorizedIdentity, reservations: LedgerBudgetReservation[], actualCostMicros: number): Promise<void> {
-  const results = await Promise.allSettled(reservations.map((reservation) => settleReservation(env, auth, reservation, actualCostMicros)));
+export async function settleBudget(env: Env, reservation: BudgetReservation, actualCostMicros: number): Promise<void> {
+  const results = await Promise.allSettled(reservation.reservations.map((reservation) => settleReservation(env, reservation, actualCostMicros)));
   const failed = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
   if (failed) throw failed.reason;
 }
 
-async function settleReservation(env: Env, auth: AuthorizedIdentity, reservation: LedgerBudgetReservation, actualCostMicros: number): Promise<void> {
+async function settleReservation(env: Env, reservation: LedgerBudgetReservation, actualCostMicros: number): Promise<void> {
   const body: BudgetSettleRequest = { reservationId: reservation.reservationId, actualCostMicros };
-  const job: QueueMessage = reservation.ledger === "provider"
-    ? { kind: "budget_settlement", tenant_id: reservation.tenant, policy_id: reservation.policyId, principal_id: null, ledger: { objectName: reservation.objectName }, request: body }
-    : { kind: "budget_settlement", tenant_id: reservation.tenant, policy_id: auth.policyId, principal_id: reservation.principalId, request: body };
   try {
     const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(reservation.objectName));
     const response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(body) });
@@ -110,11 +97,7 @@ async function settleReservation(env: Env, auth: AuthorizedIdentity, reservation
   } catch {
     // The durable queue is the recovery boundary for thrown and non-2xx ledger failures.
   }
-  await env.USAGE_QUEUE.send(job);
+  await env.USAGE_QUEUE.send({ kind: "budget_settlement", ledger: { objectName: reservation.objectName }, request: body });
 }
 
 export function emptyReservation(): BudgetReservation { return { reservations: [], reservedMicros: 0 }; }
-
-export async function enqueueUsage(env: Env, event: UsageEvent): Promise<void> {
-  await env.USAGE_QUEUE.send(event satisfies QueueMessage);
-}

--- a/worker/ledgers.ts
+++ b/worker/ledgers.ts
@@ -160,7 +160,7 @@ export async function queue(batch: MessageBatch<QueueMessage>, env: Env): Promis
       if ("type" in message.body) response = await usageStub(env, message.body.tenant_id, message.body.policy_id).fetch("https://clawrouter.internal/ingest", { method: "POST", body: JSON.stringify(message.body) });
       else {
         const job = message.body;
-        const objectName = job.ledger?.objectName ?? `${job.tenant_id}:${job.policy_id}${job.principal_id ? `:${job.principal_id}` : ""}`;
+        const objectName = "ledger" in job ? job.ledger.objectName : `${job.tenant_id}:${job.policy_id}${job.principal_id ? `:${job.principal_id}` : ""}`;
         const stub = env.BUDGET_LEDGER.get(env.BUDGET_LEDGER.idFromName(objectName));
         response = await stub.fetch("https://clawrouter.internal/settle", { method: "POST", body: JSON.stringify(job.request) });
       }

--- a/worker/proxy-accounting.ts
+++ b/worker/proxy-accounting.ts
@@ -48,7 +48,7 @@ export function createProxyAccounting(options: AccountingContext) {
       pricing_effective_at: selection.model?.pricing?.effectiveAt ?? null, cost_basis: cost.basis, status_code: statusCode,
       duration_ms: Date.now() - started, content_retained: !!contentRef, content_ref: contentRef, status,
     };
-    return finalizeAccounting(env, auth, reservation, actual, event);
+    return finalizeAccounting(env, reservation, actual, event);
   }
   return {
     cost,

--- a/worker/test/accounting.test.mjs
+++ b/worker/test/accounting.test.mjs
@@ -1,26 +1,32 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { finalizeAccounting, settleBudget } from "../accounting.ts";
+import { queue } from "../ledgers.ts";
 
-const auth = {
-  credentialId: "credential",
-  principalId: "user@example.com",
-  authType: "proxy_key",
-  policyId: "policy",
-  policy: { enabled: true, generation: "v1", providers: [], tenantId: "tenant", retainRequestContent: true },
-  contentRetentionDisabled: false,
-};
 const reservation = {
-  reservations: [{ reservationId: "reservation", objectName: "tenant:policy", tenant: "tenant", policyId: "tenant/policy", principalId: null, ledger: "policy" }],
+  reservations: [{ reservationId: "reservation", objectName: "tenant:policy" }],
   reservedMicros: 100,
 };
 const event = { id: "usage", type: "clawrouter.usage.v1", tenant_id: "tenant", policy_id: "policy", request_id: "request-safe" };
 
 test("thrown ledger settlement queues a retry", async () => {
-  const sent = [];
-  const env = mockEnv(async (message) => { sent.push(message); });
-  await settleBudget(env, auth, reservation, 42);
-  assert.deepEqual(sent, [{ kind: "budget_settlement", tenant_id: "tenant", policy_id: "policy", principal_id: null, request: { reservationId: "reservation", actualCostMicros: 42 } }]);
+  for (const objectName of ["tenant:policy", "tenant:policy:user@example.com", "provider:openai"]) {
+    const sent = [], destinations = [];
+    let available = false, acknowledged = false;
+    const env = mockEnv(async message => { sent.push(message); });
+    env.BUDGET_LEDGER.get = name => ({ fetch: async (_url, init) => {
+      destinations.push(name);
+      assert.deepEqual(JSON.parse(init.body), { reservationId: "reservation", actualCostMicros: 42 });
+      if (!available) throw new Error("synthetic outage");
+      return new Response("settled");
+    } });
+    await settleBudget(env, { ...reservation, reservations: [{ reservationId: "reservation", objectName }] }, 42);
+    assert.deepEqual(sent, [{ kind: "budget_settlement", ledger: { objectName }, request: { reservationId: "reservation", actualCostMicros: 42 } }]);
+    available = true;
+    await queue({ messages: [{ body: sent[0], ack() { acknowledged = true; }, retry() { assert.fail("settlement should succeed"); } }] }, env);
+    assert.equal(acknowledged, true);
+    assert.deepEqual(destinations, [objectName, objectName]);
+  }
 });
 
 test("settlement retry failure does not suppress the usage event", async () => {
@@ -33,7 +39,7 @@ test("settlement retry failure does not suppress the usage event", async () => {
   const original = console.error;
   console.error = (...values) => errors.push(JSON.stringify(values));
   try {
-    await finalizeAccounting(env, auth, reservation, 42, event);
+    await finalizeAccounting(env, reservation, 42, event);
   } finally {
     console.error = original;
   }

--- a/worker/test/budget-scope.test.mjs
+++ b/worker/test/budget-scope.test.mjs
@@ -30,7 +30,7 @@ test("reserve and settle use the same principal ledger without orphaning the res
   const env = budgetEnv();
   const identity = auth("owner@example.com", "owner_key");
   const reservation = await reserveBudget(env, identity, "llm.chat", cost);
-  await settleBudget(env, identity, reservation, 25);
+  await settleBudget(env, reservation, 25);
   await assert.doesNotReject(() => reserveBudget(env, identity, "llm.chat", { ...cost, reserveMicros: 75 }));
   assert.equal(env.objectNames[0], "tenant:maintainer_access:owner@example.com");
   assert.equal(env.objectNames[1], env.objectNames[0]);

--- a/worker/test/provider-budget.test.mjs
+++ b/worker/test/provider-budget.test.mjs
@@ -29,7 +29,7 @@ test("provider denial returns provider_budget_exhausted and releases the policy 
 test("successful accounting settles policy and provider ledgers to actual cost", async () => {
   const env = budgetEnv();
   const reservation = await reserveBudget(env, auth, "llm.chat", cost, { providerId: "openai", enabled: true, monthlyBudgetMicros: 100 });
-  await settleBudget(env, auth, reservation, 25);
+  await settleBudget(env, reservation, 25);
   const settlements = env.calls.filter((call) => call.path === "/settle");
   assert.deepEqual(settlements.map(({ name, body }) => [name, body.actualCostMicros]).sort(), [["provider:openai", 25], ["tenant:policy", 25]]);
   assert.equal(reservation.reservedMicros, 60);

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -336,7 +336,11 @@ export interface UsageEvent {
   status: "success" | "provider_error" | "client_error" | "denied" | "timeout";
 }
 
-export type QueueMessage = UsageEvent | { kind: "budget_settlement"; tenant_id: string; policy_id: string; principal_id?: string | null; ledger?: { objectName: string }; request: BudgetSettleRequest };
+export type QueueMessage = UsageEvent | ({ kind: "budget_settlement"; request: BudgetSettleRequest } & (
+  { ledger: { objectName: string } }
+  // Queued jobs from earlier deployments still carry their original scope.
+  | { tenant_id: string; policy_id: string; principal_id?: string | null }
+));
 
 export interface BudgetReserveRequest {
   policyId: string;


### PR DESCRIPTION
Budget settlement now uses the ledger address captured when the reservation was created for both immediate settlement and durable retries. Previously policy retries reconstructed that address from authentication and scope fields while provider retries used the stored address. The reservation now contains only its ID and destination, and the unused forwarding helpers are removed.

Older scope-addressed queue jobs remain readable so an upgrade does not strand pending settlements. The request API, budget limits, and usage event schema are unchanged.

Validation: full `pnpm check` passed; the final Worker check passed all 292 tests; local `pnpm worker:e2e` passed. Focused coverage verifies failed settlement and queue replay for policy, principal, and provider budgets, alongside existing legacy queue delivery coverage. Independent Codex review found no actionable findings.

Deployment: source change only; no live deployment or configuration changes. Remaining risk is the internal queue payload transition, covered by both current and older job tests.
