### PR TITLE
feat(private): add safe rejection telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.3 - Unreleased
 
 - Add Claude Fable 5.1 with current input, output, and cache pricing, and update the Claude subscription transport identity to the minimum compatible client version.
+- Add content-free server-side predicates and exact consumed-byte counts for authenticated private Codex requests rejected locally with HTTP 400.
 
 ## 0.2.2 - 2026-08-31
 

--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -17,10 +17,17 @@ establish native Codex integration.
 
 For a dedicated private Worker, use `worker/private-entry.ts` as its entrypoint
 and bind only the two private secret-store objects below. This entrypoint exposes
-no shared admin, public catalog, usage, or proxy routes. Disable Worker request
-logging and observability for that deployment, and verify the actual deployed
-origin with the native client before enabling a consumer. A local emulator does
-not establish upstream acceptance of the deployed transport.
+no shared admin, public catalog, usage, or proxy routes. Disable automatic Worker
+request logs and tracing for that deployment. The facade emits one constrained
+server-side event for authenticated requests it rejects locally with HTTP 400:
+`{ predicate, request_bytes }`. Predicates are fixed validator names and
+`request_bytes` is the exact body byte count consumed, or `null` when rejection
+precedes body reading. The event never uses `Content-Length` and contains no
+request identifier, header, body, model, alias, URL, credential, exception, or
+rejected field value. Hidden-route 404s, upstream failures and successful calls
+emit no such event. Verify the actual deployed origin with the native client
+before enabling a consumer. A local emulator does not establish upstream
+acceptance of the deployed transport.
 
 ## Runtime configuration
 

--- a/worker/private-codex-io.ts
+++ b/worker/private-codex-io.ts
@@ -15,18 +15,46 @@ export async function read(reader: ReadableStreamDefaultReader<Uint8Array>, sign
   } finally { signal.removeEventListener("abort", listener); }
 }
 
-export async function boundedJson(body: ReadableStream<Uint8Array> | null, limit: number, signal: AbortSignal): Promise<unknown> {
-  if (!body) throw new Error("missing private body");
-  const reader = body.getReader(), decoder = new TextDecoder("utf-8", { fatal: true });
+export type PrivateBodyPredicate = "body.missing" | "body.read" | "body.aborted" | "body.limit" | "body.utf8" | "body.json";
+
+export class PrivateBodyError extends Error {
+  readonly predicate: PrivateBodyPredicate;
+  readonly bytes: number | null;
+
+  constructor(predicate: PrivateBodyPredicate, bytes: number | null) {
+    super("private body rejected");
+    this.predicate = predicate;
+    this.bytes = bytes;
+  }
+}
+
+export async function boundedRequestJson(body: ReadableStream<Uint8Array> | null, limit: number, signal: AbortSignal): Promise<{ value: unknown; bytes: number }> {
+  if (!body) throw new PrivateBodyError("body.missing", null);
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try { reader = body.getReader(); } catch { throw new PrivateBodyError("body.read", 0); }
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   let text = "", bytes = 0;
   try {
     while (true) {
-      const result = await read(reader, signal);
+      let result: ReadableStreamReadResult<Uint8Array>;
+      try { result = await read(reader, signal); }
+      catch { throw new PrivateBodyError(signal.aborted ? "body.aborted" : "body.read", bytes); }
       if (result.done) break;
       bytes += result.value.byteLength;
-      if (bytes > limit) throw new Error("private body limit");
-      text += decoder.decode(result.value, { stream: true });
+      if (bytes > limit) throw new PrivateBodyError("body.limit", bytes);
+      try { text += decoder.decode(result.value, { stream: true }); }
+      catch { throw new PrivateBodyError("body.utf8", bytes); }
     }
-    return JSON.parse(text + decoder.decode());
+    try { text += decoder.decode(); }
+    catch { throw new PrivateBodyError("body.utf8", bytes); }
+    try { return { value: JSON.parse(text), bytes }; }
+    catch { throw new PrivateBodyError("body.json", bytes); }
+  } catch (error) {
+    if (error instanceof PrivateBodyError) throw error;
+    throw new PrivateBodyError(signal.aborted ? "body.aborted" : "body.read", bytes);
   } finally { cancel(reader); }
+}
+
+export async function boundedJson(body: ReadableStream<Uint8Array> | null, limit: number, signal: AbortSignal): Promise<unknown> {
+  return (await boundedRequestJson(body, limit, signal)).value;
 }

--- a/worker/private-codex-protocol.ts
+++ b/worker/private-codex-protocol.ts
@@ -17,6 +17,29 @@ const booleanHeaders = new Set(["x-openai-internal-codex-responses-lite", "x-ope
 const selectorKeys = new Set(["model", "retry_model", "faster_model", "auto_review_model_override"]);
 const encoder = new TextEncoder();
 
+export type PrivateProtocolPredicate =
+  | "headers.content_encoding" | "headers.transfer_encoding" | "headers.value_limit"
+  | "headers.total_limit" | "headers.routing_hint" | "headers.routing_tier"
+  | "headers.selector" | "headers.namespace" | "headers.boolean"
+  | "headers.turn_metadata" | "headers.characters"
+  | "protocol.metadata_object" | "protocol.metadata_count" | "protocol.metadata_key"
+  | "protocol.metadata_value_type" | "protocol.metadata_value_limit" | "protocol.turn_metadata"
+  | "protocol.stream_options_object" | "protocol.stream_options_keys"
+  | "protocol.stream_options_delivery" | "protocol.stream_options_stream"
+  | "protocol.access_programs_object" | "protocol.access_programs_keys"
+  | "protocol.access_programs_type" | "protocol.access_programs_value"
+  | "protocol.opaque_limit" | "protocol.opaque_identity" | "protocol.opaque_size"
+  | "protocol.opaque_selector" | "protocol.opaque_json" | "protocol.opaque_encoding";
+
+export class PrivateProtocolError extends Error {
+  readonly predicate: PrivateProtocolPredicate;
+
+  constructor(predicate: PrivateProtocolPredicate) {
+    super("private protocol rejected");
+    this.predicate = predicate;
+  }
+}
+
 function boundedMetadata(value: unknown, depth = 0, budget = { nodes: 0 }): void {
   if (++budget.nodes > 10_000 || depth > 32) throw new Error("private metadata limit");
   if (Array.isArray(value)) for (const item of value) boundedMetadata(item, depth + 1, budget);
@@ -27,22 +50,35 @@ function metadataObject(value: string): boolean {
   try { const parsed: unknown = JSON.parse(value); boundedMetadata(parsed); return record(parsed); } catch { return false; }
 }
 
-export function validPrivateProtocolBody(body: Record<string, unknown>): boolean {
+export function privateProtocolBodyRejection(body: Record<string, unknown>): PrivateProtocolPredicate | null {
   const metadata = body.client_metadata;
   if (metadata != null) {
-    if (!record(metadata) || Object.keys(metadata).length > 32) return false;
+    if (!record(metadata)) return "protocol.metadata_object";
+    if (Object.keys(metadata).length > 32) return "protocol.metadata_count";
     for (const [key, value] of Object.entries(metadata)) {
-      if (!metadataKeys.has(key) || typeof value !== "string" || value.length > (key === "x-codex-turn-metadata" ? 256 * 1024 : 8192)) return false;
-      if (key === "x-codex-turn-metadata" && !metadataObject(value)) return false;
+      if (!metadataKeys.has(key)) return "protocol.metadata_key";
+      if (typeof value !== "string") return "protocol.metadata_value_type";
+      if (value.length > (key === "x-codex-turn-metadata" ? 256 * 1024 : 8192)) return "protocol.metadata_value_limit";
+      if (key === "x-codex-turn-metadata" && !metadataObject(value)) return "protocol.turn_metadata";
     }
   }
   const options = body.stream_options;
-  if (options != null && (!record(options) || Object.keys(options).length !== 1 || options.reasoning_summary_delivery !== "sequential_cutoff" || body.stream !== true)) return false;
+  if (options != null) {
+    if (!record(options)) return "protocol.stream_options_object";
+    if (Object.keys(options).length !== 1) return "protocol.stream_options_keys";
+    if (options.reasoning_summary_delivery !== "sequential_cutoff") return "protocol.stream_options_delivery";
+    if (body.stream !== true) return "protocol.stream_options_stream";
+  }
   // This is an upstream access selection, not permission granted by the facade.
   // Preserve the supplied wire token; never manufacture entitlement or a program fallback.
   const programs = body.access_programs;
-  if (programs != null && (!record(programs) || Object.keys(programs).length !== 1 || typeof programs.cyber !== "string" || !/^[a-z][a-z0-9_]{0,63}$/.test(programs.cyber))) return false;
-  return true;
+  if (programs != null) {
+    if (!record(programs)) return "protocol.access_programs_object";
+    if (Object.keys(programs).length !== 1) return "protocol.access_programs_keys";
+    if (typeof programs.cyber !== "string") return "protocol.access_programs_type";
+    if (!/^[a-z][a-z0-9_]{0,63}$/.test(programs.cyber)) return "protocol.access_programs_value";
+  }
+  return null;
 }
 
 function parseRoutingHint(value: string, alias: string): { tier?: string } | null {
@@ -50,24 +86,27 @@ function parseRoutingHint(value: string, alias: string): { tier?: string } | nul
   return match && match[1] === alias ? { tier: match[2] } : null;
 }
 
-export function validPrivateHeaders(headers: Headers, alias: string, body?: Record<string, unknown>): boolean {
-  if (headers.has("content-encoding") || headers.has("transfer-encoding")) return false;
+export function privateHeadersRejection(headers: Headers, alias: string, body?: Record<string, unknown>): PrivateProtocolPredicate | null {
+  if (headers.has("content-encoding")) return "headers.content_encoding";
+  if (headers.has("transfer-encoding")) return "headers.transfer_encoding";
   let bytes = 0;
   for (const [key, value] of headers) {
     bytes += encoder.encode(key + value).byteLength;
-    if (value.length > 8192 || bytes > 64 * 1024) return false;
+    if (value.length > 8192) return "headers.value_limit";
+    if (bytes > 64 * 1024) return "headers.total_limit";
     if (key === routingHint) {
       const hint = parseRoutingHint(value, alias);
-      if (!hint || body && hint.tier !== (body.service_tier ?? undefined)) return false;
+      if (!hint) return "headers.routing_hint";
+      if (body && hint.tier !== (body.service_tier ?? undefined)) return "headers.routing_tier";
       continue;
     }
-    if (/(?:model|provider|base[-_]?url|upstream|account|organization|project)/i.test(key)) return false;
-    if ((key.startsWith("x-codex-") || key.startsWith("x-openai-internal-") || /(?:approval|review|attestation|safety|routing)/i.test(key)) && !forwardedHeaders.has(key)) return false;
-    if (booleanHeaders.has(key) && value !== "true" && value !== "false") return false;
-    if (key === "x-codex-turn-metadata" && !metadataObject(value)) return false;
-    if (forwardedHeaders.has(key) && !/^[\x20-\x7e]+$/.test(value)) return false;
+    if (/(?:model|provider|base[-_]?url|upstream|account|organization|project)/i.test(key)) return "headers.selector";
+    if ((key.startsWith("x-codex-") || key.startsWith("x-openai-internal-") || /(?:approval|review|attestation|safety|routing)/i.test(key)) && !forwardedHeaders.has(key)) return "headers.namespace";
+    if (booleanHeaders.has(key) && value !== "true" && value !== "false") return "headers.boolean";
+    if (key === "x-codex-turn-metadata" && !metadataObject(value)) return "headers.turn_metadata";
+    if (forwardedHeaders.has(key) && !/^[\x20-\x7e]+$/.test(value)) return "headers.characters";
   }
-  return true;
+  return null;
 }
 
 export function forwardPrivateHeaders(incoming: Headers, outgoing: Headers, alias: string, target: string): void {
@@ -83,33 +122,34 @@ export function forwardPrivateHeaders(incoming: Headers, outgoing: Headers, alia
 // Opaque affinity is never rewritten. Inspect literal, JSON, percent and base64/JWT
 // representations before returning it; this is not cryptographic attestation verification.
 export function inspectPrivateOpaque(value: unknown, alias: string, secrets: readonly string[], depth = 0, budget = { nodes: 0 }): void {
-  if (++budget.nodes > 10_000 || depth > 12) throw new Error("private opaque limit");
+  if (++budget.nodes > 10_000 || depth > 12) throw new PrivateProtocolError("protocol.opaque_limit");
   if (typeof value === "string") {
-    if (containsPrivate(value, secrets)) throw new Error("private opaque identity");
-    if (value.length > 8192) throw new Error("private opaque size");
+    if (containsPrivate(value, secrets)) throw new PrivateProtocolError("protocol.opaque_identity");
+    if (value.length > 8192) throw new PrivateProtocolError("protocol.opaque_size");
     for (const match of value.matchAll(/(?:^|[;,&\s])(?:model|retry_model|faster_model)=([^;,&\s]+)/g)) {
-      if (match[1] !== alias) throw new Error("private opaque selector");
+      if (match[1] !== alias) throw new PrivateProtocolError("protocol.opaque_selector");
     }
     if (/^\s*[\[{]/.test(value)) {
       let decoded: unknown;
-      try { decoded = JSON.parse(value); } catch { throw new Error("private opaque JSON"); }
+      try { decoded = JSON.parse(value); } catch { throw new PrivateProtocolError("protocol.opaque_json"); }
       inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
     } else if (/%[0-9a-f]{2}/i.test(value)) {
-      const decoded = decodeURIComponent(value);
+      let decoded: string;
+      try { decoded = decodeURIComponent(value); } catch { throw new PrivateProtocolError("protocol.opaque_encoding"); }
       if (decoded !== value) inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
     } else {
       for (const part of value.split(".")) {
         if (!/^[A-Za-z0-9+/_-]{8,}={0,2}$/.test(part)) continue;
         let decoded: string;
         try { decoded = atob(part.replaceAll("-", "+").replaceAll("_", "/")); } catch { continue; }
-        if (containsPrivate(decoded, secrets)) throw new Error("private opaque encoded identity");
+        if (containsPrivate(decoded, secrets)) throw new PrivateProtocolError("protocol.opaque_identity");
         if (/^[\x20-\x7e\r\n\t]+$/.test(decoded) && decoded !== value) inspectPrivateOpaque(decoded, alias, secrets, depth + 1, budget);
       }
     }
   } else if (Array.isArray(value)) for (const item of value) inspectPrivateOpaque(item, alias, secrets, depth + 1, budget);
   else if (record(value)) for (const [key, item] of Object.entries(value)) {
     inspectPrivateOpaque(key, alias, secrets, depth + 1, budget);
-    if (selectorKeys.has(key) && item != null && item !== alias) throw new Error("private opaque selector");
+    if (selectorKeys.has(key) && item != null && item !== alias) throw new PrivateProtocolError("protocol.opaque_selector");
     inspectPrivateOpaque(item, alias, secrets, depth + 1, budget);
   }
 }

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -1,7 +1,7 @@
-import { boundedJson } from "./private-codex-io";
+import { boundedJson, boundedRequestJson, PrivateBodyError } from "./private-codex-io";
 import { containsPrivate, privateAuthorizationCurrent, privateAuthorized, privateCredential, privatePolicy, privateSensitive, privateUpstream, privateUpstreamActive, record, type PrivatePolicy, type PrivateUpstream } from "./private-codex-config";
 import { containResponse, privateError, privateJson } from "./private-codex-output";
-import { forwardPrivateHeaders, inspectPrivateOpaque, validPrivateHeaders, validPrivateProtocolBody } from "./private-codex-protocol";
+import { forwardPrivateHeaders, inspectPrivateOpaque, privateHeadersRejection, privateProtocolBodyRejection, PrivateProtocolError } from "./private-codex-protocol";
 import { privateContinuations } from "./private-codex-continuation";
 import type { Env } from "./types";
 
@@ -26,6 +26,11 @@ export function privateSubscriptionBody(body: Record<string, unknown>, target: s
   return outgoing;
 }
 
+function reject(predicate: string, requestBytes: number | null): Response {
+  try { console.info({ predicate, request_bytes: requestBytes }); } catch {}
+  return privateError(400);
+}
+
 export async function privateCodex(request: Request, env: Env): Promise<Response> {
   try {
     const url = new URL(request.url);
@@ -36,14 +41,15 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
     if (!policy) return privateError(404);
     const authorization = await privateAuthorized(request, policy);
     if (!authorization || !await privateAuthorizationCurrent(authorization, policy, env)) return privateError(404);
-    if (!validPrivateHeaders(request.headers, policy.alias.id)) return privateError(400);
+    const initialHeaderRejection = privateHeadersRejection(request.headers, policy.alias.id);
+    if (initialHeaderRejection) return reject(initialHeaderRejection, null);
 
     // Target/account/credential resolution happens only inside this authenticated boundary.
     const upstream = await privateUpstream(env, policy);
     if (!upstream || !await privateAuthorizationCurrent(authorization, policy, env) || !privateUpstreamActive(upstream)) return privateError(404);
     const { id, name } = policy.alias;
     if (discovery) {
-      if (request.body) return privateError(400);
+      if (request.body) return reject("request.discovery_body", null);
       const reasoning = policy.alias.supportedReasoningEfforts ? { supportedReasoningEfforts: policy.alias.supportedReasoningEfforts } : {};
       if (url.pathname.endsWith("/models")) return privateJson({ object: "list", data: [{ id, object: "model", owned_by: "private", display_name: name, capabilities: ["llm.responses"], ...reasoning }] });
       return privateJson({ version: "clawrouter.client-catalog.v1", providers: [{
@@ -52,21 +58,39 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
         models: [{ id, displayName: name, upstream: id, capabilities: ["llm.responses"], pricing_ref: null, pricing: null, ...reasoning }],
       }] });
     }
-    if (!/^application\/json(?:;\s*charset=utf-8)?$/i.test(request.headers.get("content-type") ?? "")) return privateError(400);
+    if (!/^application\/json(?:;\s*charset=utf-8)?$/i.test(request.headers.get("content-type") ?? "")) return reject("request.content_type", null);
     let body: unknown;
-    try { body = await boundedJson(request.body, 1024 * 1024, AbortSignal.any([request.signal, AbortSignal.timeout(30_000)])); } catch { return privateError(400); }
-    if (!record(body) || body.model !== id || Object.keys(body).some((key) => !requestFields.has(key))
-      || body.store !== false || body.background === true || (body.background !== undefined && body.background !== false)
-      || (body.stream !== undefined && typeof body.stream !== "boolean") || !validPrivateProtocolBody(body)
-      || (body.max_output_tokens !== undefined && (typeof body.max_output_tokens !== "number" || !Number.isSafeInteger(body.max_output_tokens) || body.max_output_tokens <= 0))
-      || !validPrivateHeaders(request.headers, id, body)) return privateError(400);
+    let requestBytes: number;
+    try {
+      const parsed = await boundedRequestJson(request.body, 1024 * 1024, AbortSignal.any([request.signal, AbortSignal.timeout(30_000)]));
+      body = parsed.value;
+      requestBytes = parsed.bytes;
+    } catch (error) {
+      if (error instanceof PrivateBodyError) return reject(error.predicate, error.bytes);
+      throw error;
+    }
+    if (!record(body)) return reject("request.body_object", requestBytes);
+    if (body.model !== id) return reject("request.model_alias", requestBytes);
+    if (Object.keys(body).some((key) => !requestFields.has(key))) return reject("request.field_allowlist", requestBytes);
+    if (body.store !== false) return reject("request.store_false", requestBytes);
+    if (body.background === true || (body.background !== undefined && body.background !== false)) return reject("request.background_false", requestBytes);
+    if (body.stream !== undefined && typeof body.stream !== "boolean") return reject("request.stream_boolean", requestBytes);
+    const protocolRejection = privateProtocolBodyRejection(body);
+    if (protocolRejection) return reject(protocolRejection, requestBytes);
+    if (body.max_output_tokens !== undefined && (typeof body.max_output_tokens !== "number" || !Number.isSafeInteger(body.max_output_tokens) || body.max_output_tokens <= 0)) {
+      return reject("request.max_output_tokens", requestBytes);
+    }
+    const bodyHeaderRejection = privateHeadersRejection(request.headers, id, body);
+    if (bodyHeaderRejection) return reject(bodyHeaderRejection, requestBytes);
     const continuations = upstream.fallbackTarget ? await privateContinuations(policy, upstream) : undefined;
     let routed = { body, headers: request.headers, slot: 0, continuing: !!body.previous_response_id || request.headers.has("x-codex-turn-state") };
     try {
       if (continuations) routed = await continuations.request(body, request.headers);
       const affinity = routed.headers.get("x-codex-turn-state");
       if (affinity !== null) inspectPrivateOpaque(affinity, id, privateSensitive(upstream));
-    } catch { return privateError(400); }
+    } catch (error) {
+      return reject(error instanceof PrivateProtocolError ? error.predicate : "protocol.continuation", requestBytes);
+    }
 
     // Re-read both bindings after a potentially slow upload; never cache authorization.
     if (!await upstreamCurrent(request, env, policy, upstream)) return privateError(404);

--- a/worker/test/private-codex-telemetry.test.mjs
+++ b/worker/test/private-codex-telemetry.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { extname } from "node:path";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+registerHooks({ resolve(specifier, context, next) {
+  return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
+} });
+const { privateCodex } = await import("../private-codex.ts");
+const { privateHeadersRejection, privateProtocolBodyRejection } = await import("../private-codex-protocol.ts");
+const { sha256Hex } = await import("../utils.ts");
+
+const alias = "codex-latest";
+const credential = "private-workload-SYNTHETIC_TELEMETRY_CREDENTIAL_0123456789";
+const target = "SYNTHETIC_TELEMETRY_TARGET";
+const encoder = new TextEncoder();
+
+async function environment() {
+  const policy = {
+    version: 1,
+    enabled: true,
+    alias: { id: alias, name: "Codex (Latest)" },
+    auth: { mode: "workload", credentialSha256: await sha256Hex(credential) },
+  };
+  const upstream = {
+    version: 1,
+    target,
+    accountId: "SYNTHETIC_TELEMETRY_ACCOUNT",
+    accessToken: "SYNTHETIC_TELEMETRY_TOKEN",
+    expiresAt: Date.now() + 3_600_000,
+  };
+  return {
+    PRIVATE_CODEX_POLICY: { get: async () => JSON.stringify(policy) },
+    PRIVATE_CODEX_UPSTREAM: { get: async () => JSON.stringify(upstream) },
+  };
+}
+
+function request(body, headers = {}, path = "/private/v1/responses") {
+  return new Request(`https://synthetic.invalid${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${credential}`, "content-type": "application/json", ...headers },
+    body,
+  });
+}
+
+function expected(predicate, requestBytes) {
+  return { predicate, request_bytes: requestBytes };
+}
+
+test("local rejection telemetry contains only a fixed predicate and exact consumed bytes", async (context) => {
+  const env = await environment();
+  const events = [];
+  context.mock.method(console, "info", (event) => events.push(event));
+  context.mock.method(globalThis, "fetch", () => assert.fail("locally rejected request reached upstream"));
+
+  const preBody = request("{}", { "content-type": "text/plain", "content-length": "999999999" });
+  assert.equal((await privateCodex(preBody, env)).status, 400);
+  assert.deepEqual(events.pop(), expected("request.content_type", null));
+
+  const invalidJson = "{";
+  assert.equal((await privateCodex(request(invalidJson), env)).status, 400);
+  assert.deepEqual(events.pop(), expected("body.json", encoder.encode(invalidJson).byteLength));
+
+  const invalidUtf8 = new Uint8Array([0x7b, 0xff, 0x7d]);
+  assert.equal((await privateCodex(request(invalidUtf8), env)).status, 400);
+  assert.deepEqual(events.pop(), expected("body.utf8", invalidUtf8.byteLength));
+
+  const wrongModel = JSON.stringify({ model: "synthetic-other", store: false });
+  assert.equal((await privateCodex(request(wrongModel), env)).status, 400);
+  assert.deepEqual(events.pop(), expected("request.model_alias", encoder.encode(wrongModel).byteLength));
+
+  const badProtocol = JSON.stringify({ model: alias, store: false, client_metadata: { "x-codex-turn-metadata": "{" } });
+  assert.equal((await privateCodex(request(badProtocol), env)).status, 400);
+  assert.deepEqual(events.pop(), expected("protocol.turn_metadata", encoder.encode(badProtocol).byteLength));
+
+  const body = JSON.stringify({ model: alias, store: false, service_tier: "priority" });
+  assert.equal((await privateCodex(request(body, { "x-codex-routing-hint": `model=${alias}` }), env)).status, 400);
+  assert.deepEqual(events.pop(), expected("headers.routing_tier", encoder.encode(body).byteLength));
+
+  assert.equal(events.length, 0);
+});
+
+test("header and protocol validators expose distinct fixed owning predicates", () => {
+  assert.equal(privateHeadersRejection(new Headers({ "content-encoding": "gzip" }), alias), "headers.content_encoding");
+  assert.equal(privateHeadersRejection(new Headers({ "transfer-encoding": "chunked" }), alias), "headers.transfer_encoding");
+  assert.equal(privateHeadersRejection(new Headers({ "x-model-override": "synthetic" }), alias), "headers.selector");
+  assert.equal(privateHeadersRejection(new Headers({ "x-codex-unknown": "true" }), alias), "headers.namespace");
+  assert.equal(privateHeadersRejection(new Headers({ "x-openai-memgen-request": "maybe" }), alias), "headers.boolean");
+  assert.equal(privateHeadersRejection(new Headers({ "x-codex-turn-metadata": "{" }), alias), "headers.turn_metadata");
+  assert.equal(privateHeadersRejection(new Headers({ "x-codex-routing-hint": "model=synthetic-other" }), alias), "headers.routing_hint");
+
+  assert.equal(privateProtocolBodyRejection({ client_metadata: [] }), "protocol.metadata_object");
+  assert.equal(privateProtocolBodyRejection({ client_metadata: { unknown: "value" } }), "protocol.metadata_key");
+  assert.equal(privateProtocolBodyRejection({ client_metadata: { "x-codex-window-id": 1 } }), "protocol.metadata_value_type");
+  assert.equal(privateProtocolBodyRejection({ client_metadata: { "x-codex-window-id": "x".repeat(8193) } }), "protocol.metadata_value_limit");
+  assert.equal(privateProtocolBodyRejection({ stream_options: [] }), "protocol.stream_options_object");
+  assert.equal(privateProtocolBodyRejection({ stream_options: {} }), "protocol.stream_options_keys");
+  assert.equal(privateProtocolBodyRejection({ stream: true, stream_options: { reasoning_summary_delivery: "other" } }), "protocol.stream_options_delivery");
+  assert.equal(privateProtocolBodyRejection({ stream: false, stream_options: { reasoning_summary_delivery: "sequential_cutoff" } }), "protocol.stream_options_stream");
+  assert.equal(privateProtocolBodyRejection({ access_programs: [] }), "protocol.access_programs_object");
+  assert.equal(privateProtocolBodyRejection({ access_programs: {} }), "protocol.access_programs_keys");
+  assert.equal(privateProtocolBodyRejection({ access_programs: { cyber: 1 } }), "protocol.access_programs_type");
+  assert.equal(privateProtocolBodyRejection({ access_programs: { cyber: "NOT_VALID" } }), "protocol.access_programs_value");
+});
+
+test("hidden routes, upstream responses and successful calls emit no rejection telemetry", async (context) => {
+  const env = await environment();
+  const events = [];
+  context.mock.method(console, "info", (event) => events.push(event));
+
+  assert.equal((await privateCodex(request("{}", {}, "/private/v1/unknown"), env)).status, 404);
+  assert.deepEqual(events, []);
+
+  for (const status of [200, 400, 502]) {
+    context.mock.method(globalThis, "fetch", () => status === 200
+      ? Response.json({ id: "synthetic-response", object: "response", model: target, status: "completed", output: [] })
+      : Response.json({ error: { code: "synthetic-upstream" } }, { status }));
+    const body = JSON.stringify({ model: alias, input: "synthetic", store: false });
+    assert.equal((await privateCodex(request(body), env)).status, status);
+    assert.deepEqual(events, []);
+    context.mock.restoreAll();
+    context.mock.method(console, "info", (event) => events.push(event));
+  }
+});
+
+test("telemetry sink failures do not change the local rejection response", async (context) => {
+  const env = await environment();
+  context.mock.method(console, "info", () => { throw new Error("synthetic sink failure"); });
+  const response = await privateCodex(request("{}", { "content-type": "text/plain" }), env);
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: { code: "invalid_request", message: "Unsupported private request." } });
+});


### PR DESCRIPTION
## Summary

- Emit one server-side event for authenticated private Codex requests rejected locally with HTTP 400.
- Keep the event strictly limited to `{ predicate, request_bytes }`, where predicates are fixed validator names and byte counts come from the consumed request stream rather than `Content-Length`.
- Split header, body, and protocol validation into privacy-safe owning predicates without changing authentication, routing, limits, provider behavior, or client responses.
- Keep hidden-route 404s, upstream 400/502 responses, transport failures, and successful calls silent.

Production TypeScript delta: `+136/-44` (`+92` net), justified by the explicit predicate taxonomy and exact request-body byte accounting.

## Verification

- `./node_modules/.bin/tsc -p worker/tsconfig.json --noEmit`
- `node --test worker/test/*.test.mjs` (325 passed)
- `git diff --check origin/main...HEAD`
- Autoreview, Codex `gpt-5.6-sol` at high reasoning: clean, no accepted/actionable P0 findings, correctness 0.99
- Outgoing review bundle and diff passed the repository credential scan; test values are synthetic.

## Deployment status

Code only. Not deployed or enabled by this pull request.

## Remaining risk

The event relies on the deployment's server-side console ingestion. Automatic Worker request logs and tracing should remain disabled for the private deployment as documented. Live verification should use a synthetic malformed request and inspect only the emitted predicate and byte count.
