### PR TITLE
fix: keep legacy migration reads canonical

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,12 @@ bindings, provider connections, OAuth authorization state, upstream-grant pool
 membership, and sanitized grant runtime state. Existing KV data is imported
 once per resource family and recorded with a Durable Object migration marker.
 After that marker, missing records remain missing; request paths never resurrect
-stale KV state. Assignment rules, scoped upstream-grant secrets, and provider
+stale KV state. The authority checks the marker when accepting an import, so
+an already-running KV read cannot seed records after migration closes. Migration
+callers return a fresh canonical read, never their local seed copy; concurrent
+canonical updates take precedence. The authority also owns import precedence
+and result ordering instead of duplicating those decisions in client-side maps.
+Assignment rules, scoped upstream-grant secrets, and provider
 health remain outside that global authority because they have separate lifecycle
 and consistency needs. `GRANT_CREDENTIALS` is the canonical raw-secret owner,
 sharded one Durable Object per grant. KV holds its redacted routing projection;

--- a/worker/authority.ts
+++ b/worker/authority.ts
@@ -85,6 +85,7 @@ export class PolicyBindingIndexObject implements DurableObject {
   }
 
   private initializeBindings(seeds: Seed[]): void {
+    if (this.hasMeta("bindings_global_initialized")) return;
     for (const seed of seeds) {
       const principal = normalizePrincipal(seed.principal);
       const key = principalKey(principal);
@@ -143,6 +144,7 @@ export class PolicyBindingIndexObject implements DurableObject {
   }
 
   private initializeUsers(users: AccessControlUser[]): void {
+    if (this.hasMeta("users_global_initialized")) return;
     for (const user of users) if (!this.getUser(user.email)) this.putUser(user);
   }
 
@@ -183,7 +185,10 @@ export class PolicyBindingIndexObject implements DurableObject {
     this.sql.exec("INSERT OR REPLACE INTO access_policies (policy_id, policy_json) VALUES (?, ?)", entry.policyId, JSON.stringify(entry.policy));
   }
 
-  private initializePolicies(entries: AccessPolicyEntry[]): void { for (const entry of entries) if (!this.getPolicy(entry.policyId)) this.putPolicy(entry); }
+  private initializePolicies(entries: AccessPolicyEntry[]): void {
+    if (this.hasMeta("policies_global_initialized")) return;
+    for (const entry of entries) if (!this.getPolicy(entry.policyId)) this.putPolicy(entry);
+  }
   private getPolicy(id: string): AccessPolicyEntry | null {
     const row = rows<{ policy_json: string }>(this.sql.exec("SELECT policy_json FROM access_policies WHERE policy_id = ?", id))[0];
     return row ? { policyId: id, policy: JSON.parse(row.policy_json) } : null;
@@ -220,7 +225,10 @@ export class PolicyBindingIndexObject implements DurableObject {
     return { outcome: "updated" };
   }
   private deleteCredential(id: string): void { this.sql.exec("DELETE FROM proxy_credentials WHERE credential_id = ?", id); }
-  private initializeCredentials(entries: ProxyCredentialEntry[]): void { for (const entry of entries) if (!this.getCredential(entry.credentialId)) this.putCredential(entry); }
+  private initializeCredentials(entries: ProxyCredentialEntry[]): void {
+    if (this.hasMeta("credentials_global_initialized")) return;
+    for (const entry of entries) if (!this.getCredential(entry.credentialId)) this.putCredential(entry);
+  }
   private getCredential(id: string): ProxyCredentialEntry | null {
     const row = rows<{ credential_json: string }>(this.sql.exec("SELECT credential_json FROM proxy_credentials WHERE credential_id = ?", id))[0];
     return row ? { credentialId: id, credential: JSON.parse(row.credential_json) } : null;
@@ -237,7 +245,10 @@ export class PolicyBindingIndexObject implements DurableObject {
   private putConnection(connection: ProviderConnection): void {
     this.sql.exec("INSERT OR REPLACE INTO provider_connections (provider_id, connection_json) VALUES (?, ?)", connection.providerId, JSON.stringify(connection));
   }
-  private initializeConnections(items: ProviderConnection[]): void { for (const item of items) if (!this.getConnection(item.providerId)) this.putConnection(item); }
+  private initializeConnections(items: ProviderConnection[]): void {
+    if (this.hasMeta("connections_global_initialized")) return;
+    for (const item of items) if (!this.getConnection(item.providerId)) this.putConnection(item);
+  }
   private getConnection(id: string): ProviderConnection | null {
     const row = rows<{ connection_json: string }>(this.sql.exec("SELECT connection_json FROM provider_connections WHERE provider_id = ?", id))[0];
     return row ? JSON.parse(row.connection_json) : null;
@@ -571,33 +582,25 @@ export async function authorityCall<T>(env: Env, path: string, body: unknown, ob
 
 export async function listPolicies(env: Env): Promise<AccessPolicyEntry[]> {
   const result = await authorityCall<{ initialized: boolean; policies: AccessPolicyEntry[] }>(env, "/policies/list", {});
-  const authoritative = result.policies;
-  if (result.initialized) return authoritative;
-  const byId = new Map(authoritative.map((entry) => [entry.policyId, entry]));
-  for (const [key, value] of await listKvJson<Record<string, unknown>>(env, "policies/")) {
-    const policyId = key.slice("policies/".length);
-    if (!byId.has(policyId)) byId.set(policyId, { policyId, policy: normalizePolicyRecord(value, contentRetentionDefault(env)) });
-  }
-  for (const [policyId, value] of await listGenuineLegacyKeys(env)) {
-    if (!byId.has(policyId)) byId.set(policyId, { policyId, policy: normalizePolicyRecord(value, contentRetentionDefault(env)) });
-  }
-  await authorityCall(env, "/policies/initialize-all", [...byId.values()]);
-  return [...byId.values()].sort((a, b) => a.policyId.localeCompare(b.policyId));
+  if (result.initialized) return result.policies;
+  const policies = await listKvJson<Record<string, unknown>>(env, "policies/");
+  const legacy = await listGenuineLegacyKeys(env);
+  await authorityCall(env, "/policies/initialize-all", [
+    ...policies.map(([key, value]) => ({ policyId: key.slice("policies/".length), policy: normalizePolicyRecord(value, contentRetentionDefault(env)) })),
+    ...legacy.map(([policyId, value]) => ({ policyId, policy: normalizePolicyRecord(value, contentRetentionDefault(env)) })),
+  ]);
+  return (await authorityCall<{ policies: AccessPolicyEntry[] }>(env, "/policies/list", {})).policies;
 }
 export async function listCredentials(env: Env): Promise<ProxyCredentialEntry[]> {
   const result = await authorityCall<{ initialized: boolean; credentials: ProxyCredentialEntry[] }>(env, "/credentials/list", {});
-  const authoritative = result.credentials;
-  if (result.initialized) return authoritative;
-  const byId = new Map(authoritative.map((entry) => [entry.credentialId, entry]));
-  for (const [key, value] of await listKvJson<Record<string, unknown>>(env, "credentials/")) {
-    const credentialId = key.slice("credentials/".length);
-    if (!byId.has(credentialId)) byId.set(credentialId, { credentialId, credential: normalizeCredentialRecord(value) });
-  }
-  for (const [credentialId, value] of await listGenuineLegacyKeys(env)) {
-    if (!byId.has(credentialId)) byId.set(credentialId, { credentialId, credential: normalizeCredentialRecord(value, credentialId) });
-  }
-  await authorityCall(env, "/credentials/initialize-all", [...byId.values()]);
-  return [...byId.values()].sort((a, b) => a.credentialId.localeCompare(b.credentialId));
+  if (result.initialized) return result.credentials;
+  const credentials = await listKvJson<Record<string, unknown>>(env, "credentials/");
+  const legacy = await listGenuineLegacyKeys(env);
+  await authorityCall(env, "/credentials/initialize-all", [
+    ...credentials.map(([key, value]) => ({ credentialId: key.slice("credentials/".length), credential: normalizeCredentialRecord(value) })),
+    ...legacy.map(([credentialId, value]) => ({ credentialId, credential: normalizeCredentialRecord(value, credentialId) })),
+  ]);
+  return (await authorityCall<{ credentials: ProxyCredentialEntry[] }>(env, "/credentials/list", {})).credentials;
 }
 export async function listUsers(env: Env): Promise<AccessControlUser[]> {
   const result = await authorityCall<{ initialized: boolean; users: AccessControlUser[] }>(env, "/users/list", {});
@@ -615,36 +618,36 @@ export async function listBindings(env: Env): Promise<PolicyBinding[]> {
 }
 export async function resolvePolicies(env: Env, ids: string[]): Promise<AccessPolicyEntry[]> {
   const result = await authorityCall<{ initialized: boolean; policies: AccessPolicyEntry[]; missingPolicyIds: string[] }>(env, "/policies/resolve", { policyIds: ids });
-  if (result.initialized) return result.policies;
+  if (result.initialized || !result.missingPolicyIds.length) return result.policies;
   const seeded: AccessPolicyEntry[] = [];
   for (const policyId of result.missingPolicyIds) {
     const value = await env.POLICY_KV.get<Record<string, unknown>>(`policies/${policyId}`, "json") ?? await genuineLegacyKey(env, policyId);
     if (value) seeded.push({ policyId, policy: normalizePolicyRecord(value, contentRetentionDefault(env)) });
   }
   if (seeded.length) await authorityCall(env, "/policies/initialize", seeded);
-  return [...result.policies, ...seeded];
+  return (await authorityCall<typeof result>(env, "/policies/resolve", { policyIds: ids })).policies;
 }
 export async function resolveCredentials(env: Env, ids: string[]): Promise<ProxyCredentialEntry[]> {
   const result = await authorityCall<{ initialized: boolean; credentials: ProxyCredentialEntry[]; missingCredentialIds: string[] }>(env, "/credentials/resolve", { credentialIds: ids });
-  if (result.initialized) return result.credentials;
+  if (result.initialized || !result.missingCredentialIds.length) return result.credentials;
   const seeded: ProxyCredentialEntry[] = [];
   for (const credentialId of result.missingCredentialIds) {
     const value = await env.POLICY_KV.get<Record<string, unknown>>(`credentials/${credentialId}`, "json") ?? await genuineLegacyKey(env, credentialId);
     if (value) seeded.push({ credentialId, credential: normalizeCredentialRecord(value, credentialId) });
   }
   if (seeded.length) await authorityCall(env, "/credentials/initialize", seeded);
-  return [...result.credentials, ...seeded];
+  return (await authorityCall<typeof result>(env, "/credentials/resolve", { credentialIds: ids })).credentials;
 }
 export async function resolveUsers(env: Env, emails: string[]): Promise<AccessControlUser[]> {
   const result = await authorityCall<{ initialized: boolean; users: AccessControlUser[]; missingEmails: string[] }>(env, "/users/resolve", { emails });
-  if (result.initialized) return result.users;
+  if (result.initialized || !result.missingEmails.length) return result.users;
   const seeded: AccessControlUser[] = [];
   for (const email of result.missingEmails) {
     const record = await env.POLICY_KV.get<AccessUserRecord>(`access/users/${email}`, "json");
     if (record) seeded.push({ email, record });
   }
   if (seeded.length) await authorityCall(env, "/users/initialize", seeded);
-  return [...result.users, ...seeded];
+  return (await authorityCall<typeof result>(env, "/users/resolve", { emails })).users;
 }
 export async function resolveBindings(env: Env, principals: Principal[]): Promise<PolicyBinding[]> {
   const result = await authorityCall<{ initialized: boolean; bindings: PolicyBinding[]; missingPrincipals: Principal[] }>(env, "/resolve", { principals });
@@ -655,15 +658,15 @@ export async function resolveBindings(env: Env, principals: Principal[]): Promis
     seeds.push({ principal, bindings: (await listKvJson<PolicyBinding>(env, prefix)).map(([, binding]) => binding) });
   }
   await authorityCall(env, "/initialize", seeds);
-  return sortBindings([...result.bindings, ...seeds.flatMap((seed) => seed.bindings)]);
+  return (await authorityCall<typeof result>(env, "/resolve", { principals })).bindings;
 }
 export async function resolveConnections(env: Env, providerIds: string[]): Promise<ProviderConnection[]> {
   const ids = [...new Set(providerIds)];
   const result = await authorityCall<{ initialized: boolean; connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
-  if (result.initialized) return result.connections;
+  if (result.initialized || !result.missingProviderIds.length) return result.connections;
   const seeded = (await Promise.all(result.missingProviderIds.map((id) => env.POLICY_KV.get<ProviderConnection>(`connections/${id}`, "json")))).filter(Boolean) as ProviderConnection[];
   if (seeded.length) await authorityCall(env, "/connections/initialize", seeded);
-  return [...result.connections, ...seeded];
+  return (await authorityCall<typeof result>(env, "/connections/resolve", { providerIds: ids })).connections;
 }
 
 export async function listConnections(env: Env, providerIds: string[]): Promise<ProviderConnection[]> {
@@ -671,9 +674,8 @@ export async function listConnections(env: Env, providerIds: string[]): Promise<
   const result = await authorityCall<{ initialized: boolean; connections: ProviderConnection[]; missingProviderIds: string[] }>(env, "/connections/resolve", { providerIds: ids });
   if (result.initialized) return result.connections;
   const seeded = (await Promise.all(result.missingProviderIds.map((id) => env.POLICY_KV.get<ProviderConnection>(`connections/${id}`, "json")))).filter(Boolean) as ProviderConnection[];
-  const connections = [...result.connections, ...seeded];
-  await authorityCall(env, "/connections/initialize-all", connections);
-  return connections;
+  await authorityCall(env, "/connections/initialize-all", seeded);
+  return (await authorityCall<typeof result>(env, "/connections/resolve", { providerIds: ids })).connections;
 }
 
 export async function resolveConnection(env: Env, providerId: string): Promise<ProviderConnection | null> {

--- a/worker/test/authority-migration.test.mjs
+++ b/worker/test/authority-migration.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import {
+  PolicyBindingIndexObject, listBindings, listConnections, listCredentials, listPolicies, listUsers,
+  resolveBindings, resolveConnections, resolveCredentials, resolvePolicies, resolveUsers,
+} from "../authority.ts";
+
+const principal = { principalType: "user", principalId: "fixture@example.com" };
+const families = [
+  { name: "policies", key: "policies/fixture", value: { enabled: true, generation: "v1", providers: [] },
+    row: value => ({ policyId: "fixture", policy: value }), enabled: row => row.policy.enabled,
+    put: "/policies/put", close: "/policies/initialize-all", list: listPolicies, resolve: env => resolvePolicies(env, ["fixture"]) },
+  { name: "credentials", key: "credentials/fixture", value: { enabled: true, policyId: "fixture", policyGeneration: "v1", secretSha256: "a".repeat(64) },
+    row: value => ({ credentialId: "fixture", credential: value }), enabled: row => row.credential.enabled,
+    put: "/credentials/put", close: "/credentials/initialize-all", list: listCredentials, resolve: env => resolveCredentials(env, ["fixture"]) },
+  { name: "users", key: "access/users/fixture@example.com", value: { enabled: true, role: "user", tenantId: "fixture", groups: [] },
+    row: value => ({ email: "fixture@example.com", record: value }), enabled: row => row.record.enabled,
+    put: "/users/put", close: "/users/initialize-all", list: listUsers, resolve: env => resolveUsers(env, ["fixture@example.com"]) },
+  { name: "connections", key: "connections/fixture", value: { providerId: "fixture", enabled: true },
+    row: value => value, enabled: row => row.enabled,
+    put: "/connections/put", close: "/connections/initialize-all", list: env => listConnections(env, ["fixture"]), resolve: env => resolveConnections(env, ["fixture"]) },
+  { name: "bindings", key: `access/bindings/user/${encodeURIComponent(principal.principalId)}/fixture`, value: { ...principal, policyId: "fixture", enabled: true, priority: 100 },
+    row: value => ({ seed: { principal, bindings: [] }, binding: value }), enabled: row => row.enabled,
+    put: "/mutate", close: "/initialize-all", list: listBindings, resolve: env => resolveBindings(env, [principal]) },
+];
+
+for (const family of families) {
+  for (const mode of ["list", "resolve"]) {
+    test(`${family.name} ${mode} returns the canonical update made during a legacy read`, async t => {
+      const fixture = migrationEnv(t, family);
+      fixture.beforeRead = () => fixture.call(family.put, family.row({ ...family.value, enabled: false }));
+      const rows = await family[mode](fixture.env);
+      assert.equal(rows.length, 1);
+      assert.equal(family.enabled(rows[0]), false);
+    });
+
+    test(`${family.name} ${mode} cannot seed after migration closes during its legacy read`, async t => {
+      const fixture = migrationEnv(t, family);
+      fixture.beforeRead = () => fixture.call(family.close, []);
+      assert.deepEqual(await family[mode](fixture.env), []);
+      assert.deepEqual(await family.resolve(fixture.env), []);
+      assert.equal(fixture.reads, 1, "closed migrations never read KV again");
+      await fixture.call(family.put, family.row({ ...family.value, enabled: false }));
+      const current = await family.resolve(fixture.env);
+      assert.equal(current.length, 1, "explicit canonical writes remain available");
+      assert.equal(family.enabled(current[0]), false);
+    });
+  }
+}
+
+for (const family of families.slice(0, 2)) {
+  test(`${family.name} import keeps canonical and explicit-record precedence over combined legacy keys`, async t => {
+    const fixture = migrationEnv(t, family);
+    fixture.store.set("keys/fixture", { enabled: false, generation: "legacy" });
+    const imported = await family.list(fixture.env);
+    assert.equal(imported.length, 1);
+    assert.equal(family.enabled(imported[0]), true, "explicit KV record wins over a combined legacy key");
+    await fixture.call(family.put, family.row({ ...family.value, enabled: false }));
+    assert.equal(family.enabled((await family.list(fixture.env))[0]), false, "canonical data stays authoritative");
+  });
+}
+
+function migrationEnv(t, family) {
+  const db = new DatabaseSync(":memory:");
+  t.after(() => db.close());
+  const sql = { exec(query, ...bindings) {
+    const statement = db.prepare(query);
+    if (statement.columns().length) return statement.all(...bindings);
+    statement.run(...bindings);
+    return [];
+  } };
+  const authority = new PolicyBindingIndexObject({ storage: { sql } });
+  const fixture = {
+    beforeRead: null, reads: 0, store: new Map([[family.key, family.value]]),
+    async call(path, body) {
+      const response = await authority.fetch(new Request(`https://clawrouter.internal${path}`, { method: "POST", body: JSON.stringify(body) }));
+      assert.equal(response.status, 200, await response.clone().text());
+      return response;
+    },
+    env: {
+      ACCESS_CONTROL: { idFromName: name => name, get: () => ({ fetch: (url, init) => authority.fetch(new Request(url, init)) }) },
+      POLICY_KV: {
+        async list({ prefix }) { return { list_complete: true, keys: [...fixture.store.keys()].filter(name => name.startsWith(prefix)).map(name => ({ name })) }; },
+        async get(key) {
+          if (!fixture.store.has(key)) return null;
+          fixture.reads++;
+          const action = fixture.beforeRead;
+          fixture.beforeRead = null;
+          await action?.();
+          return structuredClone(fixture.store.get(key));
+        },
+      },
+    },
+  };
+  return fixture;
+}


### PR DESCRIPTION
A legacy KV read can finish after a canonical record changes or migration closes. Previously callers could return stale KV records even when the canonical store rejected them, and late imports could resurrect records after migration had closed.

The canonical store now checks the migration marker at the import boundary, and migration callers return its current records. This removes the client-side merged snapshots and duplicate precedence maps. Explicit canonical writes still work after closure; ordinary reads of initialized or already-known records keep their existing fast path. No public API or storage schema change is required.

Validation: 18 of 20 race cases failed against the old code; all 22 new regression cases now pass across policies, credentials, users, connections, and bindings. The extra cases verify explicit-record precedence over combined legacy keys. Full `pnpm check` and local `pnpm worker:e2e` passed. Independent Codex review found no actionable findings.

Deployment: source change only; no live deployment or configuration changes. Migration reads now perform a canonical reread after awaiting KV; that extra call is limited to migration work.
