### PR TITLE
fix(worker): support larger private context requests

### DIFF
--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -482,7 +482,11 @@ be passed through into an apparently successful stream that ignores it.
 Native SSE may omit Content-Type; a supplied Content-Type must still identify
 UTF-8 SSE and every frame is validated. No unbounded buffering is used.
 
-Limits: 1 MiB request, 4 MiB JSON response, 256 KiB SSE frame, 1 MiB holdback or
+Request JSON accepts up to 8 MiB of UTF-8 bytes, sharing the public JSON intake
+limit so full-history requests are not restricted to 1 MiB. The limit includes
+all fields and JSON overhead; it does not establish a model's token capacity.
+
+Output limits: 4 MiB JSON response, 256 KiB SSE frame, 1 MiB holdback or
 individual network chunk, 1024 held events, 128 logical streams/items, 64 MiB
 total SSE bytes, 48 JSON nesting levels, and 50,000 inspected nodes. Request
 upload has a 30-second deadline; each Access verification plus identity lookup

--- a/worker/private-codex.ts
+++ b/worker/private-codex.ts
@@ -4,6 +4,7 @@ import { containResponse, privateError, privateJson } from "./private-codex-outp
 import { forwardPrivateHeaders, inspectPrivateOpaque, privateHeadersRejection, privateProtocolBodyRejection, PrivateProtocolError } from "./private-codex-protocol";
 import { privateContinuations } from "./private-codex-continuation";
 import type { Env } from "./types";
+import { maxJsonBodyBytes } from "./utils";
 
 const upstreamUrl = "https://chatgpt.com/backend-api/codex/responses";
 const apiUrl = "https://api.openai.com/v1/responses";
@@ -62,7 +63,7 @@ export async function privateCodex(request: Request, env: Env): Promise<Response
     let body: unknown;
     let requestBytes: number;
     try {
-      const parsed = await boundedRequestJson(request.body, 1024 * 1024, AbortSignal.any([request.signal, AbortSignal.timeout(30_000)]));
+      const parsed = await boundedRequestJson(request.body, maxJsonBodyBytes, AbortSignal.any([request.signal, AbortSignal.timeout(30_000)]));
       body = parsed.value;
       requestBytes = parsed.bytes;
     } catch (error) {

--- a/worker/test/private-codex-adversarial.test.mjs
+++ b/worker/test/private-codex-adversarial.test.mjs
@@ -7,6 +7,7 @@ registerHooks({ resolve(specifier, context, next) {
   return next(specifier.startsWith(".") && context.parentURL && !extname(new URL(specifier, context.parentURL).pathname) ? `${specifier}.ts` : specifier, context);
 } });
 const { default: worker } = await import("../index.ts");
+const { default: privateWorker } = await import("../private-entry.ts");
 const { containResponse } = await import("../private-codex-output.ts");
 const { privateResponseHeaders } = await import("../private-codex-protocol.ts");
 const { sha256Hex } = await import("../utils.ts");
@@ -192,20 +193,40 @@ test("adversarial frame, response-header and total-stream limits hold at their a
   }
 });
 
-test("adversarial request bytes and response structure limits accept the boundary but not the next unit", async (context) => {
-  const { env } = await fixture(); let calls = 0;
-  context.mock.method(globalThis, "fetch", () => {
-    calls++; return Response.json({ object: "response", id: "synthetic-response", status: "completed", model: target });
-  });
+test("private requests preserve input through 8 MiB and cancel the next byte before egress", async (context) => {
   const empty = JSON.stringify({ model: alias, store: false, input: "" });
-  for (const extra of [0, 1]) {
-    const body = JSON.stringify({ model: alias, store: false, input: "x".repeat(1024 * 1024 - enc.encode(empty).length + extra) });
-    assert.equal(enc.encode(body).length, 1024 * 1024 + extra);
-    const req = new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers: { authorization: `Bearer ${credential}`, "content-type": "application/json" }, body });
-    const response = await run(req, env);
-    assert.equal(response.status, extra ? 400 : 200); contained(await response.text());
+  const limit = 8 * 1024 * 1024;
+  const logs = [];
+  context.mock.method(console, "info", (event) => logs.push(event));
+  for (const [entry, transport] of [[worker, "subscription"], [privateWorker, "openai-api"]]) {
+    const { env, state } = await fixture();
+    if (transport === "openai-api") state.upstream = { version: 1, transport, target, apiKey: accessToken };
+    for (const size of [1024 * 1024 + 1, limit - 1, limit, limit + 1]) {
+      const inputBytes = size - enc.encode(empty).length;
+      const input = "🦞".repeat(Math.floor(inputBytes / 4)) + "x".repeat(inputBytes % 4);
+      const bytes = enc.encode(JSON.stringify({ model: alias, store: false, input }));
+      assert.equal(bytes.length, size);
+      let calls = 0;
+      context.mock.method(globalThis, "fetch", (url, options) => {
+        calls++;
+        assert.equal(url, transport === "openai-api" ? "https://api.openai.com/v1/responses" : "https://chatgpt.com/backend-api/codex/responses");
+        const outgoing = JSON.parse(options.body);
+        assert.equal(outgoing.model, target); assert.ok(outgoing.input === input);
+        return Response.json({ object: "response", id: "synthetic-response", status: "completed", model: target });
+      });
+      // Split multibyte characters across chunks; a false length must not bypass the byte cap.
+      const { body, observed } = source(bytes, [65535]);
+      const headers = { authorization: `Bearer ${credential}`, "content-type": "application/json", ...(size > limit ? { "content-length": "1" } : {}) };
+      const response = await entry.fetch(new Request("https://synthetic.invalid/private/v1/responses", { method: "POST", headers, body, duplex: "half" }), env);
+      assert.equal(response.status, size > limit ? 400 : 200); contained(await response.text());
+      assert.equal(calls, size > limit ? 0 : 1);
+      assert.deepEqual(logs.splice(0), size > limit ? [{ predicate: "body.limit", request_bytes: size }] : []);
+      if (size > limit) assert.equal(observed.canceled, true);
+    }
   }
-  assert.equal(calls, 1);
+});
+
+test("adversarial response structure limits accept the boundary but not the next unit", async () => {
   const metadataCases = [];
   for (const depth of [47, 48]) {
     let value = "safe";

--- a/worker/test/private-codex.test.mjs
+++ b/worker/test/private-codex.test.mjs
@@ -548,11 +548,8 @@ test("SSE late errors, malformed/unsupported frames, mismatched identities and i
   });
 });
 
-test("bounded request/JSON/SSE and unsupported content cancel upstream without exposure", async () => {
+test("bounded JSON/SSE and unsupported content cancel upstream without exposure", async () => {
   const { env } = await environment();
-  await withFetch(() => assert.fail("Oversized request reached upstream"), async () => {
-    assert.equal((await run(request(undefined, { body: { model: alias, store: false, input: "x".repeat(1024 * 1024) } }), env)).status, 400);
-  });
   for (const make of [
     () => new Response("{", { headers: { "content-type": "application/json" } }),
     () => new Response(new Uint8Array([0xff]), { headers: { "content-type": "application/json" } }),

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -131,7 +131,7 @@ export function commaSet(value: string | undefined): Set<string> {
 export function nowIso(): string { return new Date().toISOString(); }
 export function randomId(prefix: string): string { return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`; }
 
-const maxJsonBodyBytes = 8 * 1024 * 1024;
+export const maxJsonBodyBytes = 8 * 1024 * 1024;
 
 export async function readJson<T>(request: Request): Promise<T> {
   const declared = Number(request.headers.get("content-length"));


### PR DESCRIPTION
Private Responses requests were rejected above 1 MiB even though the public JSON intake accepts 8 MiB. Large conversation requests could therefore fail at the router before reaching the selected model. Reuse the existing public 8 MiB byte limit in the private reader; the private authentication, strict UTF-8 parsing, cancellation, telemetry, reauthorization, protocol checks, upload deadline, and response limits remain intact. This changes the transport allowance, not model token capacity.

The regression reproduced HTTP 400 instead of 200 at 1,048,577 bytes on the previous implementation. Coverage now exercises both Worker entrypoints and API/subscription transports, multibyte characters split across chunks, unchanged input forwarding, 8 MiB−1/exact/+1 boundaries, misleading Content-Length, cancellation, and zero upstream calls after overflow. TypeScript and all 326 Worker tests pass with `pnpm worker:check`; structured Codex autoreview is clean at its requested P0 scope.

Controlled live proof sent a 1,052,672-byte JSON request over localhost HTTP into the actual private Worker entrypoint. Whitespace was inside the input field, and the real OpenAI Responses API received 1,052,671 bytes after alias translation, returned HTTP 200, and produced the expected completed response. The client-facing alias was preserved. Usage was 8,235 input and 5 output tokens: this deliberately tests byte handling cheaply, not a full-token-window stress case. Separate local HTTP boundary proof accepts exactly 8 MiB and rejects 8 MiB+1 without egress. The task-only live proof used a stdin-only API credential, with no credential/model values or raw prompt/response logs published.

Deployment status: source change only; no Cloudflare deployment or production configuration mutation has occurred. The live proof used the real handler and API with synthetic local policy bindings, so it does not establish deployed Cloudflare state. Remaining operational work is deployment and verification through the production configuration owner. Production delta is +1 line: exporting the existing limit and importing it into its private consumer.
