### PR TITLE
fix: keep automatic user updates in the access authority

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,10 @@ Authentication is read-only after an existing user receives versioned
 verified GitHub evidence remains an explicit admin operation. Legacy KV
 assignment retention state is imported once before the first canonical
 reconciliation so unknown external membership does not revoke existing access.
+Reconciliation evaluates and writes the current user inside `ACCESS_CONTROL`;
+callers supply rules and evidence, never a replacement user snapshot. Automatic
+login creation inserts only missing users. Both operations preserve intervening
+administrator changes to enabled state, tenant, manual groups, and retention.
 
 The browser loads immutable providers/routes once. Admin refreshes use
 `GET /v1/admin/bootstrap` for one coherent authority/readiness snapshot. Usage is

--- a/worker/access.ts
+++ b/worker/access.ts
@@ -34,8 +34,7 @@ async function cloudflareAccessSession(request: Request, env: Env): Promise<Acce
   const role = adminRole(email, env) ? "admin" : "user";
   let user = (await resolveUsers(env, [email]))[0];
   if (!user) {
-    user = { email, record: { role: "user", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } };
-    await authorityCall(env, "/users/put", user);
+    user = await authorityCall<AccessControlUser>(env, "/users/create", { email, record: { role: "user", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } });
   }
   const rules = await listAssignmentRules(env);
   const hasGithubRules = rules.some((rule) => rule.enabled && ["github_org", "github_team"].includes(rule.kind));

--- a/worker/assignments.ts
+++ b/worker/assignments.ts
@@ -1,16 +1,13 @@
-import { authorityCall } from "./authority";
+import { authorityCall } from "./authority.ts";
 import {
   assignmentGroup,
-  evaluateUserAssignments,
-  normalizeAssignmentEvidence,
-  withLegacyAssignmentState,
   type AssignmentEvidence,
   type AssignmentRuleEntry,
-} from "./assignment-evaluator";
+} from "./assignment-evaluator.ts";
 import type { AccessControlUser, AssignmentRule, AssignmentState, Env } from "./types";
 
-export { assignmentRulesRevision, normalizeAssignmentEvidence } from "./assignment-evaluator";
-export type { AssignmentEvidence, AssignmentRuleEntry } from "./assignment-evaluator";
+export { assignmentRulesRevision, normalizeAssignmentEvidence } from "./assignment-evaluator.ts";
+export type { AssignmentEvidence, AssignmentRuleEntry } from "./assignment-evaluator.ts";
 
 export async function listAssignmentRules(env: Env): Promise<AssignmentRuleEntry[]> {
   const entries: AssignmentRuleEntry[] = [];
@@ -32,9 +29,5 @@ export async function reconcileUserAssignments(user: AccessControlUser, rules: A
   const legacy = user.record.assignmentState
     ? null
     : await env.POLICY_KV.get<Partial<AssignmentState>>(`access/assignment-state/${user.email.trim().toLowerCase()}`, "json");
-  const candidate = withLegacyAssignmentState(user, legacy);
-  const evaluated = evaluateUserAssignments(candidate, rules, evidence, force);
-  if (!evaluated.changed) return { user, matchedRuleIds: evaluated.matchedRuleIds, retainedRuleIds: evaluated.retainedRuleIds };
-  await authorityCall(env, "/users/put", evaluated.user);
-  return { user: evaluated.user, matchedRuleIds: evaluated.matchedRuleIds, retainedRuleIds: evaluated.retainedRuleIds };
+  return authorityCall(env, "/users/reconcile-assignments", { email: user.email, rules, legacy, evidence, force });
 }

--- a/worker/authority.ts
+++ b/worker/authority.ts
@@ -1,7 +1,8 @@
 import type {
   AccessControlUser, AccessPolicyEntry, AccessUserRecord, Env, OAuthState, PolicyBinding,
-  GrantRoutingPolicy, GrantRuntimeState, ProviderConnection, ProxyCredentialEntry,
+  AssignmentState, GrantRoutingPolicy, GrantRuntimeState, ProviderConnection, ProxyCredentialEntry,
 } from "./types";
+import { evaluateUserAssignments, withLegacyAssignmentState, type AssignmentEvidence, type AssignmentRuleEntry } from "./assignment-evaluator.ts";
 import { contentRetentionDefault } from "./content-retention.ts";
 import { errorResponse, HttpError, json, normalizeEmail, readJson, safeEqual } from "./utils.ts";
 
@@ -32,6 +33,8 @@ export class PolicyBindingIndexObject implements DurableObject {
       if (path === "/users/initialize") { this.initializeUsers(await readJson<AccessControlUser[]>(request)); return new Response("initialized"); }
       if (path === "/users/initialize-all") { this.initializeUsers(await readJson<AccessControlUser[]>(request)); this.putMeta("users_global_initialized"); return new Response("initialized"); }
       if (path === "/users/put") { this.putUser(await readJson<AccessControlUser>(request)); return new Response("updated"); }
+      if (path === "/users/create") return json(this.createUser(await readJson<AccessControlUser>(request)));
+      if (path === "/users/reconcile-assignments") return json(this.reconcileUserAssignments(await readJson<AssignmentReconcileRequest>(request)));
       if (path === "/users/put-bindings") return json(this.putUserBindings(await readJson<UserBindingsRequest>(request)));
       if (path === "/users/list") return json({ initialized: this.hasMeta("users_global_initialized"), users: this.listUsers() });
       if (path === "/policies/resolve") return json(this.resolvePolicies((await readJson<{ policyIds: string[] }>(request)).policyIds));
@@ -148,6 +151,13 @@ export class PolicyBindingIndexObject implements DurableObject {
     for (const user of users) if (!this.getUser(user.email)) this.putUser(user);
   }
 
+  private createUser(defaults: AccessControlUser): AccessControlUser {
+    const existing = this.getUser(defaults.email);
+    if (existing) return existing;
+    this.putUser(defaults);
+    return this.getUser(defaults.email)!;
+  }
+
   private getUser(email: string): AccessControlUser | null {
     const normalized = normalizeEmail(email);
     if (!normalized) return null;
@@ -166,6 +176,15 @@ export class PolicyBindingIndexObject implements DurableObject {
 
   private listUsers(): AccessControlUser[] {
     return rows<{ email: string; user_json: string }>(this.sql.exec("SELECT email, user_json FROM access_users ORDER BY email")).map((row) => ({ email: row.email, record: JSON.parse(row.user_json) }));
+  }
+
+  private reconcileUserAssignments(request: AssignmentReconcileRequest) {
+    const user = this.getUser(request.email);
+    if (!user) throw new HttpError(404, "unknown_user", "access user not found");
+    const candidate = withLegacyAssignmentState(user, request.legacy);
+    const result = evaluateUserAssignments(candidate, request.rules, request.evidence, request.force);
+    if (result.changed) this.putUser(result.user);
+    return result;
   }
 
   private putUserBindings(request: UserBindingsRequest): { bindings: PolicyBinding[] } {
@@ -418,6 +437,7 @@ export class PolicyBindingIndexObject implements DurableObject {
   }
 }
 
+interface AssignmentReconcileRequest { email: string; rules: AssignmentRuleEntry[]; legacy: Partial<AssignmentState> | null; evidence?: AssignmentEvidence; force: boolean }
 interface UserBindingsRequest { user: AccessControlUser; policyIds: string[]; seed: Seed }
 interface GrantPoolResolveRequest { policyId: string; tenantId: string; providerId: string; defaultKeys?: string[] }
 interface GrantPoolSyncRequest { scope: "policies" | "tenants"; scopeId: string; tokenRef: string; previousProvider: string | null; provider: string | null; enabled: boolean }

--- a/worker/local-auth.ts
+++ b/worker/local-auth.ts
@@ -55,8 +55,7 @@ export async function localLogin(request: Request, env: Env): Promise<Response> 
     if (!email) return errorResponse("local_auth_misconfigured", "CLAWROUTER_LOCAL_ADMIN_EMAIL must be a valid email address", 500);
     let user = (await resolveUsers(env, [email]))[0];
     if (!user) {
-      user = { email, record: { role: "admin", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } };
-      await authorityCall(env, "/users/put", user);
+      user = await authorityCall<AccessControlUser>(env, "/users/create", { email, record: { role: "admin", tenantId: env.CLAWROUTER_ACCESS_DEFAULT_TENANT ?? "default", enabled: true, groups: [], contentRetentionDisabled: false } });
     }
     if (user.record.enabled === false) {
       rejected = true;

--- a/worker/test/access-fetch-timeout.test.mjs
+++ b/worker/test/access-fetch-timeout.test.mjs
@@ -14,6 +14,7 @@ registerHooks({
 });
 
 const { verifiedAccessSession } = await import("../access.ts");
+const { evaluateUserAssignments, withLegacyAssignmentState } = await import("../assignment-evaluator.ts");
 
 const teamDomain = "team.cloudflareaccess.com";
 const audience = "aud-1";
@@ -73,6 +74,16 @@ function accessEnv(kv = new Map(), users = new Map()) {
           if (path === "/users/put") {
             users.set(body.email, body.record);
             return new Response("updated");
+          }
+          if (path === "/users/create") {
+            if (!users.has(body.email)) users.set(body.email, body.record);
+            return Response.json({ email: body.email, record: users.get(body.email) });
+          }
+          if (path === "/users/reconcile-assignments") {
+            const user = { email: body.email, record: users.get(body.email) };
+            const result = evaluateUserAssignments(withLegacyAssignmentState(user, body.legacy), body.rules, body.evidence, body.force);
+            if (result.changed) users.set(body.email, result.user.record);
+            return Response.json(result);
           }
           return Response.json({ error: { code: "route_not_found" } }, { status: 404 });
         },
@@ -174,4 +185,26 @@ test("GitHub identity fetch attaches a 30s AbortSignal and fails open on timeout
   assert.equal(session?.email, email);
   assert.ok(identityInit.signal instanceof AbortSignal);
   assert.deepEqual(timeouts, [30_000, 30_000]);
+});
+
+test("first Access login cannot overwrite a user disabled after its initial lookup", async context => {
+  const keys = await crypto.subtle.generateKey({ name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" }, true, ["sign", "verify"]);
+  const kid = "bootstrap-race-key";
+  const jwk = { ...await crypto.subtle.exportKey("jwk", keys.publicKey), kid, kty: "RSA" };
+  const assertion = await signedJwt(keys.privateKey, kid);
+  context.mock.method(globalThis, "fetch", async () => Response.json({ keys: [jwk] }));
+  const users = new Map();
+  const disabled = { role: "user", tenantId: "managed", enabled: false, groups: ["manual"], contentRetentionDisabled: true };
+  const env = accessEnv(new Map(), users);
+  const stub = env.ACCESS_CONTROL.get();
+  env.ACCESS_CONTROL.get = () => ({ async fetch(url, init) {
+    const response = await stub.fetch(url, init);
+    if (new URL(url).pathname === "/users/resolve") users.set(email, disabled);
+    return response;
+  } });
+  assert.equal(await verifiedAccessSession(sessionRequest(assertion), env), null);
+  assert.equal(users.get(email).enabled, false);
+  assert.equal(users.get(email).tenantId, "managed");
+  assert.deepEqual(users.get(email).groups, ["manual"]);
+  assert.equal(users.get(email).contentRetentionDisabled, true);
 });

--- a/worker/test/assignment-reconciliation.test.mjs
+++ b/worker/test/assignment-reconciliation.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { PolicyBindingIndexObject } from "../authority.ts";
+import { evaluateUserAssignments } from "../assignment-evaluator.ts";
+import { reconcileUserAssignments } from "../assignments.ts";
+
+const rule = { ruleId: "members", generatedGroup: "assignment.members", version: 1, enabled: true,
+  kind: "email_domain", subject: "example.com", groups: ["members"], policyIds: ["policy"],
+  priority: 10, revokeOnLoss: true, provenance: "cloudflare_access" };
+const user = { email: "member@example.com", record: { enabled: true, role: "user", tenantId: "original", groups: ["old-manual"], contentRetentionDisabled: false } };
+
+test("assignment reconciliation preserves administrative changes made during legacy reads", async t => {
+  const fixture = authorityEnv(t);
+  await fixture.put(user);
+  const updated = { ...user, record: { ...user.record, enabled: false, tenantId: "updated", groups: ["new-manual"], contentRetentionDisabled: true } };
+  fixture.beforeLegacyRead = () => fixture.put(updated);
+  const result = await reconcileUserAssignments(user, [rule], fixture.env);
+  assert.equal(result.user.record.enabled, false);
+  assert.equal(result.user.record.tenantId, "updated");
+  assert.equal(result.user.record.contentRetentionDisabled, true);
+  assert.deepEqual(result.user.record.groups, ["assignment.members", "members", "new-manual"]);
+  assert.deepEqual(await fixture.current(), result.user);
+});
+
+test("unchanged assignments return the current user without rewriting it", async t => {
+  const fixture = authorityEnv(t);
+  const assigned = evaluateUserAssignments(user, [rule]).user;
+  const updated = { ...assigned, record: { ...assigned.record, enabled: false, tenantId: "updated" } };
+  await fixture.put(updated);
+  const writes = fixture.writes;
+  const result = await reconcileUserAssignments(assigned, [rule], fixture.env);
+  assert.deepEqual(result.user, updated);
+  assert.equal(fixture.writes, writes);
+});
+
+test("membership-loss reconciliation preserves current manual groups and disabled state", async t => {
+  const fixture = authorityEnv(t);
+  const githubRule = { ...rule, kind: "github_org", subject: "example" };
+  const evidence = { source: "github", verified: true, githubOrgs: ["example"], githubTeams: [] };
+  const assigned = evaluateUserAssignments(user, [githubRule], evidence, true).user;
+  const updated = { ...assigned, record: { ...assigned.record, enabled: false, groups: ["assignment.members", "members", "new-manual"] } };
+  await fixture.put(updated);
+  const result = await reconcileUserAssignments(assigned, [githubRule], fixture.env, { ...evidence, githubOrgs: [] }, true);
+  assert.equal(result.user.record.enabled, false);
+  assert.deepEqual(result.user.record.groups, ["new-manual"]);
+  assert.deepEqual(result.user.record.assignmentState.assignments, {});
+  assert.deepEqual(await fixture.current(), result.user);
+});
+
+test("reconciliation cannot recreate a missing canonical user from a stale snapshot", async t => {
+  const fixture = authorityEnv(t);
+  await assert.rejects(reconcileUserAssignments(user, [rule], fixture.env));
+  assert.equal(await fixture.current(), undefined);
+});
+
+test("automatic creation preserves existing users after migration closes", async t => {
+  const fixture = authorityEnv(t);
+  await fixture.call("/users/initialize-all", []);
+  const disabled = { ...user, record: { ...user.record, enabled: false, tenantId: "managed" } };
+  const responses = await Promise.all([fixture.call("/users/create", disabled), fixture.call("/users/create", user)]);
+  for (const response of responses) assert.deepEqual(await response.json(), disabled);
+  assert.equal(fixture.writes, 1);
+  assert.deepEqual(await fixture.current(), disabled);
+});
+
+function authorityEnv(t) {
+  const db = new DatabaseSync(":memory:");
+  t.after(() => db.close());
+  const sql = { exec(query, ...bindings) {
+    const statement = db.prepare(query);
+    if (statement.columns().length) return statement.all(...bindings);
+    if (query.startsWith("INSERT OR REPLACE INTO access_users")) fixture.writes++;
+    statement.run(...bindings);
+    return [];
+  } };
+  const fixture = { writes: 0, beforeLegacyRead: null };
+  const authority = new PolicyBindingIndexObject({ storage: { sql } });
+  const call = (path, body) => authority.fetch(new Request(`https://clawrouter.internal${path}`, { method: "POST", body: JSON.stringify(body) }));
+  fixture.call = call;
+  fixture.put = async value => { assert.equal((await call("/users/put", value)).status, 200); };
+  fixture.current = async () => (await (await call("/users/resolve", { emails: [user.email] })).json()).users[0];
+  fixture.env = {
+    ACCESS_CONTROL: { idFromName: name => name, get: () => ({ fetch: (url, init) => authority.fetch(new Request(url, init)) }) },
+    POLICY_KV: { async get() { await fixture.beforeLegacyRead?.(); return null; } },
+  };
+  return fixture;
+}

--- a/worker/test/local-auth.test.mjs
+++ b/worker/test/local-auth.test.mjs
@@ -44,6 +44,10 @@ function fixture(overrides = {}) {
             return Response.json({ initialized: true, users: found, missingEmails: body.emails.filter((email) => !users.has(email)) });
           }
           if (path === "/users/put") { users.set(body.email, body.record); return new Response("updated"); }
+          if (path === "/users/create") {
+            if (!users.has(body.email)) users.set(body.email, body.record);
+            return Response.json({ email: body.email, record: users.get(body.email) });
+          }
           return Response.json({ error: { code: "route_not_found" } }, { status: 404 });
         },
       }),
@@ -219,6 +223,22 @@ test("session cookies are ignored outside local-auth mode", async () => {
   assert.equal(await localSession(new Request(`${origin}/v1/session`, { headers: { cookie } }), managed), null);
   const unset = { ...env, CLAWROUTER_LOCAL_AUTH: undefined };
   assert.equal(await verifiedAccessSession(new Request(`${origin}/v1/session`, { headers: { cookie } }), unset), null);
+});
+
+test("first local login cannot overwrite a user disabled after its initial lookup", async () => {
+  const env = fixture({ CLAWROUTER_LOCAL_ADMIN_EMAIL: "bootstrap@example.com" });
+  const disabled = { role: "user", tenantId: "managed", enabled: false, groups: ["manual"], contentRetentionDisabled: true };
+  const stub = env.ACCESS_CONTROL.get();
+  env.ACCESS_CONTROL.get = () => ({ async fetch(url, init) {
+    const response = await stub.fetch(url, init);
+    if (new URL(url).pathname === "/users/resolve") env.users.set("bootstrap@example.com", disabled);
+    return response;
+  } });
+  const response = await localLogin(loginRequest(adminKeyMaterial, { ip: "198.51.100.240" }), env);
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get("set-cookie"), null);
+  assert.deepEqual(env.users.get("bootstrap@example.com"), disabled);
+  assert.equal(env.kv.size, 0);
 });
 
 test("concurrent spoofed-client attempts cannot exceed the global sign-in cap", async () => {


### PR DESCRIPTION
Automatic user updates now run against the current record inside the access authority. Assignment reconciliation previously evaluated a caller's snapshot and wrote the entire user back; concurrent administrator edits to enabled state, tenant, manual groups, and retention could be overwritten. Both login paths also used a blind write when their initial lookup found no user.

Reconciliation now sends only the email, rules, and evidence to the authority, which evaluates and commits synchronously. Login creation inserts only a missing user and returns any existing record. Missing users cannot be recreated by stale reconciliation work, and unchanged assignments remain write-free. Public APIs and storage schemas are unchanged.

Validation: all four stale-snapshot regression cases failed before the fix. The final focused suite passes 28 tests, including canonical creation, local login, and Cloudflare Access login races. Full `pnpm check` passes 321 Worker, 30 admin, and 82 script tests. Local `pnpm worker:e2e` exercises assignment addition/removal through the admin API. Independent Codex review found no actionable findings.

Deployment: source change only; no live deployment or configuration changes. The authority gains two internal operations. Assignment rule storage and evidence verification retain their existing ownership and behavior.
