### PR TITLE
fix(worker): preserve typed fallback affinity headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ node_modules/
 .dev.vars
 *.log
 .DS_Store
+.artifacts/
+.crabbox/
 admin/test-results/
 admin/playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.3 - Unreleased
 
+- Preserve fallback continuation for mixed-case and singleton-array turn-state headers in private JSON and SSE responses.
+
 - Add Claude Fable 5.1 with current input, output, and cache pricing, and update the Claude subscription transport identity to the minimum compatible client version.
 - Add content-free server-side predicates and exact consumed-byte counts for authenticated private Codex requests rejected locally with HTTP 400.
 

--- a/docs/private-codex.md
+++ b/docs/private-codex.md
@@ -221,6 +221,10 @@ credential or routing rotation invalidates wrapped state. Clients must restart
 from full input after such a rotation. Without fallback, the existing opaque
 values remain unchanged.
 
+Typed JSON and SSE turn-state headers preserve their original casing and scalar
+or singleton-array shape. Each accepted form carries the same continuation
+envelope, so subsequent turns remain on the issuing target.
+
 Before the second call, the broker revalidates the caller and both complete
 bindings. Revocation or rotation stops the request. Both attempts share the
 existing deadline, preserve the request's genuine client and safety facts, and

--- a/docs/proof/private-affinity/README.md
+++ b/docs/proof/private-affinity/README.md
@@ -1,0 +1,26 @@
+# Private affinity continuation proof
+
+The contract is that every supported typed affinity-header form retains the
+fallback target across subsequent requests, alone or with a response ID. Header
+casing and scalar/singleton-array shape remain unchanged.
+
+The proof runs the actual private entrypoint in workerd with synthetic bindings
+and a native HTTP upstream restricted to loopback. It tests JSON response headers,
+top-level SSE headers, and nested SSE response headers, each with lowercase and
+mixed-case names and scalar or singleton-array values. One synthetic 503 forces
+fallback, followed by affinity-only and combined-continuation requests.
+
+```sh
+npm install --prefix /tmp/clawsweeper-worker-proof-tools --no-save --no-audit --no-fund wrangler@4.107.0
+node scripts/proof-private-affinity.mjs d683e35456ce2ff23d886c3fe0bfb90c67a37817 /tmp/clawsweeper-worker-proof-tools .artifacts/private-affinity
+```
+
+The baseline exhibits unwrapped mixed-case affinity and rejected lowercase
+arrays. The candidate must retain fallback routing in all twelve cases. The
+receipt records source hashes, revisions, dirty state, runtime versions, response
+statuses and numeric route slots. Synthetic upstream identity values must never
+appear in client-visible responses.
+
+This does not exercise a live provider or prove a production deployment. Existing
+unit coverage separately preserves tampering, conflicting-origin, and credential
+rotation rejection. No upstream configuration or public API shape changes.

--- a/scripts/proof-private-affinity.mjs
+++ b/scripts/proof-private-affinity.mjs
@@ -1,0 +1,147 @@
+// Controlled workerd proof with synthetic bindings and native loopback egress.
+// node scripts/proof-private-affinity.mjs BASE TOOL_PREFIX OUTPUT
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const [baseRef, toolPrefix, output] = process.argv.slice(2);
+assert.ok(baseRef && toolPrefix && output, "expected BASE TOOL_PREFIX OUTPUT");
+const require = createRequire(path.resolve(toolPrefix, "package.json"));
+const { Miniflare } = require("miniflare");
+const { build } = require("esbuild");
+const root = process.cwd();
+const out = path.resolve(output);
+mkdirSync(out, { recursive: true });
+const git = (...args) => execFileSync("git", args, { encoding: "utf8" }).trim();
+const base = git("rev-parse", `${baseRef}^{commit}`);
+const head = git("rev-parse", "HEAD");
+const sourceFile = "worker/private-codex-response.ts";
+const cases = ["json", "sse-top", "sse-response"].flatMap(envelope =>
+  ["x-codex-turn-state", "X-Codex-Turn-State"].flatMap(key => [false, true].map(array => ({ envelope, key, array }))));
+const target = "SYNTHETIC_PRIMARY_TARGET", fallback = "SYNTHETIC_FALLBACK_TARGET";
+const secret = "SYNTHETIC_SUBSCRIPTION_TOKEN", account = "SYNTHETIC_ACCOUNT";
+const receipt = { base, head, working_tree_dirty: Boolean(git("status", "--porcelain")),
+  node: process.version, workerd: require("workerd/package.json").version, sources: {}, results: {},
+  limits: "Actual private Worker with synthetic workload authentication and native HTTP upstream fixture. No live inference, production bindings, or deployment. Client-visible traces contain only statuses, shapes and route slots." };
+
+for (const variant of ["baseline", "candidate"]) {
+  const dir = path.join(out, variant);
+  mkdirSync(dir);
+  execFileSync("tar", ["-x", "-C", dir], { input: execFileSync("git", ["archive", variant === "baseline" ? base : head], { maxBuffer: 64 * 1024 * 1024 }) });
+  if (variant === "candidate") copyFileSync(path.join(root, sourceFile), path.join(dir, sourceFile));
+  receipt.sources[variant] = createHash("sha256").update(readFileSync(path.join(dir, sourceFile))).digest("hex");
+  const calls = new Map();
+  const server = createServer(async (request, response) => {
+    assert.equal(request.url, "/backend-api/codex/responses");
+    assert.equal(request.headers.authorization, `Bearer ${secret}`);
+    const chunks = []; for await (const chunk of request) chunks.push(chunk);
+    const body = JSON.parse(Buffer.concat(chunks));
+    const id = Number(body.input.slice("fixture-".length));
+    const scenario = cases[id]; assert.ok(scenario);
+    const route = body.model === target ? 0 : body.model === fallback ? 1 : -1;
+    assert.notEqual(route, -1);
+    const observed = calls.get(id) ?? []; calls.set(id, observed);
+    observed.push({ route, affinity: request.headers["x-codex-turn-state"], previous: body.previous_response_id });
+    response.setHeader("content-type", "application/json");
+    if (observed.length === 1) {
+      response.statusCode = 503;
+      response.end(JSON.stringify({ error: { code: "server_error", message: "Synthetic availability failure" } }));
+      return;
+    }
+    const affinity = `fixture-affinity-${id}`;
+    const headers = { [scenario.key]: scenario.array ? [affinity] : affinity };
+    const result = { id: `fixture-response-${id}`, object: "response", model: body.model, status: "completed", output: [] };
+    if (scenario.envelope === "json") response.end(JSON.stringify({ ...result, headers }));
+    else {
+      response.setHeader("content-type", "text/event-stream");
+      const event = scenario.envelope === "sse-top"
+        ? { type: "response.completed", response: result, headers }
+        : { type: "response.completed", response: { ...result, headers } };
+      response.end(`data: ${JSON.stringify(event)}\n\n`);
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const credential = `private-workload-${randomBytes(32).toString("hex")}`;
+  const policy = { version: 1, enabled: true, alias: { id: "internal", name: "Codex" },
+    auth: { mode: "workload", credentialSha256: createHash("sha256").update(credential).digest("hex") } };
+  const upstream = { version: 1, target, fallbackTarget: fallback, accountId: account, accessToken: secret, expiresAt: Date.now() + 3600000 };
+  const entry = path.join(dir, "proof-worker.ts");
+  writeFileSync(entry, `
+import worker from "./worker/private-entry.ts";
+const policy = ${JSON.stringify(JSON.stringify(policy))};
+const upstream = ${JSON.stringify(JSON.stringify(upstream))};
+export default { fetch(request, env, ctx) {
+  return worker.fetch(request, {
+    PRIVATE_CODEX_POLICY: { async get() { return policy; } },
+    PRIVATE_CODEX_UPSTREAM: { async get() { return upstream; } },
+  }, ctx);
+} };
+`);
+  let mf;
+  try {
+    const bundle = await build({ entryPoints: [entry], bundle: true, write: false, format: "esm", platform: "browser", target: "es2022", external: ["node:*", "cloudflare:*"] });
+    mf = new Miniflare({ modules: true, script: bundle.outputFiles[0].text,
+      compatibilityDate: "2026-07-08", compatibilityFlags: ["nodejs_compat"],
+      outboundService: { external: { address: `127.0.0.1:${server.address().port}`, http: {} } },
+    });
+    const workerUrl = await mf.ready;
+    receipt.results[variant] = [];
+    for (const [id, scenario] of cases.entries()) {
+      const send = (body = {}, headers = {}) => {
+        const payload = JSON.stringify({ model: "internal", input: `fixture-${id}`, store: false, stream: scenario.envelope !== "json", ...body });
+        return fetch(new URL("/private/v1/responses", workerUrl), {
+        method: "POST", signal: AbortSignal.timeout(10000),
+        headers: { authorization: `Bearer ${credential}`, "content-type": "application/json", "content-length": String(Buffer.byteLength(payload)), ...headers },
+        body: payload,
+      });
+      };
+      const first = await send();
+      const raw = await first.text(); contained(raw);
+      const parsed = scenario.envelope === "json" ? JSON.parse(raw)
+        : raw.trim().split("\n\n").flatMap(frame => frame.split("\n").filter(line => line.startsWith("data: ") && line !== "data: [DONE]").map(line => JSON.parse(line.slice(6)))).find(event => event.type === "response.completed");
+      const projected = scenario.envelope === "json" ? parsed : parsed?.response;
+      const headers = scenario.envelope === "sse-top" ? parsed?.headers : projected?.headers;
+      const value = headers?.[scenario.key];
+      const clientStatuses = [first.status];
+      let outcome = "response_rejected";
+      if (value !== undefined) {
+        assert.equal(Array.isArray(value), scenario.array);
+        const affinity = scenario.array ? value[0] : value;
+        outcome = affinity.startsWith("cr1.") ? "wrapped" : "unwrapped";
+        for (const body of [{}, { previous_response_id: projected.id }]) {
+          const next = await send(body, { "x-codex-turn-state": affinity });
+          clientStatuses.push(next.status); contained(await next.text());
+        }
+      }
+      const observed = calls.get(id);
+      assert.ok(observed, `${variant}/${id} did not reach the fixture; HTTP ${first.status}`);
+      const routes = observed.map(call => call.route);
+      if (variant === "candidate" || (!scenario.array && scenario.key === "x-codex-turn-state")) {
+        assert.equal(outcome, "wrapped");
+        assert.deepEqual(clientStatuses, [200, 200, 200]);
+        assert.deepEqual(routes, [0, 1, 1, 1]);
+        assert.equal(observed[2].affinity, `fixture-affinity-${id}`);
+        assert.equal(observed[3].previous, `fixture-response-${id}`);
+      } else if (scenario.key === "x-codex-turn-state") assert.equal(outcome, "response_rejected");
+      else {
+        assert.equal(outcome, "unwrapped");
+        assert.deepEqual(routes, [0, 1, 0]);
+        assert.deepEqual(clientStatuses, [200, 200, 400]);
+      }
+      receipt.results[variant].push({ ...scenario, outcome, clientStatuses, routes });
+    }
+  } finally {
+    try { await mf?.dispose(); }
+    finally { server.closeAllConnections(); await new Promise(resolve => server.close(resolve)); }
+  }
+}
+writeFileSync(path.join(out, "result.json"), `${JSON.stringify(receipt, null, 2)}\n`);
+console.log(JSON.stringify(receipt));
+
+function contained(text) {
+  for (const value of [target, fallback, secret, account]) assert.equal(text.includes(value), false);
+}

--- a/worker/private-codex-response.ts
+++ b/worker/private-codex-response.ts
@@ -50,7 +50,11 @@ export class PrivateResponseProjection {
   async headers(entries: Iterable<[string, unknown]>): Promise<Record<string, unknown>> {
     const projected = privateResponseHeaders(entries, this.alias, this.target, this.sensitive);
     this.inspect(projected);
-    if (this.continuation && projected["x-codex-turn-state"] !== undefined) projected["x-codex-turn-state"] = await this.continuation.wrap(projected["x-codex-turn-state"]);
+    if (this.continuation) for (const [key, value] of Object.entries(projected)) {
+      if (key.toLowerCase() !== "x-codex-turn-state") continue;
+      const wrapped = await this.continuation.wrap(Array.isArray(value) ? value[0] : value);
+      projected[key] = Array.isArray(value) ? [wrapped] : wrapped;
+    }
     return projected;
   }
 

--- a/worker/test/private-codex-fallback.test.mjs
+++ b/worker/test/private-codex-fallback.test.mjs
@@ -134,6 +134,43 @@ test("private continuation tampering, rotation, and conflicting origins fail bef
   assert.equal(calls, 1);
 });
 
+test("typed affinity header casing and singleton arrays preserve fallback continuation", async (context) => {
+  for (const envelope of ["json", "sse-top", "sse-response"]) for (const key of ["x-codex-turn-state", "X-Codex-Turn-State"]) for (const array of [false, true]) {
+    const { run } = await fixture(); const calls = [];
+    const upstreamAffinity = "synthetic-typed-affinity";
+    context.mock.method(globalThis, "fetch", async (_, options) => {
+      const body = JSON.parse(options.body);
+      calls.push({ model: body.model, affinity: options.headers.get("x-codex-turn-state"), previous: body.previous_response_id });
+      if (calls.length === 1) return failed(503, "server_error");
+      const headers = { [key]: array ? [upstreamAffinity] : upstreamAffinity };
+      const response = { id: "synthetic-typed-response", object: "response", model: fallbackTarget, status: "completed", output: [] };
+      if (envelope === "json") return Response.json({ ...response, headers });
+      const event = envelope === "sse-top"
+        ? { type: "response.completed", response, headers }
+        : { type: "response.completed", response: { ...response, headers } };
+      return new Response(`data: ${JSON.stringify(event)}\n\n`, { headers: { "content-type": "text/event-stream" } });
+    });
+    const first = await run({ stream: envelope !== "json" });
+    assert.equal(first.status, 200);
+    const raw = await first.text(); contained(raw);
+    const projected = JSON.parse(envelope === "json" ? raw : raw.trim().slice("data: ".length));
+    assert.notEqual(projected.type, "error");
+    const response = envelope === "json" ? projected : projected.response;
+    const headers = envelope === "sse-top" ? projected.headers : response.headers;
+    assert.equal(Array.isArray(headers[key]), array);
+    const affinity = array ? headers[key][0] : headers[key];
+    assert.match(affinity, /^cr1\./);
+    for (const body of [{}, { previous_response_id: response.id }]) {
+      const next = await run({ stream: envelope !== "json", ...body }, { "x-codex-turn-state": affinity });
+      assert.equal(next.status, 200); contained(await next.text());
+    }
+    assert.deepEqual(calls.map(call => call.model), [target, fallbackTarget, fallbackTarget, fallbackTarget]);
+    assert.equal(calls[2].affinity, upstreamAffinity);
+    assert.equal(calls[3].previous, "synthetic-typed-response");
+    context.mock.restoreAll();
+  }
+});
+
 test("streaming fallback wraps typed response state consistently without touching tool identities", async (context) => {
   const { run } = await fixture(); const calls = [];
   context.mock.method(globalThis, "fetch", async (_, options) => {


### PR DESCRIPTION
## Summary

Typed affinity headers returned by the private Worker lose their fallback ownership when the upstream varies header casing or returns a singleton array. Mixed-case headers previously escaped wrapping, so affinity-only follow-ups went back to the primary and combined continuations failed with HTTP 400. Lowercase arrays failed response projection.

Wrap the affinity value case-insensitively while preserving the existing header spelling and scalar/array shape. The change keeps continuation ownership in the existing projection path and adds no routing abstraction or accepted protocol. Document the contract and ignore generated proof captures.

## Verification

- Full `pnpm check`: 327 Worker tests, 30 admin tests, and 82 script tests passed (439 total); TypeScript checks passed.
- `pnpm worker:e2e`: local Worker smoke passed with the repository's pinned tooling.
- Fresh independent Codex review before commit and on the committed branch: no P0–P2 findings.
- Existing tamper, credential-rotation, and conflicting-origin rejection coverage remains in place.

## Real behavior proof

**Claim and surface:** the actual private Worker entrypoint preserves fallback ownership across JSON, top-level SSE, and nested SSE responses with lowercase/mixed-case scalar/singleton-array affinity headers. Each case forces an initial 503 fallback, then sends affinity-only and combined response-ID/affinity follow-ups.

**Environment and source:** Hetzner through Crabbox, lease `cbx_b53c8225301f` (`ccx63`), Node `v24.18.1`, pnpm `11.24.0`, native workerd `1.20260701.1`. Clean committed head `305cbf00112354c07f6fbe9579b6d41d5cd727fc`, baseline `d683e35456ce2ff23d886c3fe0bfb90c67a37817`. The controlled proof uses temporary Wrangler `4.107.0` tooling for a native outbound HTTP fixture; normal checks and local smoke use the repository's pinned Wrangler `4.126.0`.

**Command:** `node scripts/proof-private-affinity.mjs d683e35456ce2ff23d886c3fe0bfb90c67a37817 /tmp/clawrouter-worker-proof-tools .artifacts/private-affinity-committed` after installing the documented temporary proof tooling.

**Result:** the baseline's 12 cases produced 3 correctly wrapped continuations, 6 unwrapped/misrouted continuations, and 3 rejected responses. All 12 candidate cases preserve wrapping and fallback ownership, with HTTP statuses `[200,200,200]` and route slots `[0,1,1,1]`. Synthetic upstream identity markers never appear in client-visible output.

**Artifact/trace:** proof run `run_82104703a26c`; the committed harness and receipt format live in `scripts/proof-private-affinity.mjs` and `docs/proof/private-affinity/`. Candidate projection SHA-256 `e2cc4e7dfb718f4895d33d0ca54e5a7b5b64d07af371caba98ae18c14d695159`; baseline `5d608952a3f158325a1c03bf0adaee0554ef29f1855b88785b1aac9a6ed53fe4`. Receipts record revisions, clean-tree state, runtime, status codes, and numeric route slots without private payloads.

## Deployment and limits

This proves the actual Worker against synthetic authentication and a loopback HTTP upstream. It does not exercise live inference or prove a production deployment, and this defect has not been established as the cause of any production backlog. No upstream configuration, public API shape, or OpenClaw Bay contract changes.
